### PR TITLE
Fix DiffIDs ordering

### DIFF
--- a/v1/mutate/mutate.go
+++ b/v1/mutate/mutate.go
@@ -148,7 +148,7 @@ type image struct {
 }
 
 // Layers returns the ordered collection of filesystem layers that comprise this image.
-// The order of the list is most-recent first, and oldest base layer last.
+// The order of the list is oldest/base layer first, and most-recent/top layer last.
 func (i *image) Layers() ([]v1.Layer, error) {
 	diffIDs, err := partial.DiffIDs(i)
 	if err != nil {

--- a/v1/mutate/mutate_test.go
+++ b/v1/mutate/mutate_test.go
@@ -61,7 +61,7 @@ func TestAppendWithHistory(t *testing.T) {
 
 	layers := getLayers(t, result)
 
-	if diff := cmp.Diff(layers[0], mockLayer{}); diff != "" {
+	if diff := cmp.Diff(layers[1], mockLayer{}); diff != "" {
 		t.Fatalf("correct layer was not appended (-got, +want) %v", diff)
 	}
 
@@ -94,13 +94,13 @@ func TestAppendLayers(t *testing.T) {
 			"- got size %d; expected 2", len(layers))
 	}
 
-	if diff := cmp.Diff(layers[0], mockLayer{}); diff != "" {
+	if diff := cmp.Diff(layers[1], mockLayer{}); diff != "" {
 		t.Fatalf("correct layer was not appended (-got, +want) %v", diff)
 	}
 
 	assertLayerOrderMatchesConfig(t, result)
 	assertLayerOrderMatchesManifest(t, result)
-	assertQueryingForLayerSucceeds(t, result, layers[0])
+	assertQueryingForLayerSucceeds(t, result, layers[1])
 }
 
 func TestMutateConfig(t *testing.T) {
@@ -241,11 +241,9 @@ func assertLayerOrderMatchesConfig(t *testing.T, i v1.Image) {
 			t.Fatalf("Unable to fetch layer diff id: %v", err)
 		}
 
-		diffIDIndex := len(layers) - 1 - i
-
-		if got, want := diffID, cf.RootFS.DiffIDs[diffIDIndex]; got != want {
+		if got, want := diffID, cf.RootFS.DiffIDs[i]; got != want {
 			t.Fatalf("Layer diff id (%v) is not at the expected index (%d) in %+v",
-				got, diffIDIndex, cf.RootFS.DiffIDs)
+				got, i, cf.RootFS.DiffIDs)
 		}
 	}
 }
@@ -267,11 +265,9 @@ func assertLayerOrderMatchesManifest(t *testing.T, i v1.Image) {
 			t.Fatalf("Unable to fetch layer diff id: %v", err)
 		}
 
-		digestIndex := len(layers) - 1 - i
-
-		if got, want := digest, mf.Layers[digestIndex].Digest; got != want {
+		if got, want := digest, mf.Layers[i].Digest; got != want {
 			t.Fatalf("Layer digest (%v) is not at the expected index (%d) in %+v",
-				got, digestIndex, mf.Layers)
+				got, i, mf.Layers)
 		}
 	}
 }

--- a/v1/partial/with.go
+++ b/v1/partial/with.go
@@ -110,11 +110,7 @@ func DiffIDs(i WithConfigFile) ([]v1.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	dids := make([]v1.Hash, len(cfg.RootFS.DiffIDs))
-	for i, did := range cfg.RootFS.DiffIDs {
-		dids[len(dids)-i-1] = did
-	}
-	return dids, nil
+	return cfg.RootFS.DiffIDs, nil
 }
 
 // RawConfigFile is a helper for implementing v1.Image


### PR DESCRIPTION
I missed this in #83, which made Append's ordering inverted.