### PR TITLE
Add support for structured error handling.

### DIFF
--- a/v1/remote/BUILD.bazel
+++ b/v1/remote/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "delete.go",
         "doc.go",
+        "error.go",
         "image.go",
         "write.go",
     ],
@@ -24,6 +25,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "delete_test.go",
+        "error_test.go",
         "image_test.go",
         "write_test.go",
     ],
@@ -34,6 +36,7 @@ go_test(
         "//v1:go_default_library",
         "//v1/random:go_default_library",
         "//v1/remote/transport:go_default_library",
+        "//v1/types:go_default_library",
         "//v1/v1util:go_default_library",
     ],
 )

--- a/v1/remote/error.go
+++ b/v1/remote/error.go
@@ -1,0 +1,107 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Error implements error to support the following error specification:
+// https://github.com/docker/distribution/blob/master/docs/spec/api.md#errors
+type Error struct {
+	Errors []Diagnostic `json:"errors,omitempty"`
+}
+
+// Check that Error implements error
+var _ error = (*Error)(nil)
+
+// Error implements error
+func (e *Error) Error() string {
+	switch len(e.Errors) {
+	case 0:
+		return "<empty remote.Error response>"
+	case 1:
+		return e.Errors[0].String()
+	default:
+		var errors []string
+		for _, d := range e.Errors {
+			errors = append(errors, d.String())
+		}
+		return fmt.Sprintf("multiple errors returned: %s",
+			strings.Join(errors, ";"))
+	}
+}
+
+// Diagnostic represents a single error returned by a Docker registry interaction.
+type Diagnostic struct {
+	Code    ErrorCode   `json:"code"`
+	Message string      `json:"message,omitempty"`
+	Detail  interface{} `json:"detail,omitempty"`
+}
+
+// String stringifies the Diagnostic
+func (d Diagnostic) String() string {
+	return fmt.Sprintf("%s: %q", d.Code, d.Message)
+}
+
+// ErrorCode is an enumeration of supported error codes.
+type ErrorCode string
+
+// The set of error conditions a registry may return:
+// https://github.com/docker/distribution/blob/master/docs/spec/api.md#errors-2
+const (
+	BlobUnknownErrorCode         ErrorCode = "BLOB_UNKNOWN"
+	BlobUploadInvalidErrorCode   ErrorCode = "BLOB_UPLOAD_INVALID"
+	BlobUploadUnknownErrorCode   ErrorCode = "BLOB_UPLOAD_UNKNOWN"
+	DigestInvalidErrorCode       ErrorCode = "DIGEST_INVALID"
+	ManifestBlobUnknownErrorCode ErrorCode = "MANIFEST_BLOB_UNKNOWN"
+	ManifestInvalidErrorCode     ErrorCode = "MANIFEST_INVALID"
+	ManifestUnknownErrorCode     ErrorCode = "MANIFEST_UNKNOWN"
+	ManifestUnverifiedErrorCode  ErrorCode = "MANIFEST_UNVERIFIED"
+	NameInvalidErrorCode         ErrorCode = "NAME_INVALID"
+	NameUnknownErrorCode         ErrorCode = "NAME_UNKNOWN"
+	SizeInvalidErrorCode         ErrorCode = "SIZE_INVALID"
+	TagInvalidErrorCode          ErrorCode = "TAG_INVALID"
+	UnauthorizedErrorCode        ErrorCode = "UNAUTHORIZED"
+	DeniedErrorCode              ErrorCode = "DENIED"
+	UnsupportedErrorCode         ErrorCode = "UNSUPPORTED"
+)
+
+func checkError(resp *http.Response) error {
+	// According to the documentation, a structured error type is only return for 4XX errors,
+	// so check the StatusCode before reading the body.
+	// https://github.com/docker/distribution/blob/master/docs/spec/api.md#errors
+	if resp.StatusCode < http.StatusBadRequest {
+		return nil
+	}
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return nil
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var structuredError Error
+	if err := json.Unmarshal(b, &structuredError); err != nil {
+		return err
+	}
+	return &structuredError
+}

