### PR TITLE
Implement cmd/ko

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,10 +85,9 @@
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
-# Use HEAD (2018-04-21) to pick up:
-# https://github.com/spf13/cobra/pull/662
-[[constraint]]
+[[projects]]
   name = "github.com/spf13/cobra"
+  packages = ["."]
   revision = "615425954c3b0d9485a7027d4d451fdcdfdee84e"
 
 [[projects]]
@@ -157,6 +156,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0dce051207c5d9e5805f24759207a33a521f325de3c0f896b8047ce0dc6a1d6a"
+  inputs-digest = "333eff11e7b58853d4655d6b9737f25110d75f6ea60ebf4032ef5998a065d6bc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,6 +33,12 @@ required = [
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
+# Use HEAD (2018-04-21) to pick up:
+# https://github.com/spf13/cobra/pull/662
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  revision = "615425954c3b0d9485a7027d4d451fdcdfdee84e"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/ko/BUILD.bazel
+++ b/cmd/ko/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/google/go-containerregistry/cmd/ko",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//authn:go_default_library",
+        "//ko/build:go_default_library",
+        "//ko/publish:go_default_library",
+        "//ko/resolve:go_default_library",
+        "//name:go_default_library",
+        "//v1/remote:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "ko",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -1,0 +1,148 @@
+# `ko`
+
+`ko` is an **experimental** CLI to support rapid development of Go containers
+with Kubernetes and minimal configuration.
+
+## Installation
+
+`ko` can be installed via:
+
+```shell
+go install github.com/google/go-containerregistry/cmd/ko
+```
+
+## The `ko` Model
+
+`ko` is built around a very simple extension to Go's model for expressing
+dependencies using [import paths](https://golang.org/doc/code.html#ImportPaths).
+
+In Go, dependencies are expressed via blocks like:
+
+```go
+import (
+    "github.com/google/go-containerregistry/authn"
+    "github.com/google/go-containerregistry/name"
+)
+```
+
+Similarly (as you can see above), Go binaries can be referenced via import
+paths like `github.com/google/go-containerregistry/cmd/ko`.
+
+**One of the goals of `ko` is to make containers invisible infrastructure.**
+Simply replace image references in your Kubernetes yaml with the import path for
+your Go binary, and `ko` will handle containerizing and publishing that
+container image as needed.
+
+For example, you might use the following in a Kubernetes `Deployment` resource:
+
+```yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: hello-world
+        # This is the import path for the Go binary to build and run.
+        image: github.com/mattmoor/examples/http/cmd/helloworld
+        ports:
+        - containerPort: 8080
+```
+
+**This extension of the Go convention enables us to create a tool with an
+extremely fast development cycle and effectively zero configuration.**
+
+## Usage
+
+`ko` also three commands that interact with Kubernetes resources.
+
+### `ko resolve`
+
+`ko resolve` builds on the [model](#the-ko-model) above to determine the set of
+Go import paths to build, containerize, and publish. It then outputs a
+multi-document yaml of the resources to `STDOUT`, replacing import paths with
+published image digests.
+
+To determine where to publish the images, `ko` currently requires the
+environment variable `KO_DOCKER_REPO` to be set to an acceptable docker
+repository (e.g. `gcr.io/your-project`). This will likely change in a
+future version.
+
+Following the example above, this might result in:
+
+```shell
+export PROJECT_ID=$(gcloud config get-value core/project)
+export KO_DOCKER_REPO="gcr.io/${PROJECT_ID}"
+ko resolve -f deployment.yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: hello-world
+        # This is the digest of the published image containing the go binary
+        # at the embedded import path.
+        image: gcr.io/your-project/github.com/mattmoor/examples/http/cmd/helloworld@sha256:deadbeef
+        ports:
+        - containerPort: 8080
+```
+
+*Note that DockerHub does not currently support these multi-level names. We may
+employ alternate naming strategies in the future to broaden support, but this
+would sacrifice some amount of identifiability.*
+
+### `ko apply`
+
+`ko apply` is intended to parallel `kubectl apply`, but acts on the same
+resolved output as `ko resolve` emits. It is expected that `ko apply` will act
+as the vehicle for rapid iteration during development.  As changes are made to a
+particular application, you can run: `ko apply -f unit.yaml` to rapidly
+rebuild, repush, and redeploy their changes.
+
+`ko apply` will invoke `kubectl apply` under the covers, and therefore apply
+to whatever `kubectl` context is active.
+
+### `ko delete`
+
+`ko delete` simply passes through to `kubectl delete`, as with the `go`
+commands. It is exposed purely out of convenience for cleaning up resources
+created through `ko apply`.
+
+## Relevance to Release Management
+
+`ko` is also useful for helping manage releases. For example, if your project
+periodically releases a set of images and configuration to launch those images
+on a Kubernetes cluster, release binaries may be published and the configuration
+generated via:
+
+```shell
+export PROJECT_ID=<YOUR RELEASE PROJECT>
+export KO_DOCKER_REPO="gcr.io/${PROJECT_ID}"
+ko resolve -f config/ > release.yaml
+```
+
+This will publish all of the binary components as container images to
+`gcr.io/my-releases/...` and create a `release.yaml` file containing all of the
+configuration for your application with inlined image references.
+
+This resulting configuration may then be installed onto Kubernetes clusters via:
+
+```shell
+kubectl apply -f release.yaml
+```
+
+
+## Acknowledgements
+
+This work is based heavily on learnings from having built the
+[Docker](github.com/bazelbuild/rules_docker) and
+[Kubernetes](github.com/bazelbuild/rules_k8s) support for
+[Bazel](https://bazel.build). That work was presented
+[here](https://www.youtube.com/watch?v=RS1aiQqgUTA).

--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -1,0 +1,288 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/google/go-containerregistry/authn"
+	"github.com/google/go-containerregistry/ko/build"
+	"github.com/google/go-containerregistry/ko/publish"
+	"github.com/google/go-containerregistry/ko/resolve"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+var (
+	baseImage, _ = name.NewTag("gcr.io/distroless/base:latest", name.WeakValidation)
+)
+
+// runCmd is suitable for use with cobra.Command's Run field.
+type runCmd func(*cobra.Command, []string)
+
+// passthru returns a runCmd that simply passes our CLI arguments
+// through to a binary named command.
+func passthru(command string) runCmd {
+	return func(_ *cobra.Command, _ []string) {
+		// Start building a command line invocation by passing
+		// through our arguments to command's CLI.
+		cmd := exec.Command(command, os.Args[1:]...)
+
+		// Pass through our environment
+		cmd.Env = os.Environ()
+		// Pass through our stdfoo
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+
+		// Run it.
+		if err := cmd.Run(); err != nil {
+			log.Fatalln(err)
+		}
+	}
+}
+
+// addGoCommands augments our CLI surface with passthru sub-commands for the Go CLI surface.
+func addGoCommands(topLevel *cobra.Command) {
+	// For convenience, we expose top-level commands for each of the top-level "go foo" commands.
+	// TODO(mattmoor): Split out some of these where we can splice in additional goodness.
+	// e.g. could we make `ko fmt` format K8s yamls?
+	foos := []string{"build", "clean", "doc", "env", "bug", "fix", "fmt", "generate", "get",
+		"install", "list", "run", "test", "tool", "version", "vet"}
+	for _, foo := range foos {
+		topLevel.AddCommand(&cobra.Command{
+			Use:   foo,
+			Short: fmt.Sprintf(`See "go help %s" for detailed usage.`, foo),
+			Run:   passthru("go"),
+			// We ignore unknown flags to avoid importing everything Go exposes
+			// from our commands.
+			FParseErrWhitelist: cobra.FParseErrWhitelist{
+				UnknownFlags: true,
+			},
+		})
+	}
+}
+
+// addKubeCommands augments our CLI surface with a passthru delete command, and an apply
+// command that realizes the promise of ko, as outlined here:
+//    https://github.com/google/go-containerregistry/issues/80
+func addKubeCommands(topLevel *cobra.Command) {
+	topLevel.AddCommand(&cobra.Command{
+		Use:   "delete",
+		Short: `See "kubectl help delete" for detailed usage.`,
+		Run:   passthru("kubectl"),
+		// We ignore unknown flags to avoid importing everything Go exposes
+		// from our commands.
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+	})
+	fo := &FilenameOptions{}
+	apply := &cobra.Command{
+		Use: "apply -f FILENAME",
+		// TODO(mattmoor): Expose our own apply surface.
+		Short: `See "kubectl help apply" for detailed usage.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO(mattmoor): Use io.Pipe to avoid buffering the whole thing.
+			buf := bytes.NewBuffer(nil)
+			resolveFilesTo(fo, buf)
+
+			// Issue a "kubectl apply" command reading from stdin,
+			// to which we will pipe the resolved files.
+			kubectlCmd := exec.Command("kubectl", "apply", "-f", "-")
+
+			// Pass through our environment
+			kubectlCmd.Env = os.Environ()
+			// Pass through our std{out,err} and make our resolved buffer stdin.
+			kubectlCmd.Stderr = os.Stderr
+			kubectlCmd.Stdout = os.Stdout
+			kubectlCmd.Stdin = buf
+
+			// Run it.
+			if err := kubectlCmd.Run(); err != nil {
+				log.Fatalln(err)
+			}
+		},
+	}
+	addFileArg(apply, fo)
+	topLevel.AddCommand(apply)
+	resolve := &cobra.Command{
+		// TODO(mattmoor): Pick a better name.
+		Use:   "resolve -f FILENAME",
+		Short: `Print the input files with image references resolved to built/pushed image digests.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			resolveFilesTo(fo, os.Stdout)
+		},
+	}
+	addFileArg(resolve, fo)
+	topLevel.AddCommand(resolve)
+}
+
+func gobuildOptions() build.Options {
+	// A better story for O
+	base, err := remote.Image(baseImage, authn.Anonymous, http.DefaultTransport)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return build.Options{
+		Base: base,
+	}
+}
+
+// From pkg/kubectl
+type FilenameOptions struct {
+	Filenames []string
+	Recursive bool
+}
+
+func addFileArg(cmd *cobra.Command, fo *FilenameOptions) {
+	// From pkg/kubectl
+	cmd.Flags().StringSliceVarP(&fo.Filenames, "filename", "f", fo.Filenames,
+		"Filename, directory, or URL to files to use to create the resource")
+	cmd.Flags().BoolVarP(&fo.Recursive, "recursive", "R", fo.Recursive,
+		"Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
+}
+
+// Based heavily on pkg/kubectl
+func enumerateFiles(fo *FilenameOptions) ([]string, error) {
+	var files []string
+	for _, paths := range fo.Filenames {
+		err := filepath.Walk(paths, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if fi.IsDir() {
+				if path != paths && !fo.Recursive {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			// Don't check extension if the filepath was passed explicitly
+			if path != paths {
+				switch filepath.Ext(path) {
+				case ".json", ".yaml":
+					// Process these.
+				default:
+					return nil
+				}
+			}
+
+			files = append(files, path)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+func resolveFilesTo(fo *FilenameOptions, out io.Writer) {
+	fs, err := enumerateFiles(fo)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	opt := gobuildOptions()
+	var sm sync.Map
+	wg := sync.WaitGroup{}
+	for _, f := range fs {
+		wg.Add(1)
+		go func(f string) {
+			defer wg.Done()
+
+			b, err := resolveFile(f, opt)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			sm.Store(f, b)
+		}(f)
+	}
+	// Wait for all of them to complete.
+	wg.Wait()
+	for _, f := range fs {
+		iface, ok := sm.Load(f)
+		if !ok {
+			log.Fatalf("missing file in resolved map: %v", f)
+		}
+		b, ok := iface.([]byte)
+		if !ok {
+			log.Fatalf("unsupported type in sync.Map's value: %T", iface)
+		}
+		// Our sole output should be the resolved yamls
+		out.Write([]byte("---\n"))
+		out.Write(b)
+	}
+}
+
+func resolveFile(f string, opt build.Options) ([]byte, error) {
+	repoName := os.Getenv("KO_DOCKER_REPO")
+	repo, err := name.NewRepository(repoName, name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
+	}
+
+	b, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+
+	publisher := publish.NewDefault(repo, http.DefaultTransport, remote.WriteOptions{
+		MountPaths: []name.Repository{baseImage.Repository},
+	})
+	builder, err := build.NewGo(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(mattmoor): To better approximate Bazel, we should collect the importpath references
+	// in advance, trigger builds, and then do a second pass to finalize each of the configs.
+	b2, err := resolve.ImageReferences(b, builder, publisher)
+	if err != nil {
+		return nil, err
+	}
+	return b2, err
+}
+
+func main() {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "ko",
+		Short: "Rapidly iterate with Go, Containers, and Kubernetes.",
+		Long:  "Long Desc", // K8s has a helper here?
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+	addGoCommands(cmds)
+	addKubeCommands(cmds)
+
+	if err := cmds.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/v1/mutate/BUILD.bazel
+++ b/v1/mutate/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "mutate.go",
     ],
     importpath = "github.com/google/go-containerregistry/v1/mutate",

--- a/vendor/github.com/spf13/cobra/command.go
+++ b/vendor/github.com/spf13/cobra/command.go
@@ -27,6 +27,9 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+// FParseErrWhitelist configures Flag parse errors to be ignored
+type FParseErrWhitelist flag.ParseErrorsWhitelist
+
 // Command is just that, a command for your application.
 // E.g.  'go run ...' - 'run' is the command. Cobra requires
 // you to define the usage and description as part of your command
@@ -136,6 +139,9 @@ type Command struct {
 
 	// TraverseChildren parses flags on all parents before executing child command.
 	TraverseChildren bool
+
+	//FParseErrWhitelist flag parse errors to be ignored
+	FParseErrWhitelist FParseErrWhitelist
 
 	// commands is the list of commands supported by this program.
 	commands []*Command
@@ -1463,6 +1469,10 @@ func (c *Command) ParseFlags(args []string) error {
 	}
 	beforeErrorBufLen := c.flagErrorBuf.Len()
 	c.mergePersistentFlags()
+
+	//do it here after merging all flags and just before parse
+	c.Flags().ParseErrorsWhitelist = flag.ParseErrorsWhitelist(c.FParseErrWhitelist)
+
 	err := c.Flags().Parse(args)
 	// Print warnings if they occurred (e.g. deprecated flag messages).
 	if c.flagErrorBuf.Len()-beforeErrorBufLen > 0 && err == nil {


### PR DESCRIPTION
This uses the cobra library to implement the `ko` CLI, which wraps the `go` CLI and exposes a handful of commands for interacting with kubernetes configurations.  See `cmd/ko/README.md` for more details.

Fixes: #80