### PR TITLE
Add creation time to image build

### DIFF
--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -15,8 +15,12 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -42,6 +46,19 @@ func getBaseImage(s string) (v1.Image, error) {
 		return nil, err
 	}
 	return remote.Image(ref, auth, http.DefaultTransport)
+}
+
+func getCreationTime() (*v1.Time, error) {
+	epoch := os.Getenv("SOURCE_DATE_EPOCH")
+	if epoch == "" {
+		return nil, nil
+	}
+
+	seconds, err := strconv.ParseInt(epoch, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("the environment variable SOURCE_DATE_EPOCH is invalid. It's must be a number of seconds since January 1st 1970, 00:00 UTC, got %v", err)
+	}
+	return &v1.Time{time.Unix(seconds, 0)}, nil
 }
 
 func getMountPaths() []name.Repository {

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -33,7 +33,8 @@ import (
 
 func gobuildOptions() build.Options {
 	return build.Options{
-		GetBase: getBaseImage,
+		GetBase:         getBaseImage,
+		GetCreationTime: getCreationTime,
 	}
 }
 

--- a/v1/mutate/mutate.go
+++ b/v1/mutate/mutate.go
@@ -136,9 +136,38 @@ func Config(base v1.Image, cfg v1.Config) (v1.Image, error) {
 		Image:      base,
 		manifest:   m.DeepCopy(),
 		configFile: cf.DeepCopy(),
-		diffIDMap:  make(map[v1.Hash]v1.Layer),
 		digestMap:  make(map[v1.Hash]v1.Layer),
 	}
+
+	image.manifest.Config.Digest, err = image.ConfigName()
+	if err != nil {
+		return nil, err
+	}
+	return image, nil
+}
+
+// Created mutates the provided v1.Image to have the provided v1.Time
+func CreatedAt(base v1.Image, created v1.Time) (v1.Image, error) {
+	m, err := base.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := base.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := cf.DeepCopy()
+	cfg.Created = created
+
+	image := &image{
+		Image:      base,
+		manifest:   m.DeepCopy(),
+		configFile: cfg,
+		digestMap:  make(map[v1.Hash]v1.Layer),
+	}
+
 	image.manifest.Config.Digest, err = image.ConfigName()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using `ko` I noticed that when building images the creation time was '48 years ago' when running `docker images`:
Eg. 

```
bazel/v1/mutate                                        source_image        6e0b05049ed9        48 years ago        8B
```