### PR TITLE
Fix transport authentication errors on redirect

### DIFF
--- a/v1/remote/transport/basic_test.go
+++ b/v1/remote/transport/basic_test.go
@@ -42,7 +42,7 @@ func TestBasicTransport(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	client := http.Client{Transport: &basicTransport{inner: inner, auth: basic}}
+	client := http.Client{Transport: &basicTransport{inner: inner, auth: basic, target: "gcr.io"}}
 
 	_, err := client.Get("http://gcr.io/v2/auth")
 	if err != nil {

--- a/v1/remote/transport/transport.go
+++ b/v1/remote/transport/transport.go
@@ -53,7 +53,7 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, a Sc
 	case anonymous:
 		return t, nil
 	case basic:
-		return &basicTransport{inner: t, auth: auth}, nil
+		return &basicTransport{inner: t, auth: auth, target: ref.Context().RegistryStr()}, nil
 	case bearer:
 		// We require the realm, which tells us where to send our Basic auth to turn it into Bearer auth.
 		realm, ok := pr.parameters["realm"]
@@ -67,11 +67,12 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, a Sc
 			service = ref.Context().Registry.String()
 		}
 		bt := &bearerTransport{
-			inner:   t,
-			basic:   auth,
-			realm:   realm,
-			service: service,
-			scope:   ref.Scope(string(a)),
+			inner:    t,
+			basic:    auth,
+			realm:    realm,
+			registry: ref.Context().Registry,
+			service:  service,
+			scope:    ref.Scope(string(a)),
 		}
 		if err := bt.refresh(); err != nil {
 			return nil, err


### PR DESCRIPTION
Add a name.Registry as the target registry for a bearerTransport. The
bearerTransport will only attach bearer tokens to requests matching the
registry's domain.

This fixes an issue where the registry would redirect to object storage,
which would reject the request due to an invalid Authorization header.