### PR TITLE
Don't buffer entire tar contents into memory during Extract

### DIFF
--- a/v1/mutate/mutate_test.go
+++ b/v1/mutate/mutate_test.go
@@ -88,9 +88,6 @@ func TestExtractError(t *testing.T) {
 
 // TestExtractPartialRead tests that the reader can be partially read (e.g.,
 // tar headers) and closed without error.
-//
-// It's important to close the ReadCloser in case of a partial read, since it
-// frees up resources used during extraction.
 func TestExtractPartialRead(t *testing.T) {
 	rc := Extract(invalidImage{})
 	if _, err := io.Copy(ioutil.Discard, io.LimitReader(rc, 1)); err != nil {


### PR DESCRIPTION
Instead, initialize a pipe, write tar contents into one end in a goroutine and hand the read end back to the user.

This also adds a test that errors returned during `Extract` are surfaced to the read end (since `Extract` no longer returns an error). It also tests that partial reads of the read end, and `Close` after a partial read, don't result in errors.

/cc @nkubala 