### PR TITLE
Ignore digest mismatch for DockerHub

### DIFF
--- a/name/registry.go
+++ b/name/registry.go
@@ -16,7 +16,7 @@ package name
 
 import "net/url"
 
-const defaultRegistry = "index.docker.io"
+const DefaultRegistry = "index.docker.io"
 
 // Registry stores a docker registry name in a structured form.
 type Registry struct {
@@ -28,7 +28,7 @@ func (r Registry) RegistryStr() string {
 	if r.registry != "" {
 		return r.registry
 	}
-	return defaultRegistry
+	return DefaultRegistry
 }
 
 // Name returns the name from which the Registry was derived.

--- a/name/repository.go
+++ b/name/repository.go
@@ -33,7 +33,7 @@ type Repository struct {
 
 // See https://docs.docker.com/docker-hub/official_repos
 func hasImplicitNamespace(repo string, reg Registry) bool {
-	return !strings.ContainsRune(repo, '/') && reg.RegistryStr() == defaultRegistry
+	return !strings.ContainsRune(repo, '/') && reg.RegistryStr() == DefaultRegistry
 }
 
 // RepositoryStr returns the repository component of the Repository.


### PR DESCRIPTION
Fixes #56.

Just log a warning instead. Every official image is broken if we
validate the Docker-Content-Digest, since they are all manifest lists.