### PR TITLE
Expose compression level when creating image

### DIFF
--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -37,7 +37,7 @@ func GetBaseImage(s string) (v1.Image, error) {
 		ref = defaultBaseImage
 	}
 	log.Printf("Using base %s for %s", ref, s)
-	return remote.Image(ref, authn.Anonymous, http.DefaultTransport)
+	return remote.Image(ref, authn.Anonymous, http.DefaultTransport, nil)
 }
 
 func GetMountPaths() []name.Repository {

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -53,7 +53,7 @@ func doAppend(src, dst, tar, output string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -48,7 +48,7 @@ func doCopy(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -33,7 +33,7 @@ func getImage(r string) (v1.Image, name.Reference, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting creds for %q: %v", ref, err)
 	}
-	img, err := remote.Image(ref, auth, http.DefaultTransport)
+	img, err := remote.Image(ref, auth, http.DefaultTransport, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading image %q: %v", ref, err)
 	}

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -49,7 +49,7 @@ func pull(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", t, err)
 	}
 
-	i, err := remote.Image(t, auth, http.DefaultTransport)
+	i, err := remote.Image(t, auth, http.DefaultTransport, nil)
 	if err != nil {
 		log.Fatalf("reading image %q: %v", t, err)
 	}

--- a/v1/daemon/image_test.go
+++ b/v1/daemon/image_test.go
@@ -15,6 +15,7 @@
 package daemon
 
 import (
+	"compress/gzip"
 	"context"
 	"io"
 	"os"
@@ -22,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/name"
-
 	"github.com/google/go-containerregistry/v1/tarball"
 )
 
@@ -54,7 +54,7 @@ func TestImage(t *testing.T) {
 	}
 
 	runTest := func(buffered bool) {
-		daemonImage, err := Image(tag, &ReadOptions{Buffer: buffered})
+		daemonImage, err := Image(tag, NewReadOptions(buffered, gzip.DefaultCompression))
 		if err != nil {
 			t.Errorf("Error loading daemon image: %s", err)
 		}
@@ -74,5 +74,4 @@ func TestImage(t *testing.T) {
 
 	runTest(false)
 	runTest(true)
-
 }

--- a/v1/partial/image.go
+++ b/v1/partial/image.go
@@ -25,4 +25,6 @@ type imageCore interface {
 
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
+
+	CompressionLevel() int
 }

--- a/v1/partial/with.go
+++ b/v1/partial/with.go
@@ -268,7 +268,6 @@ func DiffIDToBlob(wm WithManifestAndConfigFile, h v1.Hash) (v1.Hash, error) {
 		}
 	}
 	return v1.Hash{}, fmt.Errorf("unknown diffID %v", h)
-
 }
 
 // WithBlob defines the subset of v1.Image used by these helper methods

--- a/v1/random/image.go
+++ b/v1/random/image.go
@@ -17,6 +17,7 @@ package random
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"crypto/rand"
 	"fmt"
 	"io"
@@ -116,6 +117,10 @@ func (i *image) ConfigFile() (*v1.ConfigFile, error) {
 // MediaType implements partial.UncompressedImageCore
 func (i *image) MediaType() (types.MediaType, error) {
 	return types.DockerManifestSchema2, nil
+}
+
+func (i *image) CompressionLevel() int {
+	return gzip.DefaultCompression
 }
 
 // LayerByDiffID implements partial.UncompressedImageCore

--- a/v1/remote/image_test.go
+++ b/v1/remote/image_test.go
@@ -328,7 +328,7 @@ func TestImage(t *testing.T) {
 	}
 
 	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
-	rmt, err := Image(tag, authn.Anonymous, http.DefaultTransport)
+	rmt, err := Image(tag, authn.Anonymous, http.DefaultTransport, nil)
 	if err != nil {
 		t.Errorf("Image() = %v", err)
 	}

--- a/v1/tarball/layer.go
+++ b/v1/tarball/layer.go
@@ -25,11 +25,12 @@ import (
 )
 
 type layer struct {
-	digest     v1.Hash
-	diffID     v1.Hash
-	size       int64
-	opener     Opener
-	compressed bool
+	digest      v1.Hash
+	diffID      v1.Hash
+	size        int64
+	opener      Opener
+	compressed  bool
+	compression int
 }
 
 func (l *layer) Digest() (v1.Hash, error) {
@@ -43,7 +44,7 @@ func (l *layer) DiffID() (v1.Hash, error) {
 func (l *layer) Compressed() (io.ReadCloser, error) {
 	rc, err := l.opener()
 	if err == nil && !l.compressed {
-		return v1util.GzipReadCloser(rc)
+		return v1util.GzipReadCloserLevel(rc, l.compression)
 	}
 
 	return rc, err
@@ -95,11 +96,12 @@ func LayerFromOpener(opener Opener) (v1.Layer, error) {
 	}
 
 	return &layer{
-		digest:     digest,
-		diffID:     diffID,
-		size:       size,
-		compressed: compressed,
-		opener:     opener,
+		digest:      digest,
+		diffID:      diffID,
+		size:        size,
+		compressed:  compressed,
+		opener:      opener,
+		compression: gzip.DefaultCompression,
 	}, nil
 }
 

--- a/v1/tarball/layer_test.go
+++ b/v1/tarball/layer_test.go
@@ -140,7 +140,7 @@ func assertCompressedStreamsAreEqual(t *testing.T, a, b v1.Layer) {
 	}
 
 	if diff := cmp.Diff(saBytes, sbBytes); diff != "" {
-		t.Fatalf("Compressed streams were different: %v", diff)
+		t.Fatal("Compressed streams were different")
 	}
 }
 


### PR DESCRIPTION
This allows users to set the desired compression level when creating images. This changes the signature of `remote.Image` and `daemon.Image` to require `readOptions` which contain the compression level. `nil` can be passed, in which case default values will be used.

cc #150 and #153 