### PR TITLE
Docker's config uses the field 'credsStore' instead of 'credStore'

### DIFF
--- a/authn/keychain.go
+++ b/authn/keychain.go
@@ -60,7 +60,7 @@ type authEntry struct {
 // This is not meant for direct consumption.
 type cfg struct {
 	CredHelper map[string]string    `json:"credHelpers,omitempty"`
-	CredStore  string               `json:"credStore,omitempty"`
+	CredStore  string               `json:"credsStore,omitempty"`
 	Auths      map[string]authEntry `json:"auths,omitempty"`
 }
 

--- a/authn/keychain_test.go
+++ b/authn/keychain_test.go
@@ -132,7 +132,7 @@ func TestVariousPaths(t *testing.T) {
 		content: `{"credHelpers": {"https://test.io": "test"}}`,
 		check:   checkHelper,
 	}, {
-		content: `{"credStore": "test"}`,
+		content: `{"credsStore": "test"}`,
 		check:   checkHelper,
 	}, {
 		content: `{"auths": {"http://test.io/v2/": {"auth": "Zm9vOmJhcg=="}}}`,


### PR DESCRIPTION
Pushing & pulling from DockerHub should now work

Signed-off-by: Brenda Chan <brchan@pivotal.io>