### PR TITLE
Fix file paths for `ko` on windows

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -43,7 +43,7 @@ func configDir() (string, error) {
 		return dc, nil
 	}
 	if h := dockerUserHomeDir(); h != "" {
-		return path.Join(dockerUserHomeDir(), ".docker"), nil
+		return filepath.Join(dockerUserHomeDir(), ".docker"), nil
 	}
 	return "", errNoHomeDir
 }
@@ -103,7 +103,7 @@ func (dk *defaultKeychain) Resolve(reg name.Registry) (Authenticator, error) {
 		log.Printf("Unable to determine config dir, falling back on anonymous: %v", err)
 		return Anonymous, nil
 	}
-	file := path.Join(dir, "config.json")
+	file := filepath.Join(dir, "config.json")
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Printf("Unable to read %q, falling back on anonymous: %v", file, err)

--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -65,10 +65,11 @@ func computeImportpath() (string, error) {
 		gopath = gb.Default.GOPATH
 	}
 	src := filepath.Join(gopath, "src")
-	if !strings.HasPrefix(wd, src) {
-		return "", fmt.Errorf("working directory %q must be on GOPATH %q", wd, src)
+	relpath, err := filepath.Rel(src, wd)
+	if err != nil {
+		return "", fmt.Errorf("working directory %q must be on GOPATH %q (%v)", wd, src, err)
 	}
-	return strings.Trim(strings.TrimPrefix(wd, src), "/"), nil
+	return filepath.ToSlash(relpath), nil
 }
 
 // NewGo returns a build.Interface implementation that:

--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/v1"
@@ -64,7 +64,7 @@ func computeImportpath() (string, error) {
 	if gopath == "" {
 		gopath = gb.Default.GOPATH
 	}
-	src := path.Join(gopath, "src")
+	src := filepath.Join(gopath, "src")
 	if !strings.HasPrefix(wd, src) {
 		return "", fmt.Errorf("working directory %q must be on GOPATH %q", wd, src)
 	}
@@ -94,7 +94,7 @@ func build(ip string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	file := path.Join(tmpDir, "out")
+	file := filepath.Join(tmpDir, "out")
 
 	log.Printf("Go building %v", ip)
 	cmd := exec.Command("go", "build", "-o", file, ip)
@@ -161,7 +161,7 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(path.Dir(file))
+	defer os.RemoveAll(filepath.Dir(file))
 
 	// Construct a tarball with the binary.
 	layerBytes, err := tarBinary(file)


### PR DESCRIPTION
Without this, you get the following error:

> `2018/07/05 14:20:16 error processing import paths in "config\\webhook.yaml": working directory "c:\\Go\\src\\github.com\\evankanderson\\sia" must be on GOPATH "c:\\\\Go/src"`

With this patch, I'm able to use `ko apply` successfully.