### PR TITLE
Implement ko/build

### DIFF
--- a/ko/build/BUILD.bazel
+++ b/ko/build/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "build.go",
+        "doc.go",
+        "fixed.go",
+        "gobuild.go",
+    ],
+    importpath = "github.com/google/go-containerregistry/ko/build",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//v1:go_default_library",
+        "//v1/mutate:go_default_library",
+        "//v1/tarball:go_default_library",
+        "//v1/v1util:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "fixed_test.go",
+        "gobuild_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//v1:go_default_library",
+        "//v1/random:go_default_library",
+    ],
+)

--- a/ko/build/build.go
+++ b/ko/build/build.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"github.com/google/go-containerregistry/v1"
+)
+
+// Interface abstracts different methods for turning a supported importpath
+// reference into a v1.Image.
+type Interface interface {
+	// IsSupportedReference determines whether the given reference is to an importpath reference
+	// that Ko supports building.
+	// TODO(mattmoor): Verify that some base repo: foo.io/bar can be suffixed with this reference and parsed.
+	IsSupportedReference(string) bool
+
+	// Build turns the given importpath reference into a v1.Image containing the Go binary.
+	Build(string) (v1.Image, error)
+}

--- a/ko/build/doc.go
+++ b/ko/build/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package build defines methods for building a v1.Image reference from a
+// Go binary reference.
+package build

--- a/ko/build/fixed.go
+++ b/ko/build/fixed.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/v1"
+)
+
+type fixed struct {
+	entries map[string]v1.Image
+}
+
+// NewFixed returns a build.Interface implementation that simply resolves particular
+// references to fixed v1.Image objects
+func NewFixed(entries map[string]v1.Image) Interface {
+	return &fixed{entries}
+}
+
+// IsSupportedReference implements build.Interface
+func (f *fixed) IsSupportedReference(s string) bool {
+	_, ok := f.entries[s]
+	return ok
+}
+
+// Build implements build.Interface
+func (f *fixed) Build(s string) (v1.Image, error) {
+	if img, ok := f.entries[s]; ok {
+		return img, nil
+	}
+	return nil, fmt.Errorf("unsupported reference: %q", s)
+}

--- a/ko/build/fixed_test.go
+++ b/ko/build/fixed_test.go
@@ -1,0 +1,48 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/random"
+)
+
+var (
+	testImage, _ = random.Image(1024, 5)
+)
+
+func TestFixed(t *testing.T) {
+	f := NewFixed(map[string]v1.Image{
+		"asdf": testImage,
+	})
+
+	if got, want := f.IsSupportedReference("asdf"), true; got != want {
+		t.Errorf("IsSupportedReference(asdf) = %v, want %v", got, want)
+	}
+	if got, err := f.Build("asdf"); err != nil {
+		t.Errorf("Build(asdf) = %v, want %v", err, testImage)
+	} else if got != testImage {
+		t.Errorf("Build(asdf) = %v, want %v", got, testImage)
+	}
+
+	if got, want := f.IsSupportedReference("blah"), false; got != want {
+		t.Errorf("IsSupportedReference(blah) = %v, want %v", got, want)
+	}
+	if got, err := f.Build("blah"); err == nil {
+		t.Errorf("Build(blah) = %v, want error", got)
+	}
+}

