### PR TITLE
 Create a separate v1.Layer abstraction

### DIFF
--- a/v1/BUILD.bazel
+++ b/v1/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "hash.go",
         "image.go",
+        "layer.go",
         "manifest.go",
     ],
     importpath = "github.com/google/go-containerregistry/v1",

--- a/v1/image.go
+++ b/v1/image.go
@@ -15,38 +15,23 @@
 package v1
 
 import (
-	"io"
-
 	"github.com/google/go-containerregistry/v1/types"
 )
 
 // Image defines the interface for interacting with an OCI v1 image.
 type Image interface {
-	// FSLayers returns the ordered collection of filesystem layers that comprise this image.
+	// Layers returns the ordered collection of filesystem layers that comprise this image.
 	// The order of the list is most-recent first, and oldest base layer last.
-	FSLayers() ([]Hash, error)
-
-	// DiffIDs returns the ordered list of uncompressed layer hashes (matches FSLayers).
-	// The order of the list is most-recent first, and oldest base layer last.
-	DiffIDs() ([]Hash, error)
-
-	// ConfigName returns the hash of the image's config file.
-	ConfigName() (Hash, error)
+	Layers() ([]Layer, error)
 
 	// BlobSet returns an unordered collection of all the blobs in the image.
 	BlobSet() (map[Hash]struct{}, error)
 
-	// Digest returns the sha256 of this image's manifest.
-	Digest() (Hash, error)
-
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 
-	// Manifest returns this image's Manifest object.
-	Manifest() (*Manifest, error)
-
-	// RawManifest returns the serialized bytes of Manifest()
-	RawManifest() ([]byte, error)
+	// ConfigName returns the hash of the image's config file.
+	ConfigName() (Hash, error)
 
 	// ConfigFile returns this image's config file.
 	ConfigFile() (*ConfigFile, error)
@@ -54,18 +39,20 @@ type Image interface {
 	// RawConfigFile returns the serialized bytes of ConfigFile()
 	RawConfigFile() ([]byte, error)
 
-	// BlobSize returns the size of the compressed blob, given its hash.
-	BlobSize(Hash) (int64, error)
+	// Digest returns the sha256 of this image's manifest.
+	Digest() (Hash, error)
 
-	// Blob returns a ReadCloser for streaming the blob's content.
-	Blob(Hash) (io.ReadCloser, error)
+	// Manifest returns this image's Manifest object.
+	Manifest() (*Manifest, error)
 
-	// Layer is the same as Blob, but takes the "diff id".
-	Layer(Hash) (io.ReadCloser, error)
+	// RawManifest returns the serialized bytes of Manifest()
+	RawManifest() ([]byte, error)
 
-	// UncompressedBlob returns a ReadCloser for streaming the blob's content uncompressed.
-	UncompressedBlob(Hash) (io.ReadCloser, error)
+	// LayerByDigest returns a Layer for interacting with a particular layer of
+	// the image, looking it up by "digest" (the compressed hash).
+	LayerByDigest(Hash) (Layer, error)
 
-	// UncompressedLayer is like UncompressedBlob, but takes the "diff id".
-	UncompressedLayer(Hash) (io.ReadCloser, error)
+	// LayerByDiffID is an analog to LayerByDigest, looking up by "diff id"
+	// (the uncompressed hash).
+	LayerByDiffID(Hash) (Layer, error)
 }

--- a/v1/layer.go
+++ b/v1/layer.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"io"
+)
+
+// Layer is an interface for accessing the properties of a particular layer of a v1.Image
+type Layer interface {
+	// Digest returns the Hash of the compressed layer.
+	Digest() (Hash, error)
+
+	// DiffID returns the Hash of the uncompressed layer.
+	DiffID() (Hash, error)
+
+	// Compressed returns an io.ReadCloser for the compressed layer contents.
+	Compressed() (io.ReadCloser, error)
+
+	// Uncompressed returns an io.ReadCloser for the uncompressed layer contents.
+	Uncompressed() (io.ReadCloser, error)
+
+	// Size returns the compressed size of the Layer.
+	Size() (int64, error)
+}

