### PR TITLE
Add empty.Image

### DIFF
--- a/v1/empty/BUILD.bazel
+++ b/v1/empty/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "image.go",
+    ],
+    importpath = "github.com/google/go-containerregistry/v1/empty",
+    visibility = ["//visibility:public"],
+    deps = ["//v1/random:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["image_test.go"],
+    embed = [":go_default_library"],
+)

--- a/v1/empty/doc.go
+++ b/v1/empty/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package empty provides an implementation of v1.Image equivalent to "FROM scratch".
+package empty

--- a/v1/empty/image.go
+++ b/v1/empty/image.go
@@ -1,0 +1,22 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	"github.com/google/go-containerregistry/v1/random"
+)
+
+// Image is a singleton empty image, think: FROM scratch.
+var Image, _ = random.Image(0, 0)

--- a/v1/empty/image_test.go
+++ b/v1/empty/image_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	"testing"
+)
+
+func TestManifestAndConfig(t *testing.T) {
+	manifest, err := Image.Manifest()
+	if err != nil {
+		t.Fatalf("Error loading manifest: %v", err)
+	}
+	if got, want := len(manifest.Layers), 0; got != want {
+		t.Fatalf("num layers; got %v, want %v", got, want)
+	}
+
+	config, err := Image.ConfigFile()
+	if err != nil {
+		t.Fatalf("Error loading config file: %v", err)
+	}
+	if got, want := len(config.RootFS.DiffIDs), 0; got != want {
+		t.Fatalf("num diff ids; got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This adds a special singleton for empty.Image, which serves a similar purpose to "FROM scratch" in the land of Dockerfiles.

In isolation this isn't particularly interesting, but it provides a foundation on top of which subsequent utilities may build.

Related to: https://github.com/google/go-containerregistry/issues/48