### PR TITLE
Don't filepath.Join names when splitting directories

### DIFF
--- a/v1/mutate/mutate.go
+++ b/v1/mutate/mutate.go
@@ -300,7 +300,14 @@ func extract(img v1.Image, w io.Writer) error {
 			}
 
 			// check if we have seen value before
-			name := filepath.Join(dirname, basename)
+			// if we're checking a directory, don't filepath.Join names
+			var name string
+			if header.Typeflag == tar.TypeDir {
+				name = header.Name
+			} else {
+				name = filepath.Join(dirname, basename)
+			}
+
 			if _, ok := fileMap[name]; ok {
 				continue
 			}


### PR DESCRIPTION
This was causing entries like `foo/bar/bar` to get ignored when writing the final tarball in `mutate.Extract`. `foo/bar/` (the parent directory) gets written fine, but when we add it to the "seen files" map, we do a `filepath.Join(basename, dirname)`, and for some reason `filepath.Dir("foo/bar/")` is `bar`. So `foo/bar/bar` gets marked as seen and subsequently ignored.

https://play.golang.org/p/EZyvIqtQRaB