### PR TITLE
Use gzip.DefaultCompression by default

### DIFF
--- a/ko/build/gobuild_test.go
+++ b/ko/build/gobuild_test.go
@@ -201,7 +201,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "7f4dbad13dfe30c580152f62973627701b72d62654b7c0c62249891f82b80a59",
+			Hex:       "118e77d59f3b68ad30e76ed9a4e1af9842ede1396f15daca2d7c249402d32acd",
 		}
 		appLayer := ls[baseLayers]
 

--- a/v1/tarball/layer_test.go
+++ b/v1/tarball/layer_test.go
@@ -193,7 +193,7 @@ func assertSizesAreEqual(t *testing.T, a, b v1.Layer) {
 // Compression settings matter in order for the digest, size,
 // compressed assertions to pass
 //
-// Since our v1util.GzipReadCloser uses gzip.BestCompression
+// Since our v1util.GzipReadCloser uses gzip.DefaultCompression
 // we need our fixture to use the same - bazel's pkg_tar doesn't
 // seem to let you control compression settings
 func setupFixtures(t *testing.T) {
@@ -213,7 +213,7 @@ func setupFixtures(t *testing.T) {
 
 	defer out.Close()
 
-	gw, _ := gzip.NewWriterLevel(out, gzip.BestCompression)
+	gw, _ := gzip.NewWriterLevel(out, gzip.DefaultCompression)
 	defer gw.Close()
 
 	_, err = io.Copy(gw, in)

--- a/v1/v1util/zip.go
+++ b/v1/v1util/zip.go
@@ -24,14 +24,23 @@ var gzipMagicHeader = []byte{'\x1f', '\x8b'}
 
 // GzipReadCloser reads uncompressed input data from the io.ReadCloser and
 // returns an io.ReadCloser from which compressed data may be read.
+// This uses gzip.DefaultCompression for the compression level.
 func GzipReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
+	return GzipReadCloserLevel(r, gzip.DefaultCompression)
+}
+
+// GzipReadCloserLevel reads uncompressed input data from the io.ReadCloser and
+// returns an io.ReadCloser from which compressed data may be read.
+// Refer to compress/gzip for the level:
+// https://golang.org/pkg/compress/gzip/#pkg-constants
+func GzipReadCloserLevel(r io.ReadCloser, level int) (io.ReadCloser, error) {
 	pr, pw := io.Pipe()
 
 	go func() {
 		defer pw.Close()
 		defer r.Close()
 
-		gw, _ := gzip.NewWriterLevel(pw, gzip.BestCompression)
+		gw, _ := gzip.NewWriterLevel(pw, level)
 		defer gw.Close()
 
 		_, err := io.Copy(gw, r)


### PR DESCRIPTION
Fixes #150.

gzip.BestCompression is very slow.

On my machine, for `gcr.io/google-appengine/python:latest`, computing
the digest of each layer took...
```
NoCompression        13.0 s
HuffmanOnly          23.0 s
BestSpeed            27.0 s
DefaultCompression   54.0 s
BestCompression     246.5 s
```

I think DefaultCompression is probably a reasonable default, but this
also adds GzipReadCloserLevel that lets callers determine the compression
level. We'll need to plumb that through all the v1/partial stuff.