### PR TITLE
Implement remote.Delete

### DIFF
--- a/cmd/deleter/BUILD.bazel
+++ b/cmd/deleter/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/google/go-containerregistry/cmd/deleter",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//authn:go_default_library",
+        "//name:go_default_library",
+        "//v1/remote:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "deleter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/deleter/main.go
+++ b/cmd/deleter/main.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+var (
+	ref = flag.String("ref", "", "The reference to delete from its registry.")
+)
+
+func parseReference(ref string) (name.Reference, error) {
+	tag, err := name.NewTag(ref, name.WeakValidation)
+	if err == nil {
+		return tag, nil
+	}
+	return name.NewDigest(ref, name.WeakValidation)
+}
+
+func main() {
+	flag.Parse()
+	if *ref == "" {
+		log.Fatalln("-ref must be specified.")
+	}
+
+	r, err := parseReference(*ref)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	auth, err := authn.DefaultKeychain.Resolve(r.Context().Registry)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if err := remote.Delete(r, auth, http.DefaultTransport, remote.DeleteOptions{}); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/v1/remote/BUILD.bazel
+++ b/v1/remote/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "delete.go",
         "doc.go",
         "image.go",
         "write.go",
@@ -19,7 +20,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["write_test.go"],
+    srcs = [
+        "delete_test.go",
+        "write_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//authn:go_default_library",

--- a/v1/remote/delete.go
+++ b/v1/remote/delete.go
@@ -16,6 +16,7 @@ package remote
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -31,7 +32,7 @@ type DeleteOptions struct {
 	// TODO(mattmoor): Delete tag and manifest?
 }
 
-// Delete pushes the provided img to the specified image reference.
+// Delete removes the specified image reference from the remote registry.
 func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, do DeleteOptions) error {
 	tr, err := transport.New(ref, auth, t, transport.DeleteScope)
 	if err != nil {
@@ -60,6 +61,10 @@ func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, d
 	case http.StatusOK, http.StatusAccepted:
 		return nil
 	default:
-		return fmt.Errorf("unrecognized status code during DELETE: %v", resp.Status)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unrecognized status code during DELETE: %v; %v", resp.Status, string(b))
 	}
 }

--- a/v1/remote/delete.go
+++ b/v1/remote/delete.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/remote/transport"
+)
+
+// DeleteOptions are used to expose optional information to guide or
+// control the image deletion.
+type DeleteOptions struct {
+	// TODO(mattmoor): Fail on not found?
+	// TODO(mattmoor): Delete tag and manifest?
+}
+
+// Delete pushes the provided img to the specified image reference.
+func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, do DeleteOptions) error {
+	tr, err := transport.New(ref, auth, t, transport.DeleteScope)
+	if err != nil {
+		return err
+	}
+	c := &http.Client{Transport: tr}
+
+	u := url.URL{
+		Scheme: transport.Scheme(ref.Context().Registry),
+		Host:   ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/manifests/%s", ref.Context().RepositoryStr(), ref.Identifier()),
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted:
+		return nil
+	default:
+		return fmt.Errorf("unrecognized status code during DELETE: %v", resp.Status)
+	}
+}

--- a/v1/remote/delete_test.go
+++ b/v1/remote/delete_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+)
+
+func TestDelete(t *testing.T) {
+	expectedRepo := "write/time"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodDelete {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodDelete)
+			}
+			http.Error(w, "Deleted", http.StatusOK)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	if err := Delete(tag, authn.Anonymous, http.DefaultTransport, DeleteOptions{}); err != nil {
+		t.Errorf("Delete() = %v", err)
+	}
+}
+
+func TestDeleteBadStatus(t *testing.T) {
+	expectedRepo := "write/time"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodDelete {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodDelete)
+			}
+			http.Error(w, "Boom Goes Server", http.StatusInternalServerError)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	if err := Delete(tag, authn.Anonymous, http.DefaultTransport, DeleteOptions{}); err == nil {
+		t.Error("Delete() = nil; wanted error")
+	}
+}


### PR DESCRIPTION
This adds support for deleting images from a registry by either tag or digest.

This also adds `//cmd/deleter` with a simple wrapper of this functionality.

Fixes: #39