--- a/v1/partial/compressed.go
+++ b/v1/partial/compressed.go
@@ -58,7 +58,7 @@ func (ule *compressedLayerExtender) DiffID() (v1.Hash, error) {
 	return h, err
 }
 
-// CompressedToLayer fills in the missing methos from an CompressedLayer so that it implements v1.Layer
+// CompressedToLayer fills in the missing methods from a CompressedLayer so that it implements v1.Layer
 func CompressedToLayer(ul CompressedLayer) (v1.Layer, error) {
 	return &compressedLayerExtender{ul}, nil
 }
@@ -72,7 +72,7 @@ type CompressedImageCore interface {
 	RawManifest() ([]byte, error)
 
 	// LayerByDigest is a variation on the v1.Image method, which returns
-	// an CompressedLayer instead.
+	// a CompressedLayer instead.
 	LayerByDigest(v1.Hash) (CompressedLayer, error)
 }
 
@@ -85,18 +85,22 @@ type compressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*compressedImageExtender)(nil)
 
+// BlobSet implements v1.Image
 func (i *compressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
 	return BlobSet(i)
 }
 
+// Digest implements v1.Image
 func (i *compressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)
 }
 
+// ConfigName implements v1.Image
 func (i *compressedImageExtender) ConfigName() (v1.Hash, error) {
 	return ConfigName(i)
 }
 
