### PR TITLE
Fix an issue accessing the Config when we mutate it.

### DIFF
--- a/v1/mutate/mutate.go
+++ b/v1/mutate/mutate.go
@@ -132,6 +132,10 @@ func Config(base v1.Image, cfg v1.Config) (v1.Image, error) {
 		diffIDMap:  make(map[v1.Hash]v1.Layer),
 		digestMap:  make(map[v1.Hash]v1.Layer),
 	}
+	image.manifest.Config.Digest, err = image.ConfigName()
+	if err != nil {
+		return nil, err
+	}
 	return image, nil
 }
 
@@ -199,6 +203,11 @@ func (i *image) RawManifest() ([]byte, error) {
 // LayerByDigest returns a Layer for interacting with a particular layer of
 // the image, looking it up by "digest" (the compressed hash).
 func (i *image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	if cn, err := i.ConfigName(); err != nil {
+		return nil, err
+	} else if h == cn {
+		return partial.ConfigLayer(i)
+	}
 	if layer, ok := i.digestMap[h]; ok {
 		return layer, nil
 	}

--- a/v1/mutate/mutate_test.go
+++ b/v1/mutate/mutate_test.go
@@ -117,8 +117,8 @@ func TestMutateConfig(t *testing.T) {
 		t.Fatalf("failed to mutate a config: %v", err)
 	}
 
-	if !manifestsAreEqual(t, source, result) {
-		t.Fatal("mutating the config mutated the manifest")
+	if manifestsAreEqual(t, source, result) {
+		t.Fatal("mutating the config MUST mutate the manifest")
 	}
 
 	if configFilesAreEqual(t, source, result) {


### PR DESCRIPTION
We were changing the `ConfigFile.Config`, but we weren't updating the `Manifest`'s digest for the `ConfigFile`.  This meant that things keying off of the `Manifest`'s `ConfigFile` digest field to access things through `LayerByDigest` would end up being delegated to the base image's implementation.  In my case, this was manifesting as us asking GCR for a non-existent blob (`remote.Image`).

Related: https://github.com/google/go-containerregistry/issues/87