### PR TITLE
Add ko publish

### DIFF
--- a/cmd/ko/BUILD.bazel
+++ b/cmd/ko/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "filestuff.go",
         "local.go",
         "main.go",
+        "publish.go",
         "resolve.go",
     ],
     importpath = "github.com/google/go-containerregistry/cmd/ko",

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -83,18 +83,18 @@ roughly 10 seconds (dominated by two `go build`s).
 ~/go/src/github.com/mattmoor/warm-image$ ko apply -f config/
 2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
 2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/controller
-2018/04/25 17:11:29 Publishing us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
 2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
 2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
 2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
-2018/04/25 17:11:30 pushed us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 Published us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
-2018/04/25 17:11:37 Publishing us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/controller:latest
+2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
+2018/04/25 17:11:37 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller:latest
 2018/04/25 17:11:37 mounted sha256:dc0dd55edef1443e976c835825479c3dc713bb689547f8a170f8a0d14f9ff734
 2018/04/25 17:11:37 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
 2018/04/25 17:11:37 mounted sha256:fbc44e14a1d848ed485b5c3f03611c3e21aaa197fcba579255e5f8416a1b7172
-2018/04/25 17:11:38 pushed us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/controller:latest
-2018/04/25 17:11:38 Published us.gcr.io/convoy-adapter/github.com/mattmoor/warm-image/cmd/controller@sha256:78794915fca48d0c4b339dc1df91a72f1e4bc6a7b33beaeef8aecda0947d5d31
+2018/04/25 17:11:38 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller:latest
+2018/04/25 17:11:38 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller@sha256:78794915fca48d0c4b339dc1df91a72f1e4bc6a7b33beaeef8aecda0947d5d31
 clusterrolebinding "warmimage-controller-admin" configured
 deployment "warmimage-controller" unchanged
 namespace "warmimage-system" configured
@@ -104,7 +104,7 @@ customresourcedefinition "warmimages.mattmoor.io" configured
 
 ## Usage
 
-`ko` has three commands that interact with Kubernetes resources.
+`ko` has three commands that interact with Kubernetes resources:
 
 ### `ko resolve`
 
@@ -165,6 +165,24 @@ to whatever `kubectl` context is active.
 `ko delete` simply passes through to `kubectl delete`, as with the `go`
 commands. It is exposed purely out of convenience for cleaning up resources
 created through `ko apply`.
+
+`ko` also has a command that only builds and publishes images:
+
+### `ko publish`
+
+`ko publish` simply builds and publishes images for each import path passed as
+an argument. It prints the images' published digests after each image is published.
+
+```shell
+$ ko publish github.com/mattmoor/warm-image/cmd/sleeper
+2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
+2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
+2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
+2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
+2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
+```
 
 ## Configuration via `.ko.yaml`
 

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -182,8 +182,6 @@ to whatever `kubectl` context is active.
 commands. It is exposed purely out of convenience for cleaning up resources
 created through `ko apply`.
 
-`ko` also has a command that only builds and publishes images:
-
 ## Configuration via `.ko.yaml`
 
 While `ko` aims to have zero configuration, there are certain scenarios where

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -104,7 +104,28 @@ customresourcedefinition "warmimages.mattmoor.io" configured
 
 ## Usage
 
-`ko` has three commands that interact with Kubernetes resources:
+`ko` has four commands:
+
+### `ko publish`
+
+`ko publish` simply builds and publishes images for each import path passed as
+an argument. It prints the images' published digests after each image is published.
+
+```shell
+$ ko publish github.com/mattmoor/warm-image/cmd/sleeper
+2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
+2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
+2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
+2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
+2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
+2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
+```
+
+To determine where to publish the images, `ko` currently requires the
+environment variable `KO_DOCKER_REPO` to be set to an acceptable docker
+repository (e.g. `gcr.io/your-project`). **This will likely change in a
+future version.**
 
 ### `ko resolve`
 
