### PR TITLE
Implement daemon.Write

### DIFF
--- a/cmd/crane/append.go
+++ b/cmd/crane/append.go
@@ -75,7 +75,7 @@ func doAppend(src, dst, tar, output string) {
 	}
 
 	if output != "" {
-		if err := tarball.Write(output, dstTag, image, &tarball.WriteOptions{}); err != nil {
+		if err := tarball.WriteToFile(output, dstTag, image, &tarball.WriteOptions{}); err != nil {
 			log.Fatalln(err)
 		}
 		return

--- a/cmd/crane/pull.go
+++ b/cmd/crane/pull.go
@@ -53,7 +53,7 @@ func pull(_ *cobra.Command, args []string) {
 		log.Fatalln(err)
 	}
 
-	if err := tarball.Write(dst, t, i, &tarball.WriteOptions{}); err != nil {
+	if err := tarball.WriteToFile(dst, t, i, &tarball.WriteOptions{}); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/v1/daemon/BUILD.bazel
+++ b/v1/daemon/BUILD.bazel
@@ -16,17 +16,23 @@ go_library(
         "//name:go_default_library",
         "//v1:go_default_library",
         "//v1/tarball:go_default_library",
+        "//vendor/github.com/docker/docker/api/types:go_default_library",
         "//vendor/github.com/docker/docker/client:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["image_test.go"],
+    srcs = [
+        "image_test.go",
+        "write_test.go",
+    ],
     data = ["//v1/tarball:test_image_1.tar"],  # keep
     embed = [":go_default_library"],
     deps = [
         "//name:go_default_library",
+        "//v1/random:go_default_library",
         "//v1/tarball:go_default_library",
     ],
 )

--- a/v1/daemon/write_test.go
+++ b/v1/daemon/write_test.go
@@ -1,0 +1,59 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/tarball"
+)
+
+type MockImageLoader struct{}
+
+func (m *MockImageLoader) ImageLoad(_ context.Context, _ io.Reader, _ bool) (types.ImageLoadResponse, error) {
+	return types.ImageLoadResponse{
+		Body: ioutil.NopCloser(strings.NewReader("Loaded")),
+	}, nil
+}
+
+func init() {
+	getImageLoader = func() (ImageLoader, error) {
+		return &MockImageLoader{}, nil
+	}
+}
+
+func TestWriteImage(t *testing.T) {
+	image, err := tarball.ImageFromPath("../tarball/test_image_1.tar", nil)
+	if err != nil {
+		t.Errorf("Error loading image: %v", err.Error())
+	}
+	tag, err := name.NewTag("test_image_2:latest", name.WeakValidation)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	response, err := Write(tag, image, WriteOptions{})
+	if err != nil {
+		t.Errorf("Error writing image tar: %s", err.Error())
+	}
+	if !strings.Contains(response, "Loaded") {
+		t.Errorf("Error loading image. Response: %s", response)
+	}
+}

--- a/v1/tarball/write_test.go
+++ b/v1/tarball/write_test.go
@@ -45,7 +45,7 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating test tag.")
 	}
-	if err := Write(fp.Name(), tag, randImage, nil); err != nil {
+	if err := WriteToFile(fp.Name(), tag, randImage, nil); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 


### PR DESCRIPTION
This adds support for loading a `v1.Image` into a local docker daemon, by first writing it in `docker save` format using `tarball.Write`, and then feeding that to the docker client.

Previously `tarball.Write` only supported writing to disk, so to avoid this I changed the signature to return an `io.ReadCloser` by default. `tarball.WriteToFile` can be used in its place to write the contents of this reader to disk.