### PR TITLE
Build a crane builder image, using ko

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,3 +14,7 @@ steps:
 # Use the crane builder to retag the crane builder.
 - name: gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane
   args: ['copy', 'gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane', 'gcr.io/$PROJECT_ID/crane']
+
+# Use the crane builder to get the crane builder's digest.
+- name: gcr.io/$PROJECT_ID/crane
+  args: ['digest', 'gcr.io/$PROJECT_ID/crane']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+# Build the ko binary.
+- name: gcr.io/cloud-builders/go:debian
+  env: ['PROJECT_ROOT=github.com/google/go-containerregistry']
+  args: ['install', 'github.com/google/go-containerregistry/cmd/ko']
+
+# Use the ko binary to build the crane builder image.
+- name: gcr.io/cloud-builders/go:debian
+  env: ['GOPATH=/workspace/gopath', 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID']
+  entrypoint: /workspace/gopath/bin/ko
+  dir: gopath/src
+  args: ['publish', 'github.com/google/go-containerregistry/cmd/crane']
+
+# Use the crane builder to retag the crane builder.
+- name: gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane
+  args: ['copy', 'gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane', 'gcr.io/$PROJECT_ID/crane']

--- a/cmd/crane/BUILD.bazel
+++ b/cmd/crane/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -19,9 +18,4 @@ go_binary(
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
-)
-
-go_image(
-    name = "builder",
-    binary = ":crane",
 )


### PR DESCRIPTION
This enables the use of `crane` as a build step in Container Builder, e.g.:

```yaml
steps:
- name: gcr.io/go-containerregistry/crane
  args: ['help']
```