### PR TITLE
Preserve the full source reference in MountableLayer

### DIFF
--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -61,8 +61,8 @@ func Image(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) (v
 	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
 	// remote.Write calls to facilitate cross-repo "mounting".
 	return &mountableImage{
-		Image:      img,
-		Repository: ref.Context(),
+		Image:     img,
+		Reference: ref,
 	}, nil
 }
 

--- a/pkg/v1/remote/mount.go
+++ b/pkg/v1/remote/mount.go
@@ -24,7 +24,7 @@ import (
 type MountableLayer struct {
 	v1.Layer
 
-	Repository name.Repository
+	Reference name.Reference
 }
 
 // mountableImage wraps the v1.Layer references returned by the embedded v1.Image
@@ -33,7 +33,7 @@ type MountableLayer struct {
 type mountableImage struct {
 	v1.Image
 
-	Repository name.Repository
+	Reference name.Reference
 }
 
 // Layers implements v1.Image
@@ -45,8 +45,8 @@ func (mi *mountableImage) Layers() ([]v1.Layer, error) {
 	mls := make([]v1.Layer, 0, len(ls))
 	for _, l := range ls {
 		mls = append(mls, &MountableLayer{
-			Layer:      l,
-			Repository: mi.Repository,
+			Layer:     l,
+			Reference: mi.Reference,
 		})
 	}
 	return mls, nil
@@ -59,8 +59,8 @@ func (mi *mountableImage) LayerByDigest(d v1.Hash) (v1.Layer, error) {
 		return nil, err
 	}
 	return &MountableLayer{
-		Layer:      l,
-		Repository: mi.Repository,
+		Layer:     l,
+		Reference: mi.Reference,
 	}, nil
 }
 
@@ -71,7 +71,7 @@ func (mi *mountableImage) LayerByDiffID(d v1.Hash) (v1.Layer, error) {
 		return nil, err
 	}
 	return &MountableLayer{
-		Layer:      l,
-		Repository: mi.Repository,
+		Layer:     l,
+		Reference: mi.Reference,
 	}, nil
 }

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -45,7 +45,7 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 	scopes := []string{ref.Scope(transport.PushScope)}
 	for _, l := range ls {
 		if ml, ok := l.(*MountableLayer); ok {
-			scopes = append(scopes, ml.Repository.Scope(transport.PullScope))
+			scopes = append(scopes, ml.Reference.Context().Scope(transport.PullScope))
 		}
 	}
 
@@ -145,7 +145,7 @@ func (w *writer) initiateUpload(h v1.Hash) (location string, mounted bool, err e
 	// if "mount" is specified, even if no "from" sources are specified.  If this turns out
 	// to not be broadly applicable then we should replace mounts without "from"s with a HEAD.
 	if ml, ok := l.(*MountableLayer); ok {
-		uv["from"] = []string{ml.Repository.RepositoryStr()}
+		uv["from"] = []string{ml.Reference.Context().RepositoryStr()}
 	}
 	u.RawQuery = uv.Encode()
 

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -266,8 +266,8 @@ func TestInitiateUploadMountsWithMount(t *testing.T) {
 	}.Encode()
 
 	img = &mountableImage{
-		Image:      img,
-		Repository: mustNewTag(t, fmt.Sprintf("gcr.io/%s", expectedMountRepo)).Repository,
+		Image:     img,
+		Reference: mustNewTag(t, fmt.Sprintf("gcr.io/%s", expectedMountRepo)),
 	}
 
 	w, closer, err := setupWriter(expectedRepo, img, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Mounting is just one way to take advantage of this information, so preserve as much information as we can to support other potential uses of this information.

Related: https://github.com/google/go-containerregistry/issues/205