### PR TITLE
Caching for remote.Image

### DIFF
--- a/cmd/crane/main.go
+++ b/cmd/crane/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
@@ -29,6 +30,8 @@ var cmds = &cobra.Command{
 }
 
 func main() {
+	cmds.Flags().StringVarP(&crane.CacheDir, "cache", "c", path.Join(os.Getenv("HOME"), ".crane-cache"), "Path to directory where blobs should be cached")
+
 	cmds.AddCommand(crane.NewCmdAppend())
 	cmds.AddCommand(crane.NewCmdConfig())
 	cmds.AddCommand(crane.NewCmdCopy())

--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -45,7 +45,7 @@ func getBaseImage(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return remote.Image(ref, auth, http.DefaultTransport)
+	return remote.Image(ref, auth, http.DefaultTransport, nil)
 }
 
 func getCreationTime() (*v1.Time, error) {

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -53,7 +53,7 @@ func doAppend(src, dst, tar, output string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -53,7 +53,7 @@ func doAppend(src, dst, tar, output string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
+	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, &remote.ImageOptions{Cache: cache()})
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -48,7 +48,7 @@ func doCopy(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
+	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, &remote.ImageOptions{Cache: cache()})
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -48,7 +48,7 @@ func doCopy(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", srcRef, err)
 	}
 
-	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport, nil)
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -24,6 +24,16 @@ import (
 	"github.com/google/go-containerregistry/v1/remote"
 )
 
+// If set, directory where blobs should be cached.
+var CacheDir string
+
+func cache() remote.Cache {
+	if CacheDir == "" {
+		return nil
+	}
+	return remote.NewDiskCache(CacheDir)
+}
+
 func getImage(r string) (v1.Image, name.Reference, error) {
 	ref, err := name.ParseReference(r, name.WeakValidation)
 	if err != nil {
@@ -33,7 +43,7 @@ func getImage(r string) (v1.Image, name.Reference, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting creds for %q: %v", ref, err)
 	}
-	img, err := remote.Image(ref, auth, http.DefaultTransport, nil)
+	img, err := remote.Image(ref, auth, http.DefaultTransport, &remote.ImageOptions{Cache: cache()})
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading image %q: %v", ref, err)
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -33,7 +33,7 @@ func getImage(r string) (v1.Image, name.Reference, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting creds for %q: %v", ref, err)
 	}
-	img, err := remote.Image(ref, auth, http.DefaultTransport)
+	img, err := remote.Image(ref, auth, http.DefaultTransport, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading image %q: %v", ref, err)
 	}

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -17,8 +17,6 @@ package crane
 import (
 	"log"
 	"net/http"
-	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 
@@ -51,9 +49,7 @@ func pull(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", t, err)
 	}
 
-	i, err := remote.Image(t, auth, http.DefaultTransport, &remote.ImageOptions{
-		Cache: remote.NewDiskCache(path.Join(os.Getenv("HOME"), ".crane-cache")),
-	})
+	i, err := remote.Image(t, auth, http.DefaultTransport, &remote.ImageOptions{Cache: cache()})
 	if err != nil {
 		log.Fatalf("reading image %q: %v", t, err)
 	}

--- a/v1/remote/BUILD.bazel
+++ b/v1/remote/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cache.go",
         "delete.go",
         "doc.go",
         "error.go",
@@ -26,6 +27,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cache_test.go",
         "delete_test.go",
         "error_test.go",
         "image_test.go",

--- a/v1/remote/cache.go
+++ b/v1/remote/cache.go
@@ -61,6 +61,10 @@ func (c diskCache) Load(h v1.Hash) (io.ReadCloser, error) {
 }
 
 func (c diskCache) Store(h v1.Hash, rc io.Reader) error {
+	if err := os.MkdirAll(c.tmpdir, 0777); err != nil {
+		return err
+	}
+
 	f, err := os.Create(path.Join(c.tmpdir, sanitizeHash(h)))
 	if err != nil {
 		return err

--- a/v1/remote/cache.go
+++ b/v1/remote/cache.go
@@ -38,10 +38,10 @@ type Cache interface {
 }
 
 // NewDiskCache returns a Cache backed by a directory on disk, rooted under the
-// specified temp dir.
-func NewDiskCache(tmpdir string) Cache { return diskCache{tmpdir} }
+// specified directory.
+func NewDiskCache(dir string) Cache { return diskCache{dir} }
 
-type diskCache struct{ tmpdir string }
+type diskCache struct{ dir string }
 
 var _ Cache = (*diskCache)(nil)
 
@@ -50,7 +50,7 @@ func sanitizeHash(h v1.Hash) string {
 }
 
 func (c diskCache) Load(h v1.Hash) (io.ReadCloser, error) {
-	f, err := os.Open(path.Join(c.tmpdir, sanitizeHash(h)))
+	f, err := os.Open(path.Join(c.dir, sanitizeHash(h)))
 	if os.IsNotExist(err) {
 		return nil, ErrCacheMiss
 	} else if err != nil {
@@ -61,11 +61,11 @@ func (c diskCache) Load(h v1.Hash) (io.ReadCloser, error) {
 }
 
 func (c diskCache) Store(h v1.Hash, rc io.Reader) error {
-	if err := os.MkdirAll(c.tmpdir, 0777); err != nil {
+	if err := os.MkdirAll(c.dir, 0700); err != nil {
 		return err
 	}
 
-	f, err := os.Create(path.Join(c.tmpdir, sanitizeHash(h)))
+	f, err := os.Create(path.Join(c.dir, sanitizeHash(h)))
 	if err != nil {
 		return err
 	}

--- a/v1/remote/cache.go
+++ b/v1/remote/cache.go
@@ -1,0 +1,107 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/google/go-containerregistry/v1"
+)
+
+// ErrCacheMiss is the error returned by implementations of Cache.Load when the
+// blob was not found in the cache.
+var ErrCacheMiss = errors.New("blob not found in cache")
+
+// Cache abstracts loading and storing blob data in a cache.
+type Cache interface {
+	Load(v1.Hash) (io.ReadCloser, error)
+	Store(v1.Hash, io.Reader) error
+}
+
+// NewDiskCache returns a Cache backed by a directory on disk, rooted under the
+// specified temp dir.
+func NewDiskCache(tmpdir string) Cache { return diskCache{tmpdir} }
+
+type diskCache struct{ tmpdir string }
+
+var _ Cache = (*diskCache)(nil)
+
+func sanitizeHash(h v1.Hash) string {
+	return strings.Replace(h.String(), ":", "_", -1)
+}
+
+func (c diskCache) Load(h v1.Hash) (io.ReadCloser, error) {
+	f, err := os.Open(path.Join(c.tmpdir, sanitizeHash(h)))
+	if os.IsNotExist(err) {
+		return nil, ErrCacheMiss
+	} else if err != nil {
+		return nil, err
+	}
+	log.Println("reading from cache", h)
+	return f, nil
+}
+
+func (c diskCache) Store(h v1.Hash, rc io.Reader) error {
+	f, err := os.Create(path.Join(c.tmpdir, sanitizeHash(h)))
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, rc)
+	log.Println("wrote to cache", h)
+	return err
+}
+
+// NewMemCache returns a Cache backed by data in memory.
+func NewMemCache() Cache { return &memcache{map[v1.Hash][]byte{}} }
+
+type memcache struct{ m map[v1.Hash][]byte }
+
+var _ Cache = (*memcache)(nil)
+
+func (m *memcache) Store(h v1.Hash, r io.Reader) error {
+	all, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.m[h] = all
+	return nil
+}
+
+func (m *memcache) Load(h v1.Hash) (io.ReadCloser, error) {
+	b, ok := m.m[h]
+	if !ok {
+		return nil, ErrCacheMiss
+	}
+	return ioutil.NopCloser(bytes.NewReader(b)), nil
+}
+
+// ReadOnly returns a Cache that only reads from the underlying cache and never
+// stores any new data.
+//
+// It can be useful in situations where the backing store does not accept
+// writes, such as a read-only persistent disk containing a cache of blobs
+// populated by some other process.
+func ReadOnly(c Cache) Cache { return readonly{c} }
+
+type readonly struct{ Cache }
+
+func (readonly) Store(v1.Hash, io.Reader) error { return nil }

--- a/v1/remote/cache_test.go
+++ b/v1/remote/cache_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/google/go-containerregistry/v1"
+)
+
+func TestReadOnlyCache(t *testing.T) {
+	fs := failStore{}
+	ro := ReadOnly(fs)
+	h := mustDigest(t, randomImage(t))
+	r := bytes.NewReader(nil)
+
+	if _, err := fs.Load(h); err != nil {
+		t.Error("Underlying Load: %v", err)
+	}
+	if err := fs.Store(h, r); err == nil {
+		t.Error("Underlying Store, want err, got none")
+	}
+
+	if _, err := ro.Load(h); err != nil {
+		t.Error("Readonly.Load: %v", err)
+	}
+	if err := ro.Store(h, r); err != nil {
+		t.Errorf("ReadOnly.Store: %v", err)
+	}
+
+}
+
+type failStore struct{}
+
+func (failStore) Load(v1.Hash) (io.ReadCloser, error) { return nil, nil }
+func (failStore) Store(v1.Hash, io.Reader) error      { return errors.New("cannot store") }

--- a/v1/remote/cache_test.go
+++ b/v1/remote/cache_test.go
@@ -42,7 +42,6 @@ func TestReadOnlyCache(t *testing.T) {
 	if err := ro.Store(h, r); err != nil {
 		t.Errorf("ReadOnly.Store: %v", err)
 	}
-
 }
 
 type failStore struct{}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -108,7 +108,7 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		return r.manifest, err
 	}
 
-	// Initialize the HTTP transport, if this is the first time its needed.
+	// Initialize the HTTP transport, if this is the first time it's needed.
 	var initErr error
 	r.initOnce.Do(func() {
 		scopes := []string{r.ref.Scope(transport.PullScope)}
@@ -165,8 +165,7 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		}
 	}
 
-	// If a cache implementation is provided, attempt to store the blob in
-	// the cache.
+	// If a cache implementation is provided, attempt to cache the blob.
 	if r.cache != nil {
 		if err := r.cache.Store(digest, ioutil.NopCloser(bytes.NewReader(manifest))); err != nil {
 			return nil, err
@@ -238,10 +237,12 @@ func (rl *remoteLayer) Compressed() (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	// If a cache implementation is provided, attempt to store the blob in
-	// the cache.
+	// If a cache implementation is provided, attempt to cache the blob.
 	if rl.ri.cache != nil {
 		defer resp.Body.Close()
+		// TODO(jasonhall): Don't do this. Instead, tee the body into
+		// the cache and into the verifying read closer passed to the
+		// caller.
 		if err := rl.ri.cache.Store(rl.digest, resp.Body); err != nil {
 			return nil, err
 		}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -16,7 +16,6 @@ package remote
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -60,15 +59,6 @@ func (o *ImageOptions) cache() Cache {
 		return nil
 	}
 	return o.Cache
-}
-
-// ErrCacheMiss is the error returned by implementations of Cache.Load when the
-// blob was not found in the cache.
-var ErrCacheMiss = errors.New("blob not found in cache")
-
-type Cache interface {
-	Load(v1.Hash) (io.ReadCloser, error)
-	Store(v1.Hash, io.Reader) error
 }
 
 // Image accesses a given image reference over the provided transport, with the provided authentication.

--- a/v1/remote/image_test.go
+++ b/v1/remote/image_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -367,31 +366,8 @@ func TestImage(t *testing.T) {
 	}
 }
 
-type memcache struct{ m map[v1.Hash][]byte }
-
-func newMemcache() *memcache { return &memcache{map[v1.Hash][]byte{}} }
-
-var _ Cache = (*memcache)(nil)
-
-func (m *memcache) Store(h v1.Hash, r io.Reader) error {
-	all, err := ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	m.m[h] = all
-	return nil
-}
-
-func (m *memcache) Load(h v1.Hash) (io.ReadCloser, error) {
-	b, ok := m.m[h]
-	if !ok {
-		return nil, ErrCacheMiss
-	}
-	return ioutil.NopCloser(bytes.NewReader(b)), nil
-}
-
 func TestCache(t *testing.T) {
-	c := newMemcache()
+	c := NewMemCache().(*memcache)
 
 	// First, populate the cache.
 	img := randomImage(t)


### PR DESCRIPTION
Fixes #163 

This change adds a `Cache` interface in `v1/remote` that, if provided, caches blobs and loads from that cache on subsequent fetches. It also adds three simple implementations:

* `NewDiskCache` returns a cache backed by blobs stored on disk, in the specified directory.
* `NewMemCache` returns a cache backed by blobs stored in memory.
* `ReadOnly(cache)` returns a cache backed by the given `Cache` implementation, and overrides `Store` to be a no-op -- this can be used in situations where the cache is populated by another process and is provided as read-only in the executing environment.

### Benchmarks

First run of `crane pull ubuntu ubuntu.tar.gz`
```
2018/05/23 21:43:09 Pulling index.docker.io/library/ubuntu:latest
2018/05/23 21:43:10 wrote to cache sha256:90f24abe180424046a5d53f6fc6f9fdb8f79b835cb2fd7d1a782e4c30dfb5dcc
2018/05/23 21:43:10 wrote to cache sha256:452a96d81c30a1e426bc250428263ac9ca3f47c9bf086f876d11cb39cf57aeec
2018/05/23 21:43:11 wrote to cache sha256:a48c500ed24e62926cb079df35f964c57d8bb08159b1d29c6a3b0a58dc365dc1
2018/05/23 21:43:11 wrote to cache sha256:1e1de00ff7e1fea0858b6a4b5ca208eeca970607ea9a6eb5fc972494e7a0cdde
2018/05/23 21:43:12 wrote to cache sha256:0330ca45a200e1fcef05ae97f434366d262a1c50b3dc053e7928b58dd37211dd
2018/05/23 21:43:12 wrote to cache sha256:471db38bcfbf0f5bac78012b9d458dfd37309d5cbb99d4e95310321a60a0cfdf
2018/05/23 21:43:12 wrote to cache sha256:0b4aba487617ca27519745ae722b8ea1917474c495b91b3c4887728a3f2ee7db

real	0m3.533s
user	0m1.613s
sys	0m0.621s
```

Subsequent run with cache hits
```
2018/05/23 21:43:15 Pulling index.docker.io/library/ubuntu:latest
2018/05/23 21:43:16 wrote to cache sha256:90f24abe180424046a5d53f6fc6f9fdb8f79b835cb2fd7d1a782e4c30dfb5dcc
2018/05/23 21:43:16 reading from cache sha256:452a96d81c30a1e426bc250428263ac9ca3f47c9bf086f876d11cb39cf57aeec
2018/05/23 21:43:16 reading from cache sha256:a48c500ed24e62926cb079df35f964c57d8bb08159b1d29c6a3b0a58dc365dc1
2018/05/23 21:43:16 reading from cache sha256:1e1de00ff7e1fea0858b6a4b5ca208eeca970607ea9a6eb5fc972494e7a0cdde
2018/05/23 21:43:16 reading from cache sha256:0330ca45a200e1fcef05ae97f434366d262a1c50b3dc053e7928b58dd37211dd
2018/05/23 21:43:16 reading from cache sha256:471db38bcfbf0f5bac78012b9d458dfd37309d5cbb99d4e95310321a60a0cfdf
2018/05/23 21:43:16 reading from cache sha256:0b4aba487617ca27519745ae722b8ea1917474c495b91b3c4887728a3f2ee7db

real	0m1.708s
user	0m1.339s
sys	0m0.474s
```

After manually deleting some cached files:

```
2018/05/23 21:46:21 Pulling index.docker.io/library/ubuntu:latest
2018/05/23 21:46:22 wrote to cache sha256:90f24abe180424046a5d53f6fc6f9fdb8f79b835cb2fd7d1a782e4c30dfb5dcc
2018/05/23 21:46:22 reading from cache sha256:452a96d81c30a1e426bc250428263ac9ca3f47c9bf086f876d11cb39cf57aeec
2018/05/23 21:46:22 reading from cache sha256:a48c500ed24e62926cb079df35f964c57d8bb08159b1d29c6a3b0a58dc365dc1
2018/05/23 21:46:22 wrote to cache sha256:1e1de00ff7e1fea0858b6a4b5ca208eeca970607ea9a6eb5fc972494e7a0cdde
2018/05/23 21:46:22 wrote to cache sha256:0330ca45a200e1fcef05ae97f434366d262a1c50b3dc053e7928b58dd37211dd
2018/05/23 21:46:22 reading from cache sha256:471db38bcfbf0f5bac78012b9d458dfd37309d5cbb99d4e95310321a60a0cfdf
2018/05/23 21:46:22 wrote to cache sha256:0b4aba487617ca27519745ae722b8ea1917474c495b91b3c4887728a3f2ee7db

real	0m2.037s
user	0m1.405s
sys	0m0.475s
```