### PR TITLE
Implement ko/publish

### DIFF
--- a/ko/publish/BUILD.bazel
+++ b/ko/publish/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "default.go",
+        "doc.go",
+        "fixed.go",
+        "publish.go",
+    ],
+    importpath = "github.com/google/go-containerregistry/ko/publish",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//authn:go_default_library",
+        "//name:go_default_library",
+        "//v1:go_default_library",
+        "//v1/remote:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "default_test.go",
+        "fixed_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//name:go_default_library",
+        "//v1:go_default_library",
+        "//v1/random:go_default_library",
+        "//v1/remote:go_default_library",
+    ],
+)

--- a/ko/publish/default.go
+++ b/ko/publish/default.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-containerregistry/v1/remote"
 )
 
-// defalt is intentionally mispelled to avoid keyword collision (and drive Jon nuts).
+// defalt is intentionally misspelled to avoid keyword collision (and drive Jon nuts).
 type defalt struct {
 	base name.Repository
 	t    http.RoundTripper

--- a/ko/publish/default.go
+++ b/ko/publish/default.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+// defalt is intentionally mispelled to avoid keyword collision (and drive Jon nuts).
+type defalt struct {
+	base name.Repository
+	t    http.RoundTripper
+	wo   remote.WriteOptions
+}
+
+// NewDefault returns a new publish.Interface that publishes references under the provided base
+// repository using the default keychain to authenticate and the default naming scheme.
+func NewDefault(base name.Repository, t http.RoundTripper, wo remote.WriteOptions) Interface {
+	return &defalt{base, t, wo}
+}
+
+// Publish implements publish.Interface
+func (d *defalt) Publish(img v1.Image, s string) (*name.Digest, error) {
+	auth, err := authn.DefaultKeychain.Resolve(d.base.Registry)
+	if err != nil {
+		return nil, err
+	}
+	// We push via tag (always latest) and then produce a digest because some registries do
+	// not support publishing by digest.
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", d.base, s), name.WeakValidation)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Publishing %v", tag)
+	if err := remote.Write(tag, img, auth, d.t, d.wo); err != nil {
+		return nil, err
+	}
+	h, err := img.Digest()
+	if err != nil {
+		return nil, err
+	}
+	dig, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", d.base, s, h), name.WeakValidation)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Published %v", dig)
+	return &dig, nil
+}

--- a/ko/publish/default_test.go
+++ b/ko/publish/default_test.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/random"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+func TestDefault(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	base := "blah"
+	importpath := "github.com/google/go-containerregistry/cmd/d8s"
+	expectedRepo := fmt.Sprintf("%s/%s", base, importpath)
+	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case initiatePath:
+			if r.Method != http.MethodPost {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
+			}
+			http.Error(w, "Mounted", http.StatusCreated)
+		case manifestPath:
+			if r.Method != http.MethodPut {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPut)
+			}
+			http.Error(w, "Created", http.StatusCreated)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	baseRepo, err := name.NewRepository(fmt.Sprintf("%s/%s", u.Host, base), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewRepository() = %v", err)
+	}
+
+	def := NewDefault(baseRepo, http.DefaultTransport, remote.WriteOptions{})
+	if d, err := def.Publish(img, importpath); err != nil {
+		t.Errorf("Publish() = %v", err)
+	} else if !strings.HasPrefix(d.String(), tag.Repository.String()) {
+		t.Errorf("Publish() = %v, wanted prefix %v", d, tag.Repository)
+	}
+}

--- a/ko/publish/doc.go
+++ b/ko/publish/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package publish defines methods for publishing a v1.Image reference and
+// returning the published digest for embedding back into a Kubernetes yaml.
+package publish

--- a/ko/publish/fixed.go
+++ b/ko/publish/fixed.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+)
+
+type fixed struct {
+	base    name.Repository
+	entries map[string]v1.Hash
+}
+
+// NewFixed returns a publish.Interface implementation that simply resolves particular
+// references to fixed name.Digest references.
+func NewFixed(base name.Repository, entries map[string]v1.Hash) Interface {
+	return &fixed{base, entries}
+}
+
+// Publish implements publish.Interface
+func (f *fixed) Publish(_ v1.Image, s string) (*name.Digest, error) {
+	h, ok := f.entries[s]
+	if !ok {
+		return nil, fmt.Errorf("unsupported importpath: %q", s)
+	}
+	d, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", f.base, s, h), name.WeakValidation)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}

--- a/ko/publish/fixed_test.go
+++ b/ko/publish/fixed_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+)
+
+var (
+	fixedBaseRepo, _ = name.NewRepository("gcr.io/asdf", name.WeakValidation)
+)
+
+func TestFixed(t *testing.T) {
+	hex1 := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	hex2 := "baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d"
+	f := NewFixed(fixedBaseRepo, map[string]v1.Hash{
+		"foo": v1.Hash{
+			Algorithm: "sha256",
+			Hex:       hex1,
+		},
+		"bar": v1.Hash{
+			Algorithm: "sha256",
+			Hex:       hex2,
+		},
+	})
+
+	fooDigest, err := f.Publish(nil, "foo")
+	if err != nil {
+		t.Errorf("Publish(foo) = %v", err)
+	}
+	if got, want := fooDigest.String(), "gcr.io/asdf/foo@sha256:"+hex1; got != want {
+		t.Errorf("Publish(foo) = %q, want %q", got, want)
+	}
+
+	barDigest, err := f.Publish(nil, "bar")
+	if err != nil {
+		t.Errorf("Publish(bar) = %v", err)
+	}
+	if got, want := barDigest.String(), "gcr.io/asdf/bar@sha256:"+hex2; got != want {
+		t.Errorf("Publish(bar) = %q, want %q", got, want)
+	}
+
+	d, err := f.Publish(nil, "baz")
+	if err == nil {
+		t.Errorf("Publish(baz) = %v, want error", d)
+	}
+}

--- a/ko/publish/publish.go
+++ b/ko/publish/publish.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+)
+
+// Interface abstracts different methods for publishing images.
+type Interface interface {
+	// Publish uploads the given v1.Image to a registry incorporating the
+	// provided string into the image's repository name.  Returns the digest
+	// of the published image.
+	Publish(v1.Image, string) (*name.Digest, error)
+}


### PR DESCRIPTION
This adds a package for handling how `v1.Image`s are published for `ko`.  The `publish.Interface` contains one method, which takes a `v1.Image` and an importpath and is responsible for publishing it to some base `name.Repository` and returning a `name.Digest` suitable for substitution into the K8s yaml.

There are currently two implementations provided:
1. `NewFixed`: this is an implementation intended to aid in testing packages that need a `publish.Interface`.
1. `NewDefault`: this is an implementation that publishes to: `{chroot}/{importpath}:latest` via `remote.Write` and the default keychain.

In the future, we might consider an alternate implementation of `publish.Interface` that support flatter naming schemes (e.g. to support DockerHub, with which the `NewDefault` scheme won't work).

Progress towards: #80