+// Layers implements v1.Image
 func (i *compressedImageExtender) Layers() ([]v1.Layer, error) {
 	hs, err := FSLayers(i)
 	if err != nil {
@@ -113,6 +117,7 @@ func (i *compressedImageExtender) Layers() ([]v1.Layer, error) {
 	return ls, nil
 }
 
+// LayerByDigest implements v1.Image
 func (i *compressedImageExtender) LayerByDigest(h v1.Hash) (v1.Layer, error) {
 	cl, err := i.CompressedImageCore.LayerByDigest(h)
 	if err != nil {
@@ -121,6 +126,7 @@ func (i *compressedImageExtender) LayerByDigest(h v1.Hash) (v1.Layer, error) {
 	return CompressedToLayer(cl)
 }
 
+// LayerByDiffID implements v1.Image
 func (i *compressedImageExtender) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 	h, err := DiffIDToBlob(i, h)
 	if err != nil {
@@ -129,10 +135,12 @@ func (i *compressedImageExtender) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 	return i.LayerByDigest(h)
 }
 
+// ConfigFile implements v1.Image
 func (i *compressedImageExtender) ConfigFile() (*v1.ConfigFile, error) {
 	return ConfigFile(i)
 }
 
+// Manifest implements v1.Image
 func (i *compressedImageExtender) Manifest() (*v1.Manifest, error) {
 	return Manifest(i)
 }

--- a/v1/partial/with.go
+++ b/v1/partial/with.go
@@ -51,6 +51,7 @@ func ConfigName(i WithRawConfigFile) (v1.Hash, error) {
 }
 
 // configLayer implements v1.Layer from the raw config bytes.
+// This is so that clients (e.g. remote) can access the config as a blob.
 type configLayer struct {
 	hash    v1.Hash
 	content []byte

--- a/v1/partial/with.go
+++ b/v1/partial/with.go
@@ -50,6 +50,54 @@ func ConfigName(i WithRawConfigFile) (v1.Hash, error) {
 	return h, err
 }
 
+// configLayer implements v1.Layer from the raw config bytes.
+type configLayer struct {
+	hash    v1.Hash
+	content []byte
+}
+
+// Digest implements v1.Layer
+func (cl *configLayer) Digest() (v1.Hash, error) {
+	return cl.hash, nil
+}
+
+// DiffID implements v1.Layer
+func (cl *configLayer) DiffID() (v1.Hash, error) {
+	return cl.hash, nil
+}
+
+// Uncompressed implements v1.Layer
+func (cl *configLayer) Uncompressed() (io.ReadCloser, error) {
+	return v1util.NopReadCloser(bytes.NewBuffer(cl.content)), nil
+}
+
+// Compressed implements v1.Layer
+func (cl *configLayer) Compressed() (io.ReadCloser, error) {
+	return v1util.NopReadCloser(bytes.NewBuffer(cl.content)), nil
+}
+
+// Size implements v1.Layer
+func (cl *configLayer) Size() (int64, error) {
+	return int64(len(cl.content)), nil
+}
+
+var _ v1.Layer = (*configLayer)(nil)
+
+func ConfigLayer(i WithRawConfigFile) (v1.Layer, error) {
+	h, err := ConfigName(i)
+	if err != nil {
+		return nil, err
+	}
+	rcfg, err := i.RawConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	return &configLayer{
+		hash:    h,
+		content: rcfg,
+	}, nil
+}
+
 // WithConfigFile defines the subset of v1.Image used by these helper methods
 type WithConfigFile interface {
 	// ConfigFile returns this image's config file.

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -160,7 +160,7 @@ type remoteLayer struct {
 	digest v1.Hash
 }
 
-// DiffID implements partial.CompressedLayer
+// Digest implements partial.CompressedLayer
 func (rl *remoteLayer) Digest() (v1.Hash, error) {
 	return rl.digest, nil
 }
@@ -192,6 +192,7 @@ func (rl *remoteLayer) Size() (int64, error) {
 	return partial.BlobSize(rl, rl.digest)
 }
 
+// LayerByDigest implements partial.CompressedLayer
 func (r *remoteImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
 	return &remoteLayer{
 		ri:     r,

--- a/v1/remote/image_test.go
+++ b/v1/remote/image_test.go
@@ -344,8 +344,12 @@ func TestImage(t *testing.T) {
 		t.Errorf("RawManifest made %v requests, expected 1", manifestReqCount)
 	}
 
+	l, err := rmt.LayerByDigest(layerDigest)
+	if err != nil {
+		t.Errorf("LayerByDigest() = %v", err)
+	}
 	// BlobSize should not HEAD.
-	size, err := rmt.BlobSize(layerDigest)
+	size, err := l.Size()
 	if err != nil {
 		t.Errorf("BlobSize() = %v", err)
 	}

--- a/v1/remote/write.go
+++ b/v1/remote/write.go
@@ -168,7 +168,11 @@ func (w *writer) initiateUpload(h v1.Hash) (location string, mounted bool, err e
 // On failure, this will return an error.  On success, this will return the location
 // header indicating how to commit the streamed blob.
 func (w *writer) streamBlob(h v1.Hash, streamLocation string) (commitLocation string, err error) {
-	blob, err := w.img.Blob(h)
+	l, err := w.img.LayerByDigest(h)
+	if err != nil {
+		return "", err
+	}
+	blob, err := l.Compressed()
 	if err != nil {
 		return "", err
 	}

--- a/v1/tarball/write.go
+++ b/v1/tarball/write.go
@@ -66,23 +66,27 @@ func Write(p string, tag name.Tag, img v1.Image, wo *WriteOptions) error {
 	}
 
 	// Write the layers.
-	layers, err := img.FSLayers()
+	layers, err := img.Layers()
 	if err != nil {
 		return err
 	}
 	layerPaths := []string{}
 	for _, l := range layers {
-		layerPaths = append(layerPaths, l.String())
-		r, err := img.Blob(l)
+		d, err := l.Digest()
 		if err != nil {
 			return err
 		}
-		blobSize, err := img.BlobSize(l)
+		layerPaths = append(layerPaths, d.String())
+		r, err := l.Compressed()
+		if err != nil {
+			return err
+		}
+		blobSize, err := l.Size()
 		if err != nil {
 			return err
 		}
 
-		if err := writeFile(tf, l.String(), r, blobSize); err != nil {
+		if err := writeFile(tf, d.String(), r, blobSize); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The number of methods on v1.Image that dealt in either "Diff ID" or "Digest" was a little silly, and carry-over from the Python library.  This change defines a v1.Layer abstraction to hold the bulk of these methods, and dramatically simplify the v1.Image interface.

Fixes: #59