### PR TITLE
Accept KO_DOCKER_REPO=ko.local in addition to -L

### DIFF
--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -115,8 +115,8 @@ their execution.  By default, `ko` publishes images to a Docker Registry
 specified via `KO_DOCKER_REPO`.
 
 However, these same commands can be directed to operate locally as well via
-the `--local` or `-L` command.  See the [`minikube` section](
-./README.md#with-minikube) for more detail.
+the `--local` or `-L` command (or setting `KO_DOCKER_REPO=ko.local`).  See
+the [`minikube` section](./README.md#with-minikube) for more detail.
 
 
 ### `ko publish`
@@ -208,6 +208,9 @@ kubectl config use-context minikube
 
 # Deploy to minikube w/o registry.
 ko apply -L -f config/
+
+# This is the same as above.
+KO_DOCKER_REPO=ko.local ko apply -f config/
 ```
 
 A caveat of this approach is that it will not work if your container is

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -73,7 +73,8 @@ func addKubeCommands(topLevel *cobra.Command) {
   # Build and publish import path references to a Docker
   # Registry as:
   #   ${KO_DOCKER_REPO}/<import path>
-  # Then, feed the resulting yaml into "kubectl apply"
+  # Then, feed the resulting yaml into "kubectl apply".
+  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
   ko apply -f config/
 
   # Build and publish import path references to a Docker
@@ -115,6 +116,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   # Build and publish import path references to a Docker
   # Registry as:
   #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
   ko resolve -f config/
 
   # Build and publish import path references to a Docker
@@ -137,6 +139,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   # Build and publish import path references to a Docker
   # Registry as:
   #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
   ko publish github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
 
   # Build and publish import path references to a Docker

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -37,10 +37,10 @@ func publishImages(importpaths []string, lo *LocalOptions) {
 			log.Fatalf("error building %q: %v", importpath, err)
 		}
 		var pub publish.Interface
-		if lo.Local {
+		repoName := os.Getenv("KO_DOCKER_REPO")
+		if lo.Local || repoName == publish.LocalDomain {
 			pub = publish.NewDaemon(daemon.WriteOptions{})
 		} else {
-			repoName := os.Getenv("KO_DOCKER_REPO")
 			repo, err := name.NewRepository(repoName, name.WeakValidation)
 			if err != nil {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -78,10 +78,10 @@ func resolveFilesToWriter(fo *FilenameOptions, lo *LocalOptions, out io.Writer) 
 
 func resolveFile(f string, lo *LocalOptions, opt build.Options) ([]byte, error) {
 	var pub publish.Interface
-	if lo.Local {
+	repoName := os.Getenv("KO_DOCKER_REPO")
+	if lo.Local || repoName == publish.LocalDomain {
 		pub = publish.NewDaemon(daemon.WriteOptions{})
 	} else {
-		repoName := os.Getenv("KO_DOCKER_REPO")
 		repo, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {
 			return nil, fmt.Errorf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)

--- a/ko/publish/daemon.go
+++ b/ko/publish/daemon.go
@@ -23,6 +23,10 @@ import (
 	"github.com/google/go-containerregistry/v1/daemon"
 )
 
+const (
+	LocalDomain = "ko.local"
+)
+
 // demon is intentionally misspelled to avoid name collision (and drive Jon nuts).
 type demon struct {
 	wo daemon.WriteOptions
@@ -39,7 +43,7 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 	if err != nil {
 		return nil, err
 	}
-	tag, err := name.NewTag(fmt.Sprintf("ko.local/%s:%s", s, h.Hex), name.WeakValidation)
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", LocalDomain, s, h.Hex), name.WeakValidation)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This enables users to configure the use of the local docker daemon via the `KO_DOCKER_REPO` environment variable in addition to supplying `-L` on the command-line.

There have been reports that `-L` makes it harder for teams that have a mix of minikube and K8s cluster usage to script with `ko`.  This is expected to make that somewhat simpler.

Fixes: https://github.com/google/go-containerregistry/issues/179

