### PR TITLE
Initial remote.Image

### DIFF
--- a/cmd/poke/BUILD.bazel
+++ b/cmd/poke/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["poke.go"],
+    importpath = "github.com/google/go-containerregistry/cmd/poke",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//authn:go_default_library",
+        "//name:go_default_library",
+        "//v1:go_default_library",
+        "//v1/remote:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "poke",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/poke/poke.go
+++ b/cmd/poke/poke.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+func parseReference(ref string) (name.Reference, error) {
+	tag, err := name.NewTag(ref, name.WeakValidation)
+	if err == nil {
+		return tag, nil
+	}
+	return name.NewDigest(ref, name.WeakValidation)
+}
+
+func dispatch(cmd string, i v1.Image) (string, error) {
+	switch cmd {
+	case "config":
+		config, err := i.RawConfigFile()
+		if err != nil {
+			return "", err
+		}
+		return string(config), nil
+	case "digest":
+		digest, err := i.Digest()
+		if err != nil {
+			return "", err
+		}
+		return digest.String(), nil
+	case "manifest":
+		manifest, err := i.RawManifest()
+		if err != nil {
+			return "", err
+		}
+		return string(manifest), nil
+	default:
+		return "", fmt.Errorf("unexpected subcommand: %s", cmd)
+	}
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Errorf("Usage:\n")
+		fmt.Errorf(" %s config <reference>\n", os.Args[0])
+		fmt.Errorf(" %s digest <reference>\n", os.Args[0])
+		fmt.Errorf(" %s manifest <reference>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	ref, err := parseReference(os.Args[2])
+	if err != nil {
+		log.Fatalln(err)
+	}
+	auth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	i, err := remote.Image(ref, auth, http.DefaultTransport)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	out, err := dispatch(os.Args[1], i)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println(out)
+}

--- a/v1/partial/compressed.go
+++ b/v1/partial/compressed.go
@@ -36,7 +36,7 @@ type CompressedImageCore interface {
 // Assert that Image is a superset of this partial interface.
 var _ CompressedImageCore = (v1.Image)(nil)
 
-// uncompressedImageExtender implements v1.Image by extending UncompressedImageCore with the
+// compressedImageExtender implements v1.Image by extending CompressedImageCore with the
 // appropriate methods computed from the minimal core.
 type compressedImageExtender struct {
 	CompressedImageCore

--- a/v1/remote/BUILD.bazel
+++ b/v1/remote/BUILD.bazel
@@ -14,7 +14,9 @@ go_library(
         "//authn:go_default_library",
         "//name:go_default_library",
         "//v1:go_default_library",
+        "//v1/partial:go_default_library",
         "//v1/remote/transport:go_default_library",
+        "//v1/types:go_default_library",
     ],
 )
 
@@ -22,6 +24,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "delete_test.go",
+        "image_test.go",
         "write_test.go",
     ],
     embed = [":go_default_library"],
@@ -31,5 +34,6 @@ go_test(
         "//v1:go_default_library",
         "//v1/random:go_default_library",
         "//v1/remote/transport:go_default_library",
+        "//v1/v1util:go_default_library",
     ],
 )

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -15,20 +15,148 @@
 package remote
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"net/url"
+	"sync"
 
 	"github.com/google/go-containerregistry/authn"
 	"github.com/google/go-containerregistry/name"
 	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/partial"
+	"github.com/google/go-containerregistry/v1/remote/transport"
+	"github.com/google/go-containerregistry/v1/types"
 )
 
-// TODO(jonjohnson): This.
-// // image accesses an image from a remote registry
-// type image struct{}
-// var _ v1.Image = (*image)(nil)
+// remoteImage accesses an image from a remote registry
+type remoteImage struct {
+	ref          name.Reference
+	client       *http.Client
+	manifestLock sync.Mutex // Protects manifest
+	manifest     []byte
+	configLock   sync.Mutex // Protects config
+	config       []byte
+}
+
+var _ partial.CompressedImageCore = (*remoteImage)(nil)
 
 // Image accesses a given image reference over the provided transport, with the provided authentication.
 func Image(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) (v1.Image, error) {
-	return nil, fmt.Errorf("NYI: remote.Image(%v)", ref)
+	tr, err := transport.New(ref, auth, t, transport.PullScope)
+	if err != nil {
+		return nil, err
+	}
+	return partial.CompressedToImage(&remoteImage{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	})
+}
+
+func (r *remoteImage) url(resource, identifier string) url.URL {
+	return url.URL{
+		Scheme: transport.Scheme(r.ref.Context().Registry),
+		Host:   r.ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", r.ref.Context().RepositoryStr(), resource, identifier),
+	}
+}
+
+func (r *remoteImage) MediaType() (types.MediaType, error) {
+	// TODO(jonjohnsonjr): Determine this based on response.
+	return types.DockerManifestSchema2, nil
+}
+
+// TODO(jonjohnsonjr): Handle manifest lists.
+// TODO(jonjohnsonjr): DockerHub returns the manifest list's digest when it falls back to schema 2??
+func (r *remoteImage) RawManifest() ([]byte, error) {
+	r.manifestLock.Lock()
+	defer r.manifestLock.Unlock()
+	if r.manifest != nil {
+		return r.manifest, nil
+	}
+
+	u := r.url("manifests", r.ref.Identifier())
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(jonjohnsonjr): Accept OCI manifest, manifest list, and image index.
+	req.Header.Set("Accept", string(types.DockerManifestSchema2))
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// TODO(jonjohnsonjr): Parse this into a structured error.
+		return nil, fmt.Errorf("unrecognized status code during manifest GET: %v", resp.Status)
+	}
+
+	manifest, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, _, err := v1.SHA256(ioutil.NopCloser(bytes.NewReader(manifest)))
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the digest matches what we asked for, if pulling by digest.
+	if dgst, ok := r.ref.(name.Digest); ok {
+		if digest.String() != dgst.DigestStr() {
+			return nil, fmt.Errorf("manifest digest: %s does not match requested digest: %s", digest, dgst.DigestStr())
+		}
+	} else if checksum := resp.Header.Get("Docker-Content-Digest"); checksum != "" && checksum != digest.String() {
+		// When pulling by tag, we can only validate that the digest matches what the registry told us it should be.
+		return nil, fmt.Errorf("manifest digest: %s does not match Docker-Content-Digest: %s", digest, checksum)
+	}
+
+	r.manifest = manifest
+	return r.manifest, nil
+}
+
+func (r *remoteImage) RawConfigFile() ([]byte, error) {
+	r.configLock.Lock()
+	defer r.configLock.Unlock()
+	if r.config != nil {
+		return r.config, nil
+	}
+
+	m, err := partial.Manifest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := r.Blob(m.Config.Digest)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	r.config, err = ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	return r.config, nil
+}
+
+func (r *remoteImage) Blob(h v1.Hash) (io.ReadCloser, error) {
+	u := r.url("blobs", h.String())
+	resp, err := r.client.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// TODO(jonjohnsonjr): Parse this into a structured error.
+		resp.Body.Close()
+		return nil, fmt.Errorf("unrecognized status code during blob (%s) GET: %v", h, resp.Status)
+	}
+
+	// TODO(jonjohnsonjr): Wrap the Body in an io.ReadCloser that verifies the digest before returning io.EOF.
+	return resp.Body, nil
 }

--- a/v1/remote/image_test.go
+++ b/v1/remote/image_test.go
@@ -1,0 +1,355 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/random"
+	"github.com/google/go-containerregistry/v1/types"
+)
+
+const bogusDigest = "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+func mustDigest(t *testing.T, img v1.Image) v1.Hash {
+	h, err := img.Digest()
+	if err != nil {
+		t.Fatalf("Digest() = %v", err)
+	}
+	return h
+}
+
+func mustManifest(t *testing.T, img v1.Image) *v1.Manifest {
+	m, err := img.Manifest()
+	if err != nil {
+		t.Fatalf("Manifest() = %v", err)
+	}
+	return m
+}
+
+func mustRawManifest(t *testing.T, img v1.Image) []byte {
+	m, err := img.RawManifest()
+	if err != nil {
+		t.Fatalf("RawManifest() = %v", err)
+	}
+	return m
+}
+
+func mustRawConfigFile(t *testing.T, img v1.Image) []byte {
+	c, err := img.RawConfigFile()
+	if err != nil {
+		t.Fatalf("RawConfigFile() = %v", err)
+	}
+	return c
+}
+
+func randomImage(t *testing.T) v1.Image {
+	rnd, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	return rnd
+}
+
+func newReference(host, repo, ref string) (name.Reference, error) {
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, ref), name.WeakValidation)
+	if err == nil {
+		return tag, nil
+	}
+	return name.NewDigest(fmt.Sprintf("%s/%s@%s", host, repo, ref), name.WeakValidation)
+}
+
+// TODO(jonjohnsonjr): Make this real.
+func TestMediaType(t *testing.T) {
+	img := remoteImage{}
+	got, err := img.MediaType()
+	if err != nil {
+		t.Fatalf("MediaType() = %v", err)
+	}
+	want := types.DockerManifestSchema2
+	if got != want {
+		t.Errorf("MediaType() = %v, want %v", got, want)
+	}
+}
+
+func TestRawManifestDigests(t *testing.T) {
+	img := randomImage(t)
+	expectedRepo := "foo/bar"
+
+	cases := []struct {
+		name          string
+		ref           string
+		responseBody  []byte
+		contentDigest string
+		wantErr       bool
+	}{{
+		name:          "normal pull, by tag",
+		ref:           "latest",
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       false,
+	}, {
+		name:          "normal pull, by digest",
+		ref:           mustDigest(t, img).String(),
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       false,
+	}, {
+		name:          "right content-digest, wrong body, by tag",
+		ref:           "latest",
+		responseBody:  []byte("not even json"),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       true,
+	}, {
+		name:          "right content-digest, wrong body, by digest",
+		ref:           mustDigest(t, img).String(),
+		responseBody:  []byte("not even json"),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       true,
+	}, {
+		name:          "right body, wrong content-digest, by tag",
+		ref:           "latest",
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: bogusDigest,
+		wantErr:       true,
+	}, {
+		// NB: This succeeds! We don't care what the registry thinks.
+		name:          "right body, wrong content-digest, by digest",
+		ref:           mustDigest(t, img).String(),
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: bogusDigest,
+		wantErr:       false,
+	}, {
+		name:          "nothing matches anything",
+		ref:           "latest",
+		responseBody:  []byte("everything is wrong with this"),
+		contentDigest: bogusDigest,
+		wantErr:       true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, tc.ref)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case manifestPath:
+					if r.Method != http.MethodGet {
+						t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+					}
+
+					w.Header().Set("Docker-Content-Digest", tc.contentDigest)
+					w.Write(tc.responseBody)
+				default:
+					t.Fatalf("Unexpected path: %v", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+			u, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+			}
+
+			ref, err := newReference(u.Host, expectedRepo, tc.ref)
+			if err != nil {
+				t.Fatalf("url.Parse(%v, %v, %v) = %v", u.Host, expectedRepo, tc.ref, err)
+			}
+
+			rmt := remoteImage{
+				ref:    ref,
+				client: http.DefaultClient,
+			}
+
+			if _, err := rmt.RawManifest(); (err != nil) != tc.wantErr {
+				t.Error("RawManifest() wrong error: %v, want %v: %v", (err != nil), tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestRawManifestNotFound(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	img := remoteImage{
+		ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+		client: http.DefaultClient,
+	}
+
+	if _, err := img.RawManifest(); err == nil {
+		t.Error("RawManifest() = nil; wanted error")
+	}
+}
+
+func TestRawConfigFileNotFound(t *testing.T) {
+	img := randomImage(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, img))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case configPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawManifest(t, img))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	rmt := remoteImage{
+		ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+		client: http.DefaultClient,
+	}
+
+	if _, err := rmt.RawConfigFile(); err == nil {
+		t.Error("RawConfigFile() = nil; wanted error")
+	}
+}
+
+func TestAcceptHeaders(t *testing.T) {
+	img := randomImage(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got, want := r.Header.Get("Accept"), string(types.DockerManifestSchema2); got != want {
+				t.Errorf("Accept header; got %v, want %v", got, want)
+			}
+			w.Write(mustRawManifest(t, img))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	rmt := &remoteImage{
+		ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+		client: http.DefaultClient,
+	}
+	manifest, err := rmt.RawManifest()
+	if err != nil {
+		t.Errorf("RawManifest() = %v", err)
+	}
+	if got, want := manifest, mustRawManifest(t, img); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawManifest() = %v, want %v", got, want)
+	}
+}
+
+func TestImage(t *testing.T) {
+	img := randomImage(t)
+	expectedRepo := "foo/bar"
+	layerDigest := mustManifest(t, img).Layers[0].Digest
+	layerSize := mustManifest(t, img).Layers[0].Size
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, img))
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	layerPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, layerDigest)
+	manifestReqCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case configPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawConfigFile(t, img))
+		case manifestPath:
+			manifestReqCount++
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawManifest(t, img))
+		case layerPath:
+			t.Fatalf("BlobSize should not make any request: %v", r.URL.Path)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	rmt, err := Image(tag, authn.Anonymous, http.DefaultTransport)
+	if err != nil {
+		t.Errorf("Image() = %v", err)
+	}
+
+	if got, want := mustRawManifest(t, rmt), mustRawManifest(t, img); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawManifest() = %v, want %v", got, want)
+	}
+	if got, want := mustRawConfigFile(t, rmt), mustRawConfigFile(t, img); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawConfigFile() = %v, want %v", got, want)
+	}
+	// Make sure caching the manifest works.
+	if manifestReqCount != 1 {
+		t.Errorf("RawManifest made %v requests, expected 1", manifestReqCount)
+	}
+
+	// BlobSize should not HEAD.
+	size, err := rmt.BlobSize(layerDigest)
+	if err != nil {
+		t.Errorf("BlobSize() = %v", err)
+	}
+	if got, want := size, layerSize; want != got {
+		t.Errorf("BlobSize() = %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
* Basic interactions with schema 2 images (relies on registry fallback for manifest lists for now).
* Poke client to use it.