### PR TITLE
Avoid recomputing the DiffID of layers where we know it.

### DIFF
--- a/v1/partial/compressed.go
+++ b/v1/partial/compressed.go
@@ -50,6 +50,11 @@ func (ule *compressedLayerExtender) Uncompressed() (io.ReadCloser, error) {
 
 // DiffID implements v1.Layer
 func (ule *compressedLayerExtender) DiffID() (v1.Hash, error) {
+	// If our nested CompressedLayer implements DiffID,
+	// then delegate to it instead.
+	if wdi, ok := ule.CompressedLayer.(WithDiffID); ok {
+		return wdi.DiffID()
+	}
 	r, err := ule.Uncompressed()
 	if err != nil {
 		return v1.Hash{}, err

--- a/v1/partial/with.go
+++ b/v1/partial/with.go
@@ -285,3 +285,8 @@ func UncompressedBlob(b WithBlob, h v1.Hash) (io.ReadCloser, error) {
 	}
 	return v1util.GunzipReadCloser(rc)
 }
+
+// WithDiffID defines the subset of v1.Layer for exposing the DiffID method.
+type WithDiffID interface {
+	DiffID() (v1.Hash, error)
+}

--- a/v1/remote/image.go
+++ b/v1/remote/image.go
@@ -200,6 +200,17 @@ func (rl *remoteLayer) Size() (int64, error) {
 	return partial.BlobSize(rl, rl.digest)
 }
 
+// ConfigFile implements partial.WithManifestAndConfigFile so that we can use partial.BlobToDiffID below.
+func (rl *remoteLayer) ConfigFile() (*v1.ConfigFile, error) {
+	return partial.ConfigFile(rl.ri)
+}
+
+// DiffID implements partial.WithDiffID so that we don't recompute a DiffID that we already have
+// available in our ConfigFile.
+func (rl *remoteLayer) DiffID() (v1.Hash, error) {
+	return partial.BlobToDiffID(rl, rl.digest)
+}
+
 // LayerByDigest implements partial.CompressedLayer
 func (r *remoteImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
 	return &remoteLayer{

--- a/v1/tarball/image.go
+++ b/v1/tarball/image.go
@@ -298,7 +298,7 @@ type compressedLayerFromTarball struct {
 	filePath string
 }
 
-// DiffID implements partial.CompressedLayer
+// Digest implements partial.CompressedLayer
 func (clft *compressedLayerFromTarball) Digest() (v1.Hash, error) {
 	return clft.digest, nil
 }


### PR DESCRIPTION
Prior to this change, the `partial` package enabled folks to implement the bare minimum interface necessary to compute the remainder of the `v1.Image` or `v1.Layer` interface.  With this change, we start to adopt a pattern that allows implementors to go beyond this bare minimum and implement additional methods and have the `partial` wrappers respect and delegate to these additional methods.

The first use case of this pattern is in `remote.Layer` where we effectively know all of the layers' `DiffID`s, but because of the "bare minimum" constraint we had previously been unable to leverage this knowledge to elide recomputing the DiffID by downloading and uncompressing the layer.

Fixes: https://github.com/google/go-containerregistry/issues/166

cc @sclevine 