### PR TITLE
Fix scope-related bug in remote.Write (#123)

### DIFF
--- a/v1/remote/delete.go
+++ b/v1/remote/delete.go
@@ -34,7 +34,8 @@ type DeleteOptions struct {
 
 // Delete removes the specified image reference from the remote registry.
 func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, do DeleteOptions) error {
-	tr, err := transport.New(ref, auth, t, transport.DeleteScope)
+	scopes := []string{ref.Scope(transport.DeleteScope)}
+	tr, err := transport.New(ref, auth, t, scopes)
 	if err != nil {
 		return err
 	}

--- a/v1/remote/delete.go
+++ b/v1/remote/delete.go
@@ -35,7 +35,7 @@ type DeleteOptions struct {
 // Delete removes the specified image reference from the remote registry.
 func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, do DeleteOptions) error {
 	scopes := []string{ref.Scope(transport.DeleteScope)}
-	tr, err := transport.New(ref, auth, t, scopes)
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
 	if err != nil {
 		return err
 	}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -48,7 +48,7 @@ var _ partial.CompressedImageCore = (*remoteImage)(nil)
 // Image accesses a given image reference over the provided transport, with the provided authentication.
 func Image(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) (v1.Image, error) {
 	scopes := []string{ref.Scope(transport.PullScope)}
-	tr, err := transport.New(ref, auth, t, scopes)
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -47,7 +47,8 @@ var _ partial.CompressedImageCore = (*remoteImage)(nil)
 
 // Image accesses a given image reference over the provided transport, with the provided authentication.
 func Image(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) (v1.Image, error) {
-	tr, err := transport.New(ref, auth, t, transport.PullScope)
+	scopes := []string{ref.Scope(transport.PullScope)}
+	tr, err := transport.New(ref, auth, t, scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/remote/image_test.go
+++ b/v1/remote/image_test.go
@@ -180,7 +180,7 @@ func TestRawManifestDigests(t *testing.T) {
 			}
 
 			if _, err := rmt.RawManifest(); (err != nil) != tc.wantErr {
-				t.Error("RawManifest() wrong error: %v, want %v: %v", (err != nil), tc.wantErr, err)
+				t.Errorf("RawManifest() wrong error: %v, want %v: %v\n", (err != nil), tc.wantErr, err)
 			}
 		})
 	}

--- a/v1/remote/transport/bearer.go
+++ b/v1/remote/transport/bearer.go
@@ -39,7 +39,7 @@ type bearerTransport struct {
 	realm string
 	// See https://docs.docker.com/registry/spec/auth/token/
 	service string
-	scope   string
+	scopes  []string
 }
 
 var _ http.RoundTripper = (*bearerTransport)(nil)
@@ -77,7 +77,7 @@ func (bt *bearerTransport) refresh() error {
 	client := http.Client{Transport: b}
 
 	u.RawQuery = url.Values{
-		"scope":   []string{bt.scope},
+		"scope":   bt.scopes,
 		"service": []string{bt.service},
 	}.Encode()
 

--- a/v1/remote/transport/bearer_test.go
+++ b/v1/remote/transport/bearer_test.go
@@ -74,7 +74,7 @@ func TestBearerRefresh(t *testing.T) {
 				basic:    basic,
 				registry: registry,
 				realm:    server.URL,
-				scope:    expectedScope,
+				scopes:   []string{expectedScope},
 				service:  expectedService,
 			}
 

--- a/v1/remote/transport/scope.go
+++ b/v1/remote/transport/scope.go
@@ -14,14 +14,11 @@
 
 package transport
 
-// Scope is an enumeration of the supported scopes to pass a transport.
-type Scope string
-
-// Scopes suitable to pass to New()
+// Scopes suitable to qualify each Repository
 const (
-	PullScope Scope = "pull"
-	PushScope Scope = "push,pull"
+	PullScope string = "pull"
+	PushScope string = "push,pull"
 	// For now DELETE is PUSH, which is the read/write ACL.
-	DeleteScope  Scope = PushScope
-	CatalogScope Scope = "catalog"
+	DeleteScope  string = PushScope
+	CatalogScope string = "catalog"
 )

--- a/v1/remote/transport/transport.go
+++ b/v1/remote/transport/transport.go
@@ -27,9 +27,9 @@ const (
 )
 
 // New returns a new RoundTripper based on the provided RoundTripper that has been
-// setup to authenticate with the remote registry hosting "ref", in the capacity
-// laid out by the specified Scope.
-func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, scopes []string) (http.RoundTripper, error) {
+// setup to authenticate with the remote registry "reg", in the capacity
+// laid out by the specified scopes.
+func New(reg name.Registry, auth authn.Authenticator, t http.RoundTripper, scopes []string) (http.RoundTripper, error) {
 	// The handshake:
 	//  1. Use "t" to ping() the registry for the authentication challenge.
 	//
@@ -44,7 +44,7 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, scop
 
 	// First we ping the registry to determine the parameters of the authentication handshake
 	// (if one is even necessary).
-	pr, err := ping(ref.Context().Registry, t)
+	pr, err := ping(reg, t)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, scop
 	case anonymous:
 		return t, nil
 	case basic:
-		return &basicTransport{inner: t, auth: auth, target: ref.Context().RegistryStr()}, nil
+		return &basicTransport{inner: t, auth: auth, target: reg.RegistryStr()}, nil
 	case bearer:
 		// We require the realm, which tells us where to send our Basic auth to turn it into Bearer auth.
 		realm, ok := pr.parameters["realm"]
@@ -64,13 +64,13 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, scop
 		if !ok {
 			// If the service parameter is not specified, then default it to the registry
 			// with which we are talking.
-			service = ref.Context().Registry.String()
+			service = reg.String()
 		}
 		bt := &bearerTransport{
 			inner:    t,
 			basic:    auth,
 			realm:    realm,
-			registry: ref.Context().Registry,
+			registry: reg,
 			service:  service,
 			scopes:   scopes,
 		}

--- a/v1/remote/transport/transport.go
+++ b/v1/remote/transport/transport.go
@@ -29,7 +29,7 @@ const (
 // New returns a new RoundTripper based on the provided RoundTripper that has been
 // setup to authenticate with the remote registry hosting "ref", in the capacity
 // laid out by the specified Scope.
-func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, a Scope) (http.RoundTripper, error) {
+func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, scopes []string) (http.RoundTripper, error) {
 	// The handshake:
 	//  1. Use "t" to ping() the registry for the authentication challenge.
 	//
@@ -72,7 +72,7 @@ func New(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, a Sc
 			realm:    realm,
 			registry: ref.Context().Registry,
 			service:  service,
-			scope:    ref.Scope(string(a)),
+			scopes:   scopes,
 		}
 		if err := bt.refresh(); err != nil {
 			return nil, err

--- a/v1/remote/transport/transport_test.go
+++ b/v1/remote/transport/transport_test.go
@@ -43,7 +43,7 @@ func TestTransportSelectionAnonymous(t *testing.T) {
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
 
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -68,7 +68,7 @@ func TestTransportSelectionBasic(t *testing.T) {
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
 
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -109,7 +109,7 @@ func TestTransportSelectionBearer(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -132,7 +132,7 @@ func TestTransportSelectionBearerMissingRealm(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil || !strings.Contains(err.Error(), "missing realm") {
 		t.Errorf("New() = %v, %v", tp, err)
 	}
@@ -159,7 +159,7 @@ func TestTransportSelectionBearerAuthError(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil {
 		t.Errorf("New() = %v", tp)
 	}
@@ -179,7 +179,7 @@ func TestTransportSelectionUnrecognizedChallenge(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
+	tp, err := New(testReference.Context().Registry, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil || !strings.Contains(err.Error(), "challenge") {
 		t.Errorf("New() = %v, %v", tp, err)
 	}

--- a/v1/remote/transport/transport_test.go
+++ b/v1/remote/transport/transport_test.go
@@ -43,7 +43,7 @@ func TestTransportSelectionAnonymous(t *testing.T) {
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
 
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -68,7 +68,7 @@ func TestTransportSelectionBasic(t *testing.T) {
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
 
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -109,7 +109,7 @@ func TestTransportSelectionBearer(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
@@ -132,7 +132,7 @@ func TestTransportSelectionBearerMissingRealm(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil || !strings.Contains(err.Error(), "missing realm") {
 		t.Errorf("New() = %v, %v", tp, err)
 	}
@@ -159,7 +159,7 @@ func TestTransportSelectionBearerAuthError(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil {
 		t.Errorf("New() = %v", tp)
 	}
@@ -179,7 +179,7 @@ func TestTransportSelectionUnrecognizedChallenge(t *testing.T) {
 	}
 
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
-	tp, err := New(testReference, basic, tprt, PullScope)
+	tp, err := New(testReference, basic, tprt, []string{testReference.Scope(PullScope)})
 	if err == nil || !strings.Contains(err.Error(), "challenge") {
 		t.Errorf("New() = %v, %v", tp, err)
 	}

--- a/v1/remote/write.go
+++ b/v1/remote/write.go
@@ -39,7 +39,13 @@ type WriteOptions struct {
 // Write pushes the provided img to the specified image reference.
 func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.RoundTripper,
 	wo WriteOptions) error {
-	tr, err := transport.New(ref, auth, t, transport.PushScope)
+
+	scopes := []string{ref.Scope(transport.PushScope)}
+	for _, mp := range wo.MountPaths {
+		scopes = append(scopes, mp.Scope(transport.PullScope))
+	}
+
+	tr, err := transport.New(ref, auth, t, scopes)
 	if err != nil {
 		return err
 	}

--- a/v1/remote/write.go
+++ b/v1/remote/write.go
@@ -45,7 +45,7 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		scopes = append(scopes, mp.Scope(transport.PullScope))
 	}
 
-	tr, err := transport.New(ref, auth, t, scopes)
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR refactors `transport.New` to take fully-qualified scopes. This is necessary to fix `crane append` when the source and destination are two different Docker Hub repos .

See #123 for additional context.