### PR TITLE
Switch from DefaultCompression to BestSpeed

### DIFF
--- a/ko/build/gobuild_test.go
+++ b/ko/build/gobuild_test.go
@@ -201,7 +201,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "118e77d59f3b68ad30e76ed9a4e1af9842ede1396f15daca2d7c249402d32acd",
+			Hex:       "dedc4f5dcc2afa66050a750529e3e1455c30bbbb983c886e7535376242f05b64",
 		}
 		appLayer := ls[baseLayers]
 

--- a/v1/tarball/layer_test.go
+++ b/v1/tarball/layer_test.go
@@ -193,7 +193,7 @@ func assertSizesAreEqual(t *testing.T, a, b v1.Layer) {
 // Compression settings matter in order for the digest, size,
 // compressed assertions to pass
 //
-// Since our v1util.GzipReadCloser uses gzip.DefaultCompression
+// Since our v1util.GzipReadCloser uses gzip.BestSpeed
 // we need our fixture to use the same - bazel's pkg_tar doesn't
 // seem to let you control compression settings
 func setupFixtures(t *testing.T) {
@@ -213,7 +213,7 @@ func setupFixtures(t *testing.T) {
 
 	defer out.Close()
 
-	gw, _ := gzip.NewWriterLevel(out, gzip.DefaultCompression)
+	gw, _ := gzip.NewWriterLevel(out, gzip.BestSpeed)
 	defer gw.Close()
 
 	_, err = io.Copy(gw, in)

--- a/v1/v1util/zip.go
+++ b/v1/v1util/zip.go
@@ -24,9 +24,9 @@ var gzipMagicHeader = []byte{'\x1f', '\x8b'}
 
 // GzipReadCloser reads uncompressed input data from the io.ReadCloser and
 // returns an io.ReadCloser from which compressed data may be read.
-// This uses gzip.DefaultCompression for the compression level.
+// This uses gzip.BestSpeed for the compression level.
 func GzipReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
-	return GzipReadCloserLevel(r, gzip.DefaultCompression)
+	return GzipReadCloserLevel(r, gzip.BestSpeed)
 }
 
 // GzipReadCloserLevel reads uncompressed input data from the io.ReadCloser and


### PR DESCRIPTION
Disk is cheap and we (generally) have fast networks, but I haven't
figured out how to get more time. This shaves ~1s off my `ko` builds.