### PR TITLE
Reject unrecognized arguments.

### DIFF
--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -81,6 +81,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   #   ko.local/<import path>
   # Then, feed the resulting yaml into "kubectl apply"
   ko apply -L -f config/`,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO(mattmoor): Use io.Pipe to avoid buffering the whole thing.
 			buf := bytes.NewBuffer(nil)
@@ -121,6 +122,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   # daemon as:
   #   ko.local/<import path>
   ko resolve -L -f config/`,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			resolveFilesToWriter(fo, lo, os.Stdout)
 		},


### PR DESCRIPTION
Previously we silently ignored unrecognized flags, which led to non-intuitive behaviors when a typo was present.

Fixes: https://github.com/google/go-containerregistry/issues/170