@@ -112,13 +133,8 @@ customresourcedefinition "warmimages.mattmoor.io" configured
 and (based on the [model above](#the-ko-model)) determines the set of
 Go import paths to build, containerize, and publish.
 
-To determine where to publish the images, `ko` currently requires the
-environment variable `KO_DOCKER_REPO` to be set to an acceptable docker
-repository (e.g. `gcr.io/your-project`). **This will likely change in a
-future version.**
-
 The output of `ko resolve` is the concatenated yaml with import paths
-replaced with published image digests.  Following the example above,
+replaced with published image digests. Following the example above,
 this would be:
 
 ```shell
@@ -153,7 +169,7 @@ would sacrifice some amount of identifiability.*
 
 `ko apply` is intended to parallel `kubectl apply`, but acts on the same
 resolved output as `ko resolve` emits. It is expected that `ko apply` will act
-as the vehicle for rapid iteration during development.  As changes are made to a
+as the vehicle for rapid iteration during development. As changes are made to a
 particular application, you can run: `ko apply -f unit.yaml` to rapidly
 rebuild, repush, and redeploy their changes.
 
@@ -168,34 +184,18 @@ created through `ko apply`.
 
 `ko` also has a command that only builds and publishes images:
 
-### `ko publish`
-
-`ko publish` simply builds and publishes images for each import path passed as
-an argument. It prints the images' published digests after each image is published.
-
-```shell
-$ ko publish github.com/mattmoor/warm-image/cmd/sleeper
-2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
-2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
-2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
-2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
-2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
-```
-
 ## Configuration via `.ko.yaml`
 
 While `ko` aims to have zero configuration, there are certain scenarios where
 you will want to override `ko`'s default behavior. This is done via `.ko.yaml`.
 
-`.ko.yaml` is put into the directory from which `ko` will be invoked.  If it
+`.ko.yaml` is put into the directory from which `ko` will be invoked. If it
 is not present, then `ko` will rely on its default behaviors.
 
 ### Overriding the default base image
 
 By default, `ko` makes use of `gcr.io/distroless/base:latest` as the base image
-for containers.  There are a wide array of scenarios in which overriding this
+for containers. There are a wide array of scenarios in which overriding this
 makes sense, for example:
 1. Pinning to a particular digest of this image for repeatable builds,
 1. Replacing this streamlined base image with another with better debugging

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -17,13 +17,9 @@ package main
 import (
 	"bytes"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 
-	"github.com/google/go-containerregistry/ko/build"
-	"github.com/google/go-containerregistry/ko/publish"
-	"github.com/google/go-containerregistry/v1/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -115,28 +111,10 @@ func addKubeCommands(topLevel *cobra.Command) {
 		Use:   "publish importpath",
 		Short: "Build and publish container images from the given importpaths.",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			b, err := build.NewGo(gobuildOptions())
-			if err != nil {
-				log.Fatalf("error creating go builder: %v", err)
-			}
-			for _, importpath := range args {
-				img, err := b.Build(importpath)
-				if err != nil {
-					log.Fatalf("error building %q: %v", importpath, err)
-				}
-				ref, ok := baseImageOverrides[importpath]
-				if !ok {
-					ref = defaultBaseImage
-				}
-				pub := publish.NewDefault(ref.Context(), http.DefaultTransport, remote.WriteOptions{
-					MountPaths: getMountPaths(),
-				})
-				if _, err := pub.Publish(img, importpath); err != nil {
-					log.Fatalf("error publishing %s: %v", importpath, err)
-				}
-			}
+		Run: func(_ *cobra.Command, args []string) {
+			publishImages(args, lo)
 		},
 	}
+	addLocalArg(publish, lo)
 	topLevel.AddCommand(publish)
 }

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -108,7 +108,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 	topLevel.AddCommand(resolve)
 
 	publish := &cobra.Command{
-		Use:   "publish importpath",
+		Use:   "publish IMPORTPATH...",
 		Short: "Build and publish container images from the given importpaths.",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -31,7 +31,7 @@ var (
 	baseImageOverrides map[string]name.Reference
 )
 
-func GetBaseImage(s string) (v1.Image, error) {
+func getBaseImage(s string) (v1.Image, error) {
 	ref, ok := baseImageOverrides[s]
 	if !ok {
 		ref = defaultBaseImage
@@ -40,7 +40,7 @@ func GetBaseImage(s string) (v1.Image, error) {
 	return remote.Image(ref, authn.Anonymous, http.DefaultTransport)
 }
 
-func GetMountPaths() []name.Repository {
+func getMountPaths() []name.Repository {
 	repos := make([]name.Repository, 0, len(baseImageOverrides)+1)
 	repos = append(repos, defaultBaseImage.Context())
 	for _, v := range baseImageOverrides {

--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -25,7 +25,6 @@ func main() {
 	cmds := &cobra.Command{
 		Use:   "ko",
 		Short: "Rapidly iterate with Go, Containers, and Kubernetes.",
-		Long:  "Long Desc", // K8s has a helper here?
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/google/go-containerregistry/ko/build"
+	"github.com/google/go-containerregistry/ko/publish"
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1/daemon"
+	"github.com/google/go-containerregistry/v1/remote"
+)
+
+func publishImages(importpaths []string, lo *LocalOptions) {
+	b, err := build.NewGo(gobuildOptions())
+	if err != nil {
+		log.Fatalf("error creating go builder: %v", err)
+	}
+	for _, importpath := range importpaths {
+		img, err := b.Build(importpath)
+		if err != nil {
+			log.Fatalf("error building %q: %v", importpath, err)
+		}
+		var pub publish.Interface
+		if lo.Local {
+			pub = publish.NewDaemon(daemon.WriteOptions{})
+		} else {
+			repoName := os.Getenv("KO_DOCKER_REPO")
+			repo, err := name.NewRepository(repoName, name.WeakValidation)
+			if err != nil {
+				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
+			}
+			pub = publish.NewDefault(repo, http.DefaultTransport, remote.WriteOptions{
+				MountPaths: getMountPaths(),
+			})
+		}
+		if _, err := pub.Publish(img, importpath); err != nil {
+			log.Fatalf("error publishing %s: %v", importpath, err)
+		}
+	}
+}

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -33,7 +33,7 @@ import (
 
 func gobuildOptions() build.Options {
 	return build.Options{
-		GetBase: GetBaseImage,
+		GetBase: getBaseImage,
 	}
 }
 
@@ -88,7 +88,7 @@ func resolveFile(f string, lo *LocalOptions, opt build.Options) ([]byte, error) 
 		}
 
 		pub = publish.NewDefault(repo, http.DefaultTransport, remote.WriteOptions{
-			MountPaths: GetMountPaths(),
+			MountPaths: getMountPaths(),
 		})
 	}
 

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -77,7 +77,6 @@ func resolveFilesToWriter(fo *FilenameOptions, lo *LocalOptions, out io.Writer) 
 
 func resolveFile(f string, lo *LocalOptions, opt build.Options) ([]byte, error) {
 	var pub publish.Interface
-
 	if lo.Local {
 		pub = publish.NewDaemon(daemon.WriteOptions{})
 	} else {


### PR DESCRIPTION
`ko publish` builds and publishes images for import paths passed as args. See [README](https://github.com/ImJasonH/go-containerregistry/blob/29f77211e26a4d53fa82d956226d889688bee85e/cmd/ko/README.md#ko-publish).

Fixes #147 