### PR TITLE
Use go/build.Import to resolve import paths

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 #   version = "2.4.0"
 #
 
-# Used for deep copy code generation
+# Used for deep copy code generation and ko publish tests.
 required = [
   "k8s.io/code-generator/cmd/deepcopy-gen",
 ]

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -31,6 +31,10 @@ func publishImages(importpaths []string, lo *LocalOptions) {
 		log.Fatalf("error creating go builder: %v", err)
 	}
 	for _, importpath := range importpaths {
+		if !b.IsSupportedReference(importpath) {
+			log.Fatalf("importpath %q is not supported", importpath)
+		}
+
 		img, err := b.Build(importpath)
 		if err != nil {
 			log.Fatalf("error building %q: %v", importpath, err)

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -35,6 +35,7 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 	for _, importpath := range []string{
 		filepath.FromSlash("github.com/google/go-containerregistry/cmd/crane"),
 		filepath.FromSlash("github.com/google/go-containerregistry/cmd/ko"),
+		filepath.FromSlash("github.com/google/go-containerregistry/vendor/k8s.io/code-generator/cmd/deepcopy-gen"), // vendored commands work too.
 	} {
 		t.Run(importpath, func(t *testing.T) {
 			if !ng.IsSupportedReference(importpath) {

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -37,7 +37,6 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 		filepath.FromSlash("github.com/google/go-containerregistry/cmd/ko"),
 	} {
 		t.Run(importpath, func(t *testing.T) {
-			// TODO(jasonhall): Figure this out.
 			if !ng.IsSupportedReference(importpath) {
 				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -16,10 +16,7 @@ package build
 
 import (
 	"io/ioutil"
-	"os"
-	"path"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"testing"
@@ -27,7 +24,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
-
 
 func TestGoBuildIsSupportedRef(t *testing.T) {
 	ng, err := NewGo(Options{})
@@ -37,8 +33,8 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 
 	// Supported import paths.
 	for _, importpath := range []string{
-		"github.com/google/go-containerregistry/cmd/crane",
-		"github.com/google/go-containerregistry/cmd/ko",
+		filepath.FromSlash("github.com/google/go-containerregistry/cmd/crane"),
+		filepath.FromSlash("github.com/google/go-containerregistry/cmd/ko"),
 	} {
 		t.Run(importpath, func(t *testing.T) {
 			// TODO(jasonhall): Figure this out.
@@ -51,15 +47,12 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 
 	// Unsupported import paths.
 	for _, importpath := range []string{
-		"github.com/google/go-containerregistry/v1/remote", // not a command.
-		"github.com/google/go-containerregistry/pkg/foo",   // does not exist.
-		"simple string",
-	}
-
-	for _, test := range unsupportedTests {
-		t.Run(test, func(t *testing.T) {
-			if ng.IsSupportedReference(test) {
-				t.Errorf("IsSupportedReference(%v) = true, want false", test)
+		filepath.FromSlash("github.com/google/go-containerregistry/v1/remote"), // not a command.
+		filepath.FromSlash("github.com/google/go-containerregistry/pkg/foo"),   // does not exist.
+	} {
+		t.Run(importpath, func(t *testing.T) {
+			if ng.IsSupportedReference(importpath) {
+				t.Errorf("IsSupportedReference(%v) = true, want false", importpath)
 			}
 		})
 	}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -41,6 +41,8 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 		"github.com/google/go-containerregistry/cmd/ko",
 	} {
 		t.Run(importpath, func(t *testing.T) {
+			// TODO(jasonhall): Figure this out.
+			t.Skip("IsSupportedReference always returns false in bazel tests")
 			if !ng.IsSupportedReference(importpath) {
 				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -38,7 +38,6 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 	} {
 		t.Run(importpath, func(t *testing.T) {
 			// TODO(jasonhall): Figure this out.
-			t.Skip("IsSupportedReference always returns false in bazel tests")
 			if !ng.IsSupportedReference(importpath) {
 				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -28,110 +28,30 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
-type testContext struct {
-	gopath  string
-	workdir string
-}
-
-func (tc *testContext) Enter(t *testing.T) {
-	// Change the current state for the test.
-	os.Setenv("GOPATH", tc.gopath)
-	getwd = func() (string, error) {
-		return tc.workdir, nil
-	}
-}
-
-func TestComputeImportPath(t *testing.T) {
-	tests := []struct {
-		desc             string
-		ctx              testContext
-		expectErr        bool
-		expectImportpath string
-	}{{
-		desc: "simple gopath",
-		ctx: testContext{
-			gopath:  "/go",
-			workdir: "/go/src/github.com/foo/bar",
-		},
-		expectImportpath: "github.com/foo/bar",
-	}, {
-		desc: "trailing slashes",
-		ctx: testContext{
-			gopath:  "/go/",
-			workdir: "/go/src/github.com/foo/bar/",
-		},
-		expectImportpath: "github.com/foo/bar",
-	}, {
-		desc: "not on gopath",
-		ctx: testContext{
-			gopath:  "/go",
-			workdir: "/rust/src/github.com/foo/bar",
-		},
-		expectErr: true,
-	}}
-
-	if runtime.GOOS == "windows" {
-		for i := range tests {
-			tests[i].ctx.gopath = "C:" + filepath.FromSlash(tests[i].ctx.gopath)
-			tests[i].ctx.workdir = "C:" + filepath.FromSlash(tests[i].ctx.workdir)
-		}
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			// Set the context for our test.
-			test.ctx.Enter(t)
-
-			ip, err := computeImportpath()
-			if err != nil && !test.expectErr {
-				t.Errorf("computeImportpath() = %v, want %v", err, test.expectImportpath)
-			} else if err == nil && test.expectErr {
-				t.Errorf("computeImportpath() = %v, want error", ip)
-			} else if err == nil && !test.expectErr {
-				if got, want := ip, test.expectImportpath; want != got {
-					t.Errorf("computeImportpath() = %v, want %v", got, want)
-				}
-			}
-		})
-	}
-}
 
 func TestGoBuildIsSupportedRef(t *testing.T) {
-	img, err := random.Image(1024, 1)
-	if err != nil {
-		t.Fatalf("random.Image() = %v", err)
-	}
-	importpath := "github.com/google/go-containerregistry"
-	tc := testContext{
-		gopath:  "/go",
-		workdir: "/go/src/" + importpath,
-	}
-	tc.Enter(t)
-	ng, err := NewGo(Options{GetBase: func(string) (v1.Image, error) {
-		return img, nil
-	}})
+	ng, err := NewGo(Options{})
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
 	}
 
-	supportedTests := []string{
-		path.Join(importpath, "pkg", "foo"),
-		path.Join(importpath, "cmd", "crane"),
-	}
-
-	for _, test := range supportedTests {
-		t.Run(test, func(t *testing.T) {
-			if !ng.IsSupportedReference(test) {
-				t.Errorf("IsSupportedReference(%v) = false, want true", test)
+	// Supported import paths.
+	for _, importpath := range []string{
+		"github.com/google/go-containerregistry/cmd/crane",
+		"github.com/google/go-containerregistry/cmd/ko",
+	} {
+		t.Run(importpath, func(t *testing.T) {
+			if !ng.IsSupportedReference(importpath) {
+				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}
 		})
 	}
 
-	unsupportedTests := []string{
+	// Unsupported import paths.
+	for _, importpath := range []string{
+		"github.com/google/go-containerregistry/v1/remote", // not a command.
+		"github.com/google/go-containerregistry/pkg/foo",   // does not exist.
 		"simple string",
-		filepath.FromSlash("k8s.io/client-go/pkg/foo"),
-		filepath.FromSlash("github.com/google/secret/cmd/sauce"),
-		filepath.Join("vendor", importpath, "pkg", "foo"),
 	}
 
 	for _, test := range unsupportedTests {
@@ -168,23 +88,15 @@ func TestGoBuild(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 	importpath := "github.com/google/go-containerregistry"
-	tc := testContext{
-		gopath:  "/go",
-		workdir: "/go/src/" + importpath,
-	}
-	tc.Enter(t)
 
 	creationTime := func() (*v1.Time, error) {
 		return &v1.Time{time.Unix(5000, 0)}, nil
 	}
 
-	ng, err := NewGo(
-		Options{
-			GetCreationTime: creationTime,
-			GetBase: func(string) (v1.Image, error) {
-				return base, nil
-			},
-		})
+	ng, err := NewGo(Options{
+		GetCreationTime: creationTime,
+		GetBase:         func(string) (v1.Image, error) { return base, nil },
+	})
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
 	}


### PR DESCRIPTION
Fixes #215 and #197 

With this change, only import paths that represent runnable commands (i.e., `package main`) are considered "supported". As a reminder, attempting to `ko publish` an unsupported path will fail, and unsupported paths are simply ignored when `ko resolve`ing.

This change also allows `ko` to be run outside of `GOPATH`, and requires import paths to be fully qualified -- `image: ./cmd/foo` will not `resolve`, it must be `image: github.com/my/repo/cmd/foo`