### PR TITLE
Switch parsing utilities to favor io.ReadCloser over []byte.

### DIFF
--- a/v1/config.go
+++ b/v1/config.go
@@ -14,7 +14,10 @@
 
 package v1
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"io"
+)
 
 // ConfigFile is the configuration file that holds the metadata describing
 // how to launch a container.  The names of the fields are chosen to reflect
@@ -82,10 +85,11 @@ type Config struct {
 	Shell           []string
 }
 
-// ParseConfigFile parses the provided string into a ConfigFile.
-func ParseConfigFile(data []byte) (*ConfigFile, error) {
+// ParseConfigFile parses the io.ReadCloser's contents into a ConfigFile.
+func ParseConfigFile(r io.ReadCloser) (*ConfigFile, error) {
+	defer r.Close()
 	cf := ConfigFile{}
-	if err := json.Unmarshal(data, &cf); err != nil {
+	if err := json.NewDecoder(r).Decode(&cf); err != nil {
 		return nil, err
 	}
 	return &cf, nil

--- a/v1/hash_test.go
+++ b/v1/hash_test.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"bytes"
+	"io/ioutil"
 	"testing"
 )
 
@@ -58,7 +60,10 @@ func TestBadHashes(t *testing.T) {
 }
 
 func TestSHA256(t *testing.T) {
-	h := SHA256("asdf")
+	h, err := SHA256(ioutil.NopCloser(bytes.NewBufferString("asdf")))
+	if err != nil {
+		t.Errorf("SHA256(asdf) = %v", err)
+	}
 	if got, want := h.Algorithm(), "sha256"; got != want {
 		t.Errorf("Algorithm(); got %v, want %v", got, want)
 	}

--- a/v1/manifest.go
+++ b/v1/manifest.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/google/go-containerregistry/v1/types"
 )
@@ -38,10 +39,11 @@ type Descriptor struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// ParseManifest parses the provided string into a Manifest.
-func ParseManifest(data []byte) (*Manifest, error) {
+// ParseManifest parses the io.ReadCloser's contents into a Manifest.
+func ParseManifest(r io.ReadCloser) (*Manifest, error) {
+	defer r.Close()
 	m := Manifest{}
-	if err := json.Unmarshal(data, &m); err != nil {
+	if err := json.NewDecoder(r).Decode(&m); err != nil {
 		return nil, err
 	}
 	return &m, nil

--- a/v1/manifest_test.go
+++ b/v1/manifest_test.go
@@ -15,12 +15,14 @@
 package v1
 
 import (
+	"bytes"
+	"io/ioutil"
 	"reflect"
 	"testing"
 )
 
 func TestGoodManifestSimple(t *testing.T) {
-	got, err := ParseManifest([]byte(`{}`))
+	got, err := ParseManifest(ioutil.NopCloser(bytes.NewBufferString((`{}`))))
 	if err != nil {
 		t.Errorf("Unexpected error parsing manifest: %v", err)
 	}
@@ -32,11 +34,11 @@ func TestGoodManifestSimple(t *testing.T) {
 }
 
 func TestGoodManifestWithHash(t *testing.T) {
-	good, err := ParseManifest([]byte(`{
+	good, err := ParseManifest(ioutil.NopCloser(bytes.NewBufferString((`{
   "config": {
     "digest": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
   }
-}`))
+}`))))
 	if err != nil {
 		t.Errorf("Unexpected error parsing manifest: %v", err)
 	}
@@ -47,11 +49,11 @@ func TestGoodManifestWithHash(t *testing.T) {
 }
 
 func TestManifestWithBadHash(t *testing.T) {
-	bad, err := ParseManifest([]byte(`{
+	bad, err := ParseManifest(ioutil.NopCloser(bytes.NewBufferString((`{
   "config": {
     "digest": "sha256:deadbeed"
   }
-}`))
+}`))))
 	if err == nil {
 		t.Errorf("Expected error parsing manifest, but got: %v", bad)
 	}


### PR DESCRIPTION
This is in anticipation of using streaming interfaces to access the contents of image parts to avoid loading them into memory.