### PR TITLE
Rename our chosen entrypoint to /ko-app

### DIFF
--- a/ko/build/gobuild.go
+++ b/ko/build/gobuild.go
@@ -39,7 +39,7 @@ var (
 )
 
 const (
-	appPath = "/app"
+	appPath = "/ko-app"
 )
 
 type Options struct {

--- a/ko/build/gobuild_test.go
+++ b/ko/build/gobuild_test.go
@@ -211,7 +211,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "dedc4f5dcc2afa66050a750529e3e1455c30bbbb983c886e7535376242f05b64",
+			Hex:       "b0780391d7e0cc1f43dc4531e73ee7493309ce446c2eeb9afe8866b623fcf3c2",
 		}
 		appLayer := ls[baseLayers]
 


### PR DESCRIPTION
Previously we used `/app`, which is unfortunately a fairly generic name, in a location that doesn't disambiguate well.  Under most circumstance this is fine, however, I ran into a problem with a base image that was using `/app` for other purposes and this unintentionally shadowed that directory with our app.