--- a/v1/remote/error_test.go
+++ b/v1/remote/error_test.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-containerregistry/v1/v1util"
+)
+
+func TestCheckErrorNil(t *testing.T) {
+	tests := []int{
+		http.StatusOK,
+		http.StatusAccepted,
+		http.StatusCreated,
+		http.StatusMovedPermanently,
+		http.StatusInternalServerError,
+	}
+
+	for _, code := range tests {
+		resp := &http.Response{StatusCode: code}
+
+		if err := checkError(resp); err != nil {
+			t.Errorf("checkError(%d) = %v", code, err)
+		}
+	}
+}
+
+func TestCheckErrorNotError(t *testing.T) {
+	tests := []struct {
+		code int
+		body string
+	}{{
+		code: http.StatusBadRequest,
+		body: "",
+	}, {
+		code: http.StatusUnauthorized,
+		body: "Not JSON",
+	}}
+
+	for _, test := range tests {
+		resp := &http.Response{
+			StatusCode: test.code,
+			Body:       v1util.NopReadCloser(bytes.NewBufferString(test.body)),
+		}
+
+		if err := checkError(resp); err == nil {
+			t.Errorf("checkError(%d, %s) = nil, wanted error", test.code, test.body)
+		} else if se, ok := err.(*Error); ok {
+			t.Errorf("checkError(%d, %s) = %v, wanted another type", test.code, test.body, se)
+		}
+	}
+}
+
+func TestCheckErrorWithError(t *testing.T) {
+	tests := []struct {
+		code  int
+		error *Error
+	}{{
+		code: http.StatusBadRequest,
+		error: &Error{
+			Errors: []Diagnostic{{
+				Code:    NameInvalidErrorCode,
+				Message: "a message for you",
+			}},
+		},
+		// TODO(mattmoor): nothing, multiple
+	}}
+
+	for _, test := range tests {
+		b, err := json.Marshal(test.error)
+		if err != nil {
+			t.Errorf("json.Marshal(%v) = %v", test.error, err)
+		}
+		resp := &http.Response{
+			StatusCode: test.code,
+			Body:       v1util.NopReadCloser(bytes.NewBuffer(b)),
+		}
+
+		if err := checkError(resp); err == nil {
+			t.Errorf("checkError(%d, %s) = nil, wanted error", test.code, string(b))
+		} else if se, ok := err.(*Error); !ok {
+			t.Errorf("checkError(%d, %s) = %T, wanted *remote.Error", test.code, string(b), se)
+		} else if !reflect.DeepEqual(se, test.error) {
+			t.Errorf("checkError(%d, %s) = %v, wanted %v", test.code, string(b), se, test.error)
+		}
+	}
+}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -90,6 +90,10 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if err := checkError(resp); err != nil {
+		return nil, err
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		// TODO(jonjohnsonjr): Parse this into a structured error.
 		return nil, fmt.Errorf("unrecognized status code during manifest GET: %v", resp.Status)
@@ -151,8 +155,12 @@ func (r *remoteImage) Blob(h v1.Hash) (io.ReadCloser, error) {
 		return nil, err
 	}
 
+	if err := checkError(resp); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		// TODO(jonjohnsonjr): Parse this into a structured error.
 		resp.Body.Close()
 		return nil, fmt.Errorf("unrecognized status code during blob (%s) GET: %v", h, resp.Status)
 	}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -90,13 +90,8 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if err := checkError(resp); err != nil {
+	if err := checkError(resp, http.StatusOK); err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		// TODO(jonjohnsonjr): Parse this into a structured error.
-		return nil, fmt.Errorf("unrecognized status code during manifest GET: %v", resp.Status)
 	}
 
 	manifest, err := ioutil.ReadAll(resp.Body)
@@ -155,14 +150,9 @@ func (r *remoteImage) Blob(h v1.Hash) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	if err := checkError(resp); err != nil {
+	if err := checkError(resp, http.StatusOK); err != nil {
 		resp.Body.Close()
 		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		return nil, fmt.Errorf("unrecognized status code during blob (%s) GET: %v", h, resp.Status)
 	}
 
 	// TODO(jonjohnsonjr): Wrap the Body in an io.ReadCloser that verifies the digest before returning io.EOF.

--- a/v1/remote/write.go
+++ b/v1/remote/write.go
@@ -146,6 +146,10 @@ func (w *writer) initiateUpload(h v1.Hash) (location string, mounted bool, err e
 	}
 	defer resp.Body.Close()
 
+	if err := checkError(resp); err != nil {
+		return "", false, err
+	}
+
 	// Check the response code to determine the result.
 	switch resp.StatusCode {
 	case http.StatusCreated:
@@ -181,6 +185,10 @@ func (w *writer) streamBlob(h v1.Hash, streamLocation string) (commitLocation st
 	}
 	defer resp.Body.Close()
 
+	if err := checkError(resp); err != nil {
+		return "", err
+	}
+
 	switch resp.StatusCode {
 	case http.StatusNoContent, http.StatusAccepted, http.StatusCreated:
 		// The blob has been uploaded, return the location header indicating
@@ -211,6 +219,11 @@ func (w *writer) commitBlob(h v1.Hash, location string) (err error) {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if err := checkError(resp); err != nil {
+		return err
+	}
+
 	switch resp.StatusCode {
 	case http.StatusCreated:
 		return nil
@@ -261,6 +274,10 @@ func (w *writer) commitImage() error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if err := checkError(resp); err != nil {
+		return err
+	}
 
 	// Check the response code to determine the result.
 	switch resp.StatusCode {


### PR DESCRIPTION
This changes adds support for parsing structured 4XX errors from a Docker registry.

Sample output against GCR:
```
2018/03/30 10:12:14 DENIED: "Please enable or contact project owners to enable the Google Container Registry API in Cloud Console at https://console.cloud.google.com/apis/api/containerregistry.googleapis.com/overview?project=convoy-adaptor before performing this operation."
```

Fixes: https://github.com/google/go-containerregistry/issues/46