### PR TITLE
Functional Options

### DIFF
--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -41,11 +40,7 @@ func getBaseImage(s string) (v1.Image, error) {
 		ref = defaultBaseImage
 	}
 	log.Printf("Using base %s for %s", ref, s)
-	auth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
-	if err != nil {
-		return nil, err
-	}
-	return remote.Image(ref, auth, http.DefaultTransport)
+	return remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 }
 
 func getCreationTime() (*v1.Time, error) {

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -55,13 +55,7 @@ func doAppend(src, dst, tar, output string) {
 	if err != nil {
 		log.Fatalf("parsing reference %q: %v", src, err)
 	}
-
-	srcAuth, err := authn.DefaultKeychain.Resolve(srcRef.Context().Registry)
-	if err != nil {
-		log.Fatalf("getting creds for %q: %v", srcRef, err)
-	}
-
-	srcImage, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	srcImage, err := remote.Image(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -45,12 +45,7 @@ func doCopy(_ *cobra.Command, args []string) {
 	}
 	log.Printf("Pulling %v", srcRef)
 
-	srcAuth, err := authn.DefaultKeychain.Resolve(srcRef.Context().Registry)
-	if err != nil {
-		log.Fatalf("getting creds for %q: %v", srcRef, err)
-	}
-
-	img, err := remote.Image(srcRef, srcAuth, http.DefaultTransport)
+	img, err := remote.Image(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		log.Fatalf("reading image %q: %v", srcRef, err)
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -16,7 +16,6 @@ package crane
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,11 +28,7 @@ func getImage(r string) (v1.Image, name.Reference, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing reference %q: %v", r, err)
 	}
-	auth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting creds for %q: %v", ref, err)
-	}
-	img, err := remote.Image(ref, auth, http.DefaultTransport)
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading image %q: %v", ref, err)
 	}

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -16,7 +16,6 @@ package crane
 
 import (
 	"log"
-	"net/http"
 
 	"github.com/spf13/cobra"
 
@@ -46,12 +45,7 @@ func pull(_ *cobra.Command, args []string) {
 	}
 	log.Printf("Pulling %v", t)
 
-	auth, err := authn.DefaultKeychain.Resolve(t.Registry)
-	if err != nil {
-		log.Fatalf("getting creds for %q: %v", t, err)
-	}
-
-	i, err := remote.Image(t, auth, http.DefaultTransport)
+	i, err := remote.Image(t, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		log.Fatalf("reading image %q: %v", t, err)
 	}

--- a/pkg/v1/daemon/BUILD.bazel
+++ b/pkg/v1/daemon/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "doc.go",
         "image.go",
+        "options.go",
         "write.go",
     ],
     data = [

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -54,7 +54,13 @@ func TestImage(t *testing.T) {
 	}
 
 	runTest := func(buffered bool) {
-		daemonImage, err := Image(tag, &ReadOptions{Buffer: buffered})
+		var bufferedOption ImageOption
+		if buffered {
+			bufferedOption = WithBufferedOpener()
+		} else {
+			bufferedOption = WithUnbufferedOpener()
+		}
+		daemonImage, err := Image(tag, bufferedOption)
 		if err != nil {
 			t.Errorf("Error loading daemon image: %s", err)
 		}

--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+func WithBufferedOpener() ImageOption {
+	return func(i *imageOpener) error {
+		return i.setBuffered(true)
+	}
+}
+
+func WithUnbufferedOpener() ImageOption {
+	return func(i *imageOpener) error {
+		return i.setBuffered(false)
+	}
+}
+
+func (i *imageOpener) setBuffered(buffer bool) error {
+	i.buffered = buffer
+	return nil
+}

--- a/pkg/v1/remote/BUILD.bazel
+++ b/pkg/v1/remote/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "image.go",
         "list.go",
         "mount.go",
+        "options.go",
         "write.go",
     ],
     importpath = "github.com/google/go-containerregistry/pkg/v1/remote",

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -42,28 +42,53 @@ type remoteImage struct {
 	config       []byte
 }
 
+type ImageOption func(*imageOpener) error
+
 var _ partial.CompressedImageCore = (*remoteImage)(nil)
 
-// Image accesses a given image reference over the provided transport, with the provided authentication.
-func Image(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) (v1.Image, error) {
-	scopes := []string{ref.Scope(transport.PullScope)}
-	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
+type imageOpener struct {
+	auth      authn.Authenticator
+	transport http.RoundTripper
+	ref       name.Reference
+	client    *http.Client
+}
+
+func (i *imageOpener) Open() (v1.Image, error) {
+	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
 	if err != nil {
 		return nil, err
 	}
-	img, err := partial.CompressedToImage(&remoteImage{
-		ref:    ref,
+	ri := &remoteImage{
+		ref:    i.ref,
 		client: &http.Client{Transport: tr},
-	})
+	}
+	imgCore, err := partial.CompressedToImage(ri)
 	if err != nil {
-		return nil, err
+		return imgCore, err
 	}
 	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
 	// remote.Write calls to facilitate cross-repo "mounting".
 	return &mountableImage{
-		Image:     img,
-		Reference: ref,
+		Image:     imgCore,
+		Reference: i.ref,
 	}, nil
+}
+
+// Image provides access to a remote image reference, applying functional options
+// to the underlying imageOpener before resolving the reference into a v1.Image.
+func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
+	img := &imageOpener{
+		auth:      authn.Anonymous,
+		transport: http.DefaultTransport,
+		ref:       ref,
+	}
+
+	for _, option := range options {
+		if err := option(img); err != nil {
+			return nil, err
+		}
+	}
+	return img.Open()
 }
 
 func (r *remoteImage) url(resource, identifier string) url.URL {

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -328,7 +327,7 @@ func TestImage(t *testing.T) {
 	}
 
 	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
-	rmt, err := Image(tag, authn.Anonymous, http.DefaultTransport)
+	rmt, err := Image(tag, WithTransport(http.DefaultTransport))
 	if err != nil {
 		t.Errorf("Image() = %v", err)
 	}

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// WithTransport is a functional option for overriding the default transport
+// on a remote image
+func WithTransport(t http.RoundTripper) ImageOption {
+	return func(i *imageOpener) error {
+		return i.setTransport(t)
+	}
+}
+
+// WithAuth is a functional option for overriding the default authenticator
+// on a remote image
+func WithAuth(auth authn.Authenticator) ImageOption {
+	return func(i *imageOpener) error {
+		return i.setAuth(auth)
+	}
+}
+
+// WithAuthFromKeychain is a functional option for overriding the default
+// authenticator on a remote image using an authn.Keychain
+func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
+	return func(i *imageOpener) error {
+		auth, err := keys.Resolve(i.ref.Context().Registry)
+		if err != nil {
+			return err
+		}
+		return i.setAuth(auth)
+	}
+}
+
+// Set client on image using provided transport, and the default authenticator
+func (i *imageOpener) setTransport(t http.RoundTripper) error {
+	i.transport = t
+	return nil
+}
+
+// Set client on image using provided authenticator, and the default transport
+func (i *imageOpener) setAuth(auth authn.Authenticator) error {
+	i.auth = auth
+	return nil
+}


### PR DESCRIPTION
Opening this PR now to get some design feedback. This refactors the interfaces to add support for functional options for all `Image` calls. Each package defines its set of legal functional options in its `options.go` file as `With...()` methods, e.g. `remote.WithTransport()`.

~To allow applying configuration to the `v1.Image` after it's created, I created a `MutableImage` which essentially serves as a concrete wrapper around the `v1.Image` and allows methods to be defined on it.~

Instead of the `MutableImage` (not great design since it makes making sync mistakes easy), I adopted @mattmoor's idea of an `ImageOpener`, which gives us an easy way of applying functional options before returning an immutable image. 