### PR TITLE
Document ko + minikube

### DIFF
--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -115,7 +115,8 @@ their execution.  By default, `ko` publishes images to a Docker Registry
 specified via `KO_DOCKER_REPO`.
 
 However, these same commands can be directed to operate locally as well via
-the `--local` or `-L` command.  See the `minikube` section for more detail.
+the `--local` or `-L` command.  See the [`minikube` section](
+./README.md#with-minikube) for more detail.
 
 
 ### `ko publish`


### PR DESCRIPTION
This adds docs covering how to use `ko` with `minikube` via `-L`.