--- a/ko/build/gobuild.go
+++ b/ko/build/gobuild.go
@@ -1,0 +1,182 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/mutate"
+	"github.com/google/go-containerregistry/v1/tarball"
+	"github.com/google/go-containerregistry/v1/v1util"
+)
+
+var (
+	// getwd is a variable for testing.
+	getwd = os.Getwd
+)
+
+const (
+	appPath = "/app"
+)
+
+type Options struct {
+	// TODO(mattmoor): Base Image?
+	// TODO(mattmoor): Architectures?
+	Base v1.Image
+}
+
+type gobuild struct {
+	importpath string
+	opt        Options
+	build      func(string) (string, error)
+}
+
+func computeImportpath() (string, error) {
+	wd, err := getwd()
+	if err != nil {
+		return "", err
+	}
+	// Go code lives under $GOPATH/src/...
+	src := path.Join(os.Getenv("GOPATH"), "src")
+	if !strings.HasPrefix(wd, src) {
+		return "", fmt.Errorf("working directory %q must be on GOPATH %q", wd, src)
+	}
+	return strings.Trim(strings.TrimPrefix(wd, src), "/"), nil
+}
+
+// NewGo returns a build.Interface implementation that:
+//  1. builds go binaries named by importpath,
+//  2. containerizes the binary on a suitable base,
+func NewGo(opt Options) (Interface, error) {
+	importpath, err := computeImportpath()
+	if err != nil {
+		return nil, err
+	}
+
+	return &gobuild{importpath, opt, build}, nil
+}
+
+// IsSupportedReference implements build.Interface
+func (gb *gobuild) IsSupportedReference(s string) bool {
+	// TODO(mattmoor): Consider supporting vendored things as well.
+	return strings.HasPrefix(s, gb.importpath)
+}
+
+func build(ip string) (string, error) {
+	file, err := ioutil.TempFile(os.TempDir(), "out")
+	if err != nil {
+		return "", err
+	}
+	log.Printf("Go building %v", ip)
+	cmd := exec.Command("go", "build", "-o", file.Name(), ip)
+
+	// Last one wins
+	// TODO(mattmoor): GOARCH=amd64
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+
+	var output bytes.Buffer
+	cmd.Stderr = &output
+	cmd.Stdout = &output
+
+	if err := cmd.Run(); err != nil {
+		os.Remove(file.Name())
+		log.Printf("Unexpected error running \"go build\": %v\n%v", err, output.String())
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func tarBinary(binary string) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	tw := tar.NewWriter(buf)
+	defer tw.Close()
+
+	file, err := os.Open(binary)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	header := &tar.Header{
+		Name: appPath,
+		Size: stat.Size(),
+		// TODO(mattmoor): Consider a fixed Mode, so that this isn't sensitive
+		// to the directory in which it was created.
+		Mode: int64(stat.Mode()),
+	}
+	// write the header to the tarball archive
+	if err := tw.WriteHeader(header); err != nil {
+		return nil, err
+	}
+	// copy the file data to the tarball
+	if _, err := io.Copy(tw, file); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Build implements build.Interface
+func (gb *gobuild) Build(s string) (v1.Image, error) {
+	// Do the build into a temporary file.
+	file, err := gb.build(s)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(file)
+
+	// Construct a tarball with the binary.
+	layerBytes, err := tarBinary(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a layer from that tarball.
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return v1util.NopReadCloser(bytes.NewBuffer(layerBytes)), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Augment the base image with our application layer.
+	withApp, err := mutate.AppendLayers(gb.opt.Base, layer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start from a copy of the base image's config file, and set
+	// the entrypoint to our app.
+	cfg, err := withApp.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	cfg = cfg.DeepCopy()
+	cfg.Config.Entrypoint = []string{appPath}
+	return mutate.Config(withApp, cfg.Config)
+}

--- a/ko/build/gobuild_test.go
+++ b/ko/build/gobuild_test.go
@@ -1,0 +1,226 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"testing"
+
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/random"
+)
+
+type testContext struct {
+	gopath  string
+	workdir string
+}
+
+func (tc *testContext) Enter(t *testing.T) {
+	// Track the original state, so that we can restore it.
+	ogp := os.Getenv("GOPATH")
+	// Change the current state for the test.
+	os.Setenv("GOPATH", tc.gopath)
+	getwd = func() (string, error) {
+		return tc.workdir, nil
+	}
+	// Record the original state for restoration.
+	tc.gopath = ogp
+}
+
+func (tc *testContext) Exit(t *testing.T) {
+	// Restore the original state.
+	os.Setenv("GOPATH", tc.gopath)
+	getwd = os.Getwd
+}
+
+func TestComputeImportPath(t *testing.T) {
+	tests := []struct {
+		desc             string
+		ctx              testContext
+		expectErr        bool
+		expectImportpath string
+	}{{
+		desc: "simple gopath",
+		ctx: testContext{
+			gopath:  "/go",
+			workdir: "/go/src/github.com/foo/bar",
+		},
+		expectImportpath: "github.com/foo/bar",
+	}, {
+		desc: "trailing slashes",
+		ctx: testContext{
+			gopath:  "/go/",
+			workdir: "/go/src/github.com/foo/bar/",
+		},
+		expectImportpath: "github.com/foo/bar",
+	}, {
+		desc: "not on gopath",
+		ctx: testContext{
+			gopath:  "/go",
+			workdir: "/rust/src/github.com/foo/bar",
+		},
+		expectErr: true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Set the context for our test.
+			test.ctx.Enter(t)
+			defer test.ctx.Exit(t)
+
+			ip, err := computeImportpath()
+			if err != nil && !test.expectErr {
+				t.Errorf("computeImportpath() = %v, want %v", err, test.expectImportpath)
+			} else if err == nil && test.expectErr {
+				t.Errorf("computeImportpath() = %v, want error", ip)
+			} else if err == nil && !test.expectErr {
+				if got, want := ip, test.expectImportpath; want != got {
+					t.Errorf("computeImportpath() = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGoBuildIsSupportedRef(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	importpath := "github.com/google/go-containerregistry"
+	tc := testContext{
+		gopath:  "/go",
+		workdir: "/go/src/" + importpath,
+	}
+	tc.Enter(t)
+	defer tc.Exit(t)
+	ng, err := NewGo(Options{Base: img})
+	if err != nil {
+		t.Fatalf("NewGo() = %v", err)
+	}
+
+	supportedTests := []string{
+		path.Join(importpath, "pkg", "foo"),
+		path.Join(importpath, "cmd", "d8s"),
+	}
+
+	for _, test := range supportedTests {
+		t.Run(test, func(t *testing.T) {
+			if !ng.IsSupportedReference(test) {
+				t.Errorf("IsSupportedReference(%v) = false, want true", test)
+			}
+		})
+	}
+
+	unsupportedTests := []string{
+		"simple string",
+		"k8s.io/client-go/pkg/foo",
+		"github.com/google/secret/cmd/sauce",
+		path.Join("vendor", importpath, "pkg", "foo"),
+	}
+
+	for _, test := range unsupportedTests {
+		t.Run(test, func(t *testing.T) {
+			if ng.IsSupportedReference(test) {
+				t.Errorf("IsSupportedReference(%v) = true, want false", test)
+			}
+		})
+	}
+}
+
+// A helper method we use to substitute for the default "build" method.
+func writeTempFile(s string) (string, error) {
+	file, err := ioutil.TempFile(os.TempDir(), "out")
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	if _, err := file.WriteString(s); err != nil {
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func TestGoBuild(t *testing.T) {
+	baseLayers := int64(3)
+	base, err := random.Image(1024, baseLayers)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	importpath := "github.com/google/go-containerregistry"
+	tc := testContext{
+		gopath:  "/go",
+		workdir: "/go/src/" + importpath,
+	}
+	tc.Enter(t)
+	defer tc.Exit(t)
+	ng, err := NewGo(Options{Base: base})
+	if err != nil {
+		t.Fatalf("NewGo() = %v", err)
+	}
+	ng.(*gobuild).build = writeTempFile
+
+	img, err := ng.Build(path.Join(importpath, "cmd", "d8s"))
+	if err != nil {
+		t.Errorf("Build() = %v", err)
+	}
+
+	ls, err := img.Layers()
+	if err != nil {
+		t.Errorf("Layers() = %v", err)
+	}
+
+	// Check that we have the expected number of layers.
+	t.Run("check layer count", func(t *testing.T) {
+		if got, want := int64(len(ls)), baseLayers+1; got != want {
+			t.Fatalf("len(Layers()) = %v, want %v", got, want)
+		}
+	})
+
+	// While we have a randomized base image, the application layer should be completely deterministic.
+	// Check that when given fixed build outputs we get a fixed layer hash.
+	t.Run("check determinism", func(t *testing.T) {
+		expectedHash := v1.Hash{
+			Algorithm: "sha256",
+			Hex:       "f6c290fa444e8e94936132309a42764f8360fb88e38adb8b3077a21780128794",
+		}
+		appLayer := ls[baseLayers]
+
+		if got, err := appLayer.Digest(); err != nil {
+			t.Errorf("Digest() = %v", err)
+		} else if got != expectedHash {
+			t.Errorf("Digest() = %v, want %v", got, expectedHash)
+		}
+	})
+
+	// Check that the entrypoint of the image is configured to invoke our Go application
+	t.Run("check entrypoint", func(t *testing.T) {
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			t.Errorf("ConfigFile() = %v", err)
+		}
+		entrypoint := cfg.Config.Entrypoint
+		if got, want := len(entrypoint), 1; got != want {
+			t.Errorf("len(entrypoint) = %v, want %v", got, want)
+		}
+
+		if got, want := entrypoint[0], appPath; got != want {
+			t.Errorf("entrypoint = %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
This adds a package for handling builds for `ko`.  The `build.Interface` contains two methods:
1. `IsSupportedReference`: this is used to determine whether a particular string (in a K8s yaml) smells like a reference for which this `build.Interface` can produce a `v1.Image`.
1. `Build`: this is responsible for synthesizing a `v1.Image` for supported references.

At present, this contains two implementations:
1. `NewFixed`: this is an implementation intended to aid in testing packages that need a `build.Interface`.
1. `NewGo`: this is a real implementation that will perform a `go build` for import paths relative to the execution context and layer the resulting binary on top of a provided base image.

Progress towards: https://github.com/google/go-containerregistry/issues/80