### PR TITLE
panic instead of fatal, so that defers get executed (just in case)

### DIFF
--- a/cmd/d8s/append.go
+++ b/cmd/d8s/append.go
@@ -59,33 +59,33 @@ func (a *appendCmd) Execute(
 
 	srcRef, err := name.ParseReference(src, name.WeakValidation)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	srcAuth, err := authn.DefaultKeychain.Resolve(srcRef.Context().Registry)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
 
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	dstTag, err := name.NewTag(dst, name.WeakValidation)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	layer, err := tarball.LayerFromFile(tar)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	image, err := mutate.AppendLayers(srcImage, layer)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	if a.outputFile != "" {
@@ -105,16 +105,16 @@ func (a *appendCmd) Execute(
 func writeRemote(ref name.Reference, i v1.Image, opts remote.WriteOptions) {
 	dstAuth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	if err := remote.Write(ref, i, dstAuth, http.DefaultTransport, opts); err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 }
 
 func writeTarball(file string, tag name.Tag, i v1.Image) {
 	if err := tarball.Write(file, tag, i, &tarball.WriteOptions{}); err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 }

--- a/cmd/d8s/delete.go
+++ b/cmd/d8s/delete.go
@@ -41,16 +41,16 @@ func (*deleteCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 
 	r, err := name.ParseReference(ref, name.WeakValidation)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	auth, err := authn.DefaultKeychain.Resolve(r.Context().Registry)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	if err := remote.Delete(r, auth, http.DefaultTransport, remote.DeleteOptions{}); err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	return subcommands.ExitSuccess
 }

--- a/cmd/d8s/get.go
+++ b/cmd/d8s/get.go
@@ -55,11 +55,11 @@ func (*configCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 
 	i, err := getImage(f.Args()[0])
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	config, err := i.RawConfigFile()
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	fmt.Println(string(config))
 	return subcommands.ExitSuccess
@@ -79,11 +79,11 @@ func (*digestCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 
 	i, err := getImage(f.Args()[0])
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	digest, err := i.Digest()
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	fmt.Println(digest.String())
 	return subcommands.ExitSuccess
@@ -103,11 +103,11 @@ func (*manifestCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 	i, err := getImage(f.Args()[0])
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	manifest, err := i.RawManifest()
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	fmt.Println(string(manifest))
 	return subcommands.ExitSuccess

--- a/cmd/d8s/pull.go
+++ b/cmd/d8s/pull.go
@@ -45,22 +45,22 @@ func (*pullCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) 
 	tag, path := f.Args()[0], f.Args()[1]
 	t, err := name.NewTag(tag, name.WeakValidation)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	log.Printf("Pulling %v", t)
 
 	auth, err := authn.DefaultKeychain.Resolve(t.Registry)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	i, err := remote.Image(t, auth, http.DefaultTransport)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	if err := tarball.Write(path, t, i, &tarball.WriteOptions{}); err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	return subcommands.ExitSuccess
 }

--- a/cmd/d8s/push.go
+++ b/cmd/d8s/push.go
@@ -45,22 +45,22 @@ func (*pushCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) 
 	path, tag := f.Args()[0], f.Args()[1]
 	t, err := name.NewTag(tag, name.WeakValidation)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	log.Printf("Pushing %v", t)
 
 	auth, err := authn.DefaultKeychain.Resolve(t.Registry)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	i, err := tarball.ImageFromPath(path, nil)
 	if err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 
 	if err := remote.Write(t, i, auth, http.DefaultTransport, remote.WriteOptions{}); err != nil {
-		log.Fatalln(err)
+		log.Panicln(err)
 	}
 	return subcommands.ExitSuccess
 }


### PR DESCRIPTION
Probably not a huge biggie, but use Panic instead of Fatal, in case a `defer` closes resources that otherwise might leak in certain circumstances.

Signed-off-by: Jake Sanders <jsand@google.com>