### PR TITLE
Support $HOME/.docker if $DOCKER_CONFIG is unset

### DIFF
--- a/authn/keychain.go
+++ b/authn/keychain.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"runtime"
 
 	"github.com/google/go-containerregistry/name"
 )
@@ -41,19 +42,22 @@ func configDir() (string, error) {
 	if dc := os.Getenv("DOCKER_CONFIG"); dc != "" {
 		return dc, nil
 	}
-	if h := homeDir(); h != "" {
-		return path.Join(homeDir(), ".docker"), nil
+	if h := dockerUserHomeDir(); h != "" {
+		return path.Join(dockerUserHomeDir(), ".docker"), nil
 	}
 	return "", errNoHomeDir
 }
 
 var errNoHomeDir = errors.New("could not determine home directory")
 
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
+// dockerUserHomeDir returns the current user's home directory, as interpreted by Docker.
+func dockerUserHomeDir() string {
+	if runtime.GOOS == "windows" {
+		// Docker specifically expands "%USERPROFILE%" on Windows,
+		return os.Getenv("USERPROFILE")
 	}
-	return os.Getenv("USERPROFILE")
+	// Docker defaults to "$HOME" Linux and OSX.
+	return os.Getenv("HOME")
 }
 
 // authEntry is a helper for JSON parsing an "auth" entry of config.json

--- a/authn/keychain.go
+++ b/authn/keychain.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"runtime"
 
 	"github.com/google/go-containerregistry/name"
 )
@@ -51,14 +50,10 @@ func configDir() (string, error) {
 var errNoHomeDir = errors.New("could not determine home directory")
 
 func homeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
+	if h := os.Getenv("HOME"); h != "" {
+		return h
 	}
-	return os.Getenv("HOME")
+	return os.Getenv("USERPROFILE")
 }
 
 // authEntry is a helper for JSON parsing an "auth" entry of config.json

--- a/authn/keychain.go
+++ b/authn/keychain.go
@@ -41,6 +41,9 @@ func configDir() (string, error) {
 	if dc := os.Getenv("DOCKER_CONFIG"); dc != "" {
 		return dc, nil
 	}
+	if h := os.Getenv("HOME"); h != "" {
+		return path.Join(h, ".docker"), nil
+	}
 	usr, err := user.Current()
 	if err != nil {
 		return "", err

--- a/authn/keychain_test.go
+++ b/authn/keychain_test.go
@@ -53,7 +53,7 @@ func TestConfigDir(t *testing.T) {
 	})
 
 	t.Run("HOME", func(t *testing.T) {
-		// DOCKER_CONFIG is unset, but HOME is (on non-Windows).
+		// DOCKER_CONFIG is unset, but HOME is.
 		if runtime.GOOS == "windows" {
 			t.Skip("Not running on Windows")
 		}
@@ -67,27 +67,8 @@ func TestConfigDir(t *testing.T) {
 		}
 	})
 
-	t.Run("HOMEDRIVE and HOMEPATH", func(t *testing.T) {
-		// DOCKER_CONFIG is unset, but HOMEDRIVE or HOMEPATH are (on Windows).
-		if runtime.GOOS != "windows" {
-			t.Skip("Not running on non-Windows")
-		}
-		clearEnv()
-		os.Setenv("HOMEDRIVE", "/homedrive")
-		os.Setenv("HOMEPATH", "homepath")
-		want := "/homedrive/homepath/.docker"
-		if got, err := configDir(); err != nil {
-			t.Errorf("configDir(): %v", err)
-		} else if got != want {
-			t.Errorf("configDir() got %q, want %q", got, want)
-		}
-	})
-
 	t.Run("USERPROFILE", func(t *testing.T) {
-		// DOCKER_CONFIG is unset, but USERPROFILE is (on Windows).
-		if runtime.GOOS != "windows" {
-			t.Skip("Not running on non-Windows")
-		}
+		// DOCKER_CONFIG and HOME are unset, but USERPROFILE is.
 		clearEnv()
 		os.Setenv("USERPROFILE", "/user/profile")
 		want := "/user/profile/.docker"

--- a/authn/keychain_test.go
+++ b/authn/keychain_test.go
@@ -27,27 +27,39 @@ import (
 func TestConfigDir(t *testing.T) {
 	notSet, err := configDir()
 	if err != nil {
-		t.Errorf("configDir() = %v", err)
+		t.Errorf("configDir() without envs set: %v", err)
 	}
 
-	// Now set it to something specific and try again.
+	// Set DOCKER_CONFIG and try again.
 	want := "/path/to/.docker"
 	os.Setenv("DOCKER_CONFIG", want)
-
 	set, err := configDir()
 	if err != nil {
-		t.Errorf("configDir() = %v", err)
+		t.Errorf("configDir() with DOCKER_CONFIG: %v", err)
 	}
 
 	// the "set" version, should match what we want.
 	if set != want {
-		t.Errorf("configDir(set); got %v, want %v", set, want)
+		t.Errorf("configDir() with DOCKER_CONFIG; got %v, want %v", set, want)
 	}
 
-	// the "notSet" version, shouldn't match what we got after setting it.
-	if notSet == set {
-		t.Errorf("configDir(not set) = %v", notSet)
+	// the "set" version should not match the unset version.
+	if set == notSet {
+		t.Errorf("configDir() with DOCKER_CONFIG == without DOCKER_CONFIG (%q)", set)
 	}
+
+	// Unset DOCKER_CONFIG but set HOME.
+	os.Setenv("DOCKER_CONFIG", "")
+	os.Setenv("HOME", "/my/home")
+	set, err = configDir()
+	if err != nil {
+		t.Errorf("configDir() with HOME: %v", err)
+	}
+	want = "/my/home/.docker"
+	if set != want {
+		t.Errorf("configDir() with HOME got %q, want %q", set, want)
+	}
+
 }
 
 var (


### PR DESCRIPTION
This is needed for image-rebase to work on Container Builder, where the
user's homedir is unset, but $HOME is explicitly set in each build step.