### PR TITLE
Fix rebase_cloudbuild.yaml

### DIFF
--- a/cmd/crane/rebase_cloudbuild.yaml
+++ b/cmd/crane/rebase_cloudbuild.yaml
@@ -1,12 +1,6 @@
 steps:
-- name: 'gcr.io/cloud-builders/bazel'
-  args: ['build', '--spawn_strategy=standalone', '//...']
-
-# Build image and retag to this project's repo.
-- name: 'gcr.io/cloud-builders/bazel'
-  args: ['run', '--spawn_strategy=standalone', '//cmd/crane:builder', '--', '--norun']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'bazel/cmd/crane:builder', 'gcr.io/$PROJECT_ID/crane']
+# This test assumes that gcr.io/$PROJECT_ID/crane exists, as built according to
+# this repo's cloudbuild.yaml
 
 # Run a simple example that builds two base images and an image based on one,
 # then rebases it on the other.
@@ -59,6 +53,3 @@ steps:
   args:
   - -c
   - docker run gcr.io/$PROJECT_ID/rebase-test:rebased | grep bar
-
-# Push the crane image.
-images: ['gcr.io/$PROJECT_ID/crane']


### PR DESCRIPTION
Fixes #223 

Instead of building the `crane` builder in the test, just assume it was already built from the repo's root `cloudbuild.yaml` and was pushed to `gcr.io/$PROJECT_ID/crane`