### PR TITLE
Introduce Raw{ConfigFile,Manifest} methods.

### DIFF
--- a/v1/image.go
+++ b/v1/image.go
@@ -45,8 +45,14 @@ type Image interface {
 	// Manifest returns this image's Manifest object.
 	Manifest() (*Manifest, error)
 
+	// RawManifest returns the serialized bytes of Manifest()
+	RawManifest() ([]byte, error)
+
 	// ConfigFile returns this image's config file.
 	ConfigFile() (*ConfigFile, error)
+
+	// RawConfigFile returns the serialized bytes of ConfigFile()
+	RawConfigFile() ([]byte, error)
 
 	// BlobSize returns the size of the compressed blob, given its hash.
 	BlobSize(Hash) (int64, error)

--- a/v1/partial/compressed.go
+++ b/v1/partial/compressed.go
@@ -26,11 +26,8 @@ import (
 type CompressedImageCore interface {
 	imageCore
 
-	// Manifest returns this image's Manifest object.
-	Manifest() (*v1.Manifest, error)
-
-	// Digest returns the sha256 of this image's manifest.
-	Digest() (v1.Hash, error)
+	// RawManifest returns the serialized bytes of the manifest.
+	RawManifest() ([]byte, error)
 
 	// Blob returns a ReadCloser for streaming the blob's content.
 	Blob(v1.Hash) (io.ReadCloser, error)
@@ -54,6 +51,10 @@ func (i *compressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
 
 func (i *compressedImageExtender) BlobSize(h v1.Hash) (int64, error) {
 	return BlobSize(i, h)
+}
+
+func (i *compressedImageExtender) Digest() (v1.Hash, error) {
+	return Digest(i)
 }
 
 func (i *compressedImageExtender) ConfigName() (v1.Hash, error) {
@@ -86,6 +87,14 @@ func (i *compressedImageExtender) UncompressedLayer(h v1.Hash) (io.ReadCloser, e
 		return nil, err
 	}
 	return v1util.GunzipReadCloser(rc)
+}
+
+func (i *compressedImageExtender) ConfigFile() (*v1.ConfigFile, error) {
+	return ConfigFile(i)
+}
+
+func (i *compressedImageExtender) Manifest() (*v1.Manifest, error) {
+	return Manifest(i)
 }
 
 // CompressedToImage fills in the missing methods from a CompressedImageCore so that it implements v1.Image

--- a/v1/partial/image.go
+++ b/v1/partial/image.go
@@ -15,14 +15,13 @@
 package partial
 
 import (
-	"github.com/google/go-containerregistry/v1"
 	"github.com/google/go-containerregistry/v1/types"
 )
 
 // imageCore is the core set of properties without which we cannot build a v1.Image
 type imageCore interface {
-	// ConfigFile returns this image's config file.
-	ConfigFile() (*v1.ConfigFile, error)
+	// RawConfigFile returns the serialized bytes of this image's config file.
+	RawConfigFile() ([]byte, error)
 
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)

--- a/v1/partial/uncompressed.go
+++ b/v1/partial/uncompressed.go
@@ -16,7 +16,6 @@ package partial
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"sync"
 
@@ -79,11 +78,7 @@ func (i *uncompressedImageExtender) Manifest() (*v1.Manifest, error) {
 		return i.manifest, nil
 	}
 
-	cfg, err := i.ConfigFile()
-	if err != nil {
-		return nil, err
-	}
-	b, err := json.Marshal(cfg)
+	b, err := i.RawConfigFile()
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +122,16 @@ func (i *uncompressedImageExtender) Manifest() (*v1.Manifest, error) {
 	return i.manifest, nil
 }
 
+func (i *uncompressedImageExtender) RawManifest() ([]byte, error) {
+	return RawManifest(i)
+}
+
 func (i *uncompressedImageExtender) ConfigName() (v1.Hash, error) {
 	return ConfigName(i)
+}
+
+func (i *uncompressedImageExtender) ConfigFile() (*v1.ConfigFile, error) {
+	return ConfigFile(i)
 }
 
 func (i *uncompressedImageExtender) BlobSize(h v1.Hash) (int64, error) {

--- a/v1/random/image.go
+++ b/v1/random/image.go
@@ -63,17 +63,22 @@ type image struct {
 
 var _ partial.UncompressedImageCore = (*image)(nil)
 
+// RawConfigFile implements partial.UncompressedImageCore
+func (i *image) RawConfigFile() ([]byte, error) {
+	return partial.RawConfigFile(i)
+}
+
 // ConfigFile implements v1.Image
 func (i *image) ConfigFile() (*v1.ConfigFile, error) {
 	return i.config, nil
 }
 
-// MediaType implements v1.Image
+// MediaType implements partial.UncompressedImageCore
 func (i *image) MediaType() (types.MediaType, error) {
 	return types.DockerManifestSchema2, nil
 }
 
-// UncompressedLayer implements v1.Image
+// UncompressedLayer implements partial.UncompressedImageCore
 func (i *image) UncompressedLayer(diffID v1.Hash) (io.ReadCloser, error) {
 	b, ok := i.layers[diffID]
 	if !ok {


### PR DESCRIPTION
These are needed to avoid inconsistencies in reserializing our structured representation.

This reorients the v1/partial interfaces around these as the new core that needs to be implemented, which leads to some slight simplification.
