### PR TITLE
Change the way mounting works in go-containerregistry.

### DIFF
--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -61,15 +61,6 @@ func getCreationTime() (*v1.Time, error) {
 	return &v1.Time{time.Unix(seconds, 0)}, nil
 }
 
-func getMountPaths() []name.Repository {
-	repos := make([]name.Repository, 0, len(baseImageOverrides)+1)
-	repos = append(repos, defaultBaseImage.Context())
-	for _, v := range baseImageOverrides {
-		repos = append(repos, v.Context())
-	}
-	return repos
-}
-
 func init() {
 	// If omitted, use this base image.
 	viper.SetDefault("defaultBaseImage", "gcr.io/distroless/base:latest")

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-containerregistry/ko/publish"
 	"github.com/google/go-containerregistry/name"
 	"github.com/google/go-containerregistry/v1/daemon"
-	"github.com/google/go-containerregistry/v1/remote"
 )
 
 func publishImages(importpaths []string, lo *LocalOptions) {
@@ -45,9 +44,7 @@ func publishImages(importpaths []string, lo *LocalOptions) {
 			if err != nil {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 			}
-			pub = publish.NewDefault(repo, http.DefaultTransport, remote.WriteOptions{
-				MountPaths: getMountPaths(),
-			})
+			pub = publish.NewDefault(repo, http.DefaultTransport)
 		}
 		if _, err := pub.Publish(img, importpath); err != nil {
 			log.Fatalf("error publishing %s: %v", importpath, err)

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-containerregistry/ko/resolve"
 	"github.com/google/go-containerregistry/name"
 	"github.com/google/go-containerregistry/v1/daemon"
-	"github.com/google/go-containerregistry/v1/remote"
 )
 
 func gobuildOptions() build.Options {
@@ -87,9 +86,7 @@ func resolveFile(f string, lo *LocalOptions, opt build.Options) ([]byte, error) 
 			return nil, fmt.Errorf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 		}
 
-		pub = publish.NewDefault(repo, http.DefaultTransport, remote.WriteOptions{
-			MountPaths: getMountPaths(),
-		})
+		pub = publish.NewDefault(repo, http.DefaultTransport)
 	}
 
 	b, err := ioutil.ReadFile(f)

--- a/ko/publish/BUILD.bazel
+++ b/ko/publish/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
         "//v1:go_default_library",
         "//v1/daemon:go_default_library",
         "//v1/random:go_default_library",
-        "//v1/remote:go_default_library",
         "//vendor/github.com/docker/docker/api/types:go_default_library",
     ],
 )

--- a/ko/publish/default.go
+++ b/ko/publish/default.go
@@ -29,13 +29,12 @@ import (
 type defalt struct {
 	base name.Repository
 	t    http.RoundTripper
-	wo   remote.WriteOptions
 }
 
 // NewDefault returns a new publish.Interface that publishes references under the provided base
 // repository using the default keychain to authenticate and the default naming scheme.
-func NewDefault(base name.Repository, t http.RoundTripper, wo remote.WriteOptions) Interface {
-	return &defalt{base, t, wo}
+func NewDefault(base name.Repository, t http.RoundTripper) Interface {
+	return &defalt{base, t}
 }
 
 // Publish implements publish.Interface
@@ -51,7 +50,7 @@ func (d *defalt) Publish(img v1.Image, s string) (name.Reference, error) {
 		return nil, err
 	}
 	log.Printf("Publishing %v", tag)
-	if err := remote.Write(tag, img, auth, d.t, d.wo); err != nil {
+	if err := remote.Write(tag, img, auth, d.t, remote.WriteOptions{}); err != nil {
 		return nil, err
 	}
 	h, err := img.Digest()

--- a/ko/publish/default_test.go
+++ b/ko/publish/default_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/go-containerregistry/name"
 	"github.com/google/go-containerregistry/v1/random"
-	"github.com/google/go-containerregistry/v1/remote"
 )
 
 func TestDefault(t *testing.T) {
@@ -71,7 +70,7 @@ func TestDefault(t *testing.T) {
 		t.Fatalf("NewRepository() = %v", err)
 	}
 
-	def := NewDefault(baseRepo, http.DefaultTransport, remote.WriteOptions{})
+	def := NewDefault(baseRepo, http.DefaultTransport)
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if !strings.HasPrefix(d.String(), tag.Repository.String()) {

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -80,16 +80,12 @@ func doAppend(src, dst, tar, output string) {
 		return
 	}
 
-	opts := remote.WriteOptions{}
-	if srcRef.Context().RegistryStr() == dstTag.Context().RegistryStr() {
-		opts.MountPaths = append(opts.MountPaths, srcRef.Context())
-	}
-
 	dstAuth, err := authn.DefaultKeychain.Resolve(dstTag.Context().Registry)
 	if err != nil {
 		log.Fatalf("getting creds for %q: %v", dstTag, err)
 	}
 
+	opts := remote.WriteOptions{}
 	if err := remote.Write(dstTag, image, dstAuth, http.DefaultTransport, opts); err != nil {
 		log.Fatalf("writing image %q: %v", dstTag, err)
 	}

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -64,10 +64,7 @@ func doCopy(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", dstRef, err)
 	}
 
-	wo := remote.WriteOptions{
-		MountPaths: []name.Repository{srcRef.Context()},
-	}
-
+	wo := remote.WriteOptions{}
 	if err := remote.Write(dstRef, img, dstAuth, http.DefaultTransport, wo); err != nil {
 		log.Fatalf("writing image %q: %v", dstRef, err)
 	}

--- a/pkg/crane/rebase.go
+++ b/pkg/crane/rebase.go
@@ -48,17 +48,17 @@ func rebase(orig, oldBase, newBase, rebased string) {
 		log.Fatalln("Must provide --original, --old_base, --new_base and --rebased")
 	}
 
-	origImg, origRef, err := getImage(orig)
+	origImg, _, err := getImage(orig)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	oldBaseImg, oldBaseRef, err := getImage(oldBase)
+	oldBaseImg, _, err := getImage(oldBase)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	newBaseImg, newBaseRef, err := getImage(newBase)
+	newBaseImg, _, err := getImage(newBase)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -83,9 +83,7 @@ func rebase(orig, oldBase, newBase, rebased string) {
 		log.Fatalf("getting creds for %q: %v", rebasedTag, err)
 	}
 
-	if err := remote.Write(rebasedTag, rebasedImg, auth, http.DefaultTransport, remote.WriteOptions{
-		MountPaths: []name.Repository{origRef.Context(), oldBaseRef.Context(), newBaseRef.Context()},
-	}); err != nil {
+	if err := remote.Write(rebasedTag, rebasedImg, auth, http.DefaultTransport, remote.WriteOptions{}); err != nil {
 		log.Fatalf("writing image %q: %v", rebasedTag, err)
 	}
 	fmt.Print(dig.String())

--- a/v1/remote/BUILD.bazel
+++ b/v1/remote/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "error.go",
         "image.go",
         "list.go",
+        "mount.go",
         "write.go",
     ],
     importpath = "github.com/google/go-containerregistry/v1/remote",

--- a/v1/remote/mount.go
+++ b/v1/remote/mount.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"github.com/google/go-containerregistry/name"
+	"github.com/google/go-containerregistry/v1"
+)
+
+// MountableLayer wraps a v1.Layer in a shim that enables the layer to be
+// "mounted" when published to another registry.
+type MountableLayer struct {
+	v1.Layer
+
+	Repository name.Repository
+}
+
+// mountableImage wraps the v1.Layer references returned by the embedded v1.Image
+// in MountableLayer's so that remote.Write might attempt to mount them from their
+// source repository.
+type mountableImage struct {
+	v1.Image
+
+	Repository name.Repository
+}
+
+// Layers implements v1.Image
+func (mi *mountableImage) Layers() ([]v1.Layer, error) {
+	ls, err := mi.Image.Layers()
+	if err != nil {
+		return nil, err
+	}
+	mls := make([]v1.Layer, 0, len(ls))
+	for _, l := range ls {
+		mls = append(mls, &MountableLayer{
+			Layer:      l,
+			Repository: mi.Repository,
+		})
+	}
+	return mls, nil
+}
+
+// LayerByDigest implements v1.Image
+func (mi *mountableImage) LayerByDigest(d v1.Hash) (v1.Layer, error) {
+	l, err := mi.Image.LayerByDigest(d)
+	if err != nil {
+		return nil, err
+	}
+	return &MountableLayer{
+		Layer:      l,
+		Repository: mi.Repository,
+	}, nil
+}
+
+// LayerByDiffID implements v1.Image
+func (mi *mountableImage) LayerByDiffID(d v1.Hash) (v1.Layer, error) {
+	l, err := mi.Image.LayerByDiffID(d)
+	if err != nil {
+		return nil, err
+	}
+	return &MountableLayer{
+		Layer:      l,
+		Repository: mi.Repository,
+	}, nil
+}

--- a/v1/remote/write_test.go
+++ b/v1/remote/write_test.go
@@ -265,6 +265,11 @@ func TestInitiateUploadMountsWithMount(t *testing.T) {
 		"from":  []string{expectedMountRepo},
 	}.Encode()
 
+	img = &mountableImage{
+		Image:      img,
+		Repository: mustNewTag(t, fmt.Sprintf("gcr.io/%s", expectedMountRepo)).Repository,
+	}
+
 	w, closer, err := setupWriter(expectedRepo, img, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
@@ -281,8 +286,6 @@ func TestInitiateUploadMountsWithMount(t *testing.T) {
 		t.Fatalf("setupWriter() = %v", err)
 	}
 	defer closer.Close()
-	w.options.MountPaths = append(w.options.MountPaths,
-		mustNewTag(t, fmt.Sprintf("gcr.io/%s", expectedMountRepo)).Repository)
 
 	_, mounted, err := w.initiateUpload(h)
 	if err != nil {


### PR DESCRIPTION
This completely changes the model for cross-repo mounting in the `go-containerregistry` library.  Rather than having clients of `remote.Write` pass in a set of potential mount sources, `remote.Write` is sensitive to a new `v1.Layer` wrapper type: `remote.MountableLayer`, which implements `v1.Layer` by embedding the layer it wraps and augmenting that with the name of the repository from which we should attempt to mount it, if written.  With this model, `remote.Image` now wraps all of the `v1.Layer`s it returns with the name of the repository from which it is pulling.

Fixes: https://github.com/google/go-containerregistry/issues/165

cc @sclevine 