### PR TITLE
cross-repo blob mount should be used only when the layer comes from the same registry.

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -145,7 +145,9 @@ func (w *writer) initiateUpload(h v1.Hash) (location string, mounted bool, err e
 	// if "mount" is specified, even if no "from" sources are specified.  If this turns out
 	// to not be broadly applicable then we should replace mounts without "from"s with a HEAD.
 	if ml, ok := l.(*MountableLayer); ok {
-		uv["from"] = []string{ml.Reference.Context().RepositoryStr()}
+		if w.ref.Context().RegistryStr() == ml.Reference.Context().RegistryStr() {
+			uv["from"] = []string{ml.Reference.Context().RepositoryStr()}
+		}
 	}
 	u.RawQuery = uv.Encode()
 


### PR DESCRIPTION
Hi!  Thank you for maintaining great project!!

go-containerregistry uses [Cross Repository Blob Mount](https://docs.docker.com/registry/spec/api/#cross-repository-blob-mount) in [`writer.initiateUpload(h)`](https://github.com/google/go-containerregistry/blob/3f6471078a9661a9a439bd5e71a371aff429566a/pkg/v1/remote/write.go#L143-L149) even when the mountable layer comes from a different registry.  This would causes `401 Unauthorized` error.  It can easily happen when users try to push the layer to their own private registry.

Although I'm not so familiar with docker registry API,  I think cross repo blob mount should be used only when the mountable layer comes from the SAME registry with the target registry.