### PR TITLE
Add newline to `crane digest` output

### DIFF
--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -40,5 +40,5 @@ func digest(_ *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Print(digest.String())
+	fmt.Println(digest.String())
 }


### PR DESCRIPTION
As (probably) the only user of this command, I find that I want a
newline more often than I don't want a newline.