### PR TITLE
Allow relative paths in ko publish

### DIFF
--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -46,8 +46,8 @@ func publishImages(importpaths []string, lo *LocalOptions) {
 	}
 	for _, importpath := range importpaths {
 		if gb.IsLocalImport(importpath) {
-			// Interpret `ko publish ./cmd/foo` as `ko publish $GOPATH/cmd/foo`
-			// $PWD must be within $GOPATH/src
+			// Qualify relative imports to their fully-qualified
+			// import path, assuming $PWD is within $GOPATH/src.
 			gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
 			pwd, err := os.Getwd()
 			if err != nil {

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -15,9 +15,13 @@
 package main
 
 import (
+	"fmt"
+	gb "go/build"
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/ko/build"
 	"github.com/google/go-containerregistry/pkg/ko/publish"
@@ -25,12 +29,36 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 )
 
+func qualifyLocalImport(importpath, gopathsrc, pwd string) (string, error) {
+	if !strings.HasPrefix(pwd, gopathsrc) {
+		return "", fmt.Errorf("pwd (%q) must be on $GOPATH/src (%q) to support local imports", pwd, gopathsrc)
+	}
+	// Given $GOPATH/src and $PWD (which must be within $GOPATH/src), trim
+	// off $GOPATH/src/ from $PWD and append local importpath to get the
+	// fully-qualified importpath.
+	return filepath.Join(strings.TrimPrefix(pwd, gopathsrc+string(filepath.Separator)), importpath), nil
+}
+
 func publishImages(importpaths []string, lo *LocalOptions) {
 	b, err := build.NewGo(gobuildOptions())
 	if err != nil {
 		log.Fatalf("error creating go builder: %v", err)
 	}
 	for _, importpath := range importpaths {
+		if gb.IsLocalImport(importpath) {
+			// Interpret `ko publish ./cmd/foo` as `ko publish $GOPATH/cmd/foo`
+			// $PWD must be within $GOPATH/src
+			gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
+			pwd, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("error getting current working directory: %v", err)
+			}
+			importpath, err = qualifyLocalImport(importpath, gopathsrc, pwd)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
 		if !b.IsSupportedReference(importpath) {
 			log.Fatalf("importpath %q is not supported", importpath)
 		}

--- a/cmd/ko/publish_test.go
+++ b/cmd/ko/publish_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestQualifyLocalImport(t *testing.T) {
+	for _, c := range []struct {
+		importpath, gopathsrc, pwd, want string
+		wantErr                          bool
+	}{{
+		importpath: "./cmd/foo",
+		gopathsrc:  "/home/go/src",
+		pwd:        "/home/go/src/github.com/my/repo",
+		want:       "github.com/my/repo/cmd/foo",
+	}, {
+		importpath: "./foo",
+		gopathsrc:  "/home/go/src",
+		pwd:        "/home/go/src/github.com/my/repo/cmd",
+		want:       "github.com/my/repo/cmd/foo",
+	}, {
+		// $PWD not on $GOPATH/src
+		importpath: "./cmd/foo",
+		gopathsrc:  "/home/go/src",
+		pwd:        "/",
+		wantErr:    true,
+	}} {
+		got, err := qualifyLocalImport(c.importpath, c.gopathsrc, c.pwd)
+		if gotErr := err != nil; gotErr != c.wantErr {
+			t.Fatalf("qualifyLocalImport returned %v, wanted err? %t", err, c.wantErr)
+		}
+		if got != c.want {
+			t.Fatalf("qualifyLocalImport(%q, %q, %q): got %q, want %q", c.importpath, c.gopathsrc, c.pwd, got, c.want)
+		}
+	}
+
+}

--- a/cmd/ko/publish_test.go
+++ b/cmd/ko/publish_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "testing"

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -38,6 +38,8 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 		filepath.FromSlash("github.com/google/go-containerregistry/vendor/k8s.io/code-generator/cmd/deepcopy-gen"), // vendored commands work too.
 	} {
 		t.Run(importpath, func(t *testing.T) {
+			// TODO(jasonhall): Figure this out.
+			t.Skip("IsSupportedReference always returns false in bazel tests")
 			if !ng.IsSupportedReference(importpath) {
 				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -38,8 +38,6 @@ func TestGoBuildIsSupportedRef(t *testing.T) {
 		filepath.FromSlash("github.com/google/go-containerregistry/vendor/k8s.io/code-generator/cmd/deepcopy-gen"), // vendored commands work too.
 	} {
 		t.Run(importpath, func(t *testing.T) {
-			// TODO(jasonhall): Figure this out.
-			t.Skip("IsSupportedReference always returns false in bazel tests")
 			if !ng.IsSupportedReference(importpath) {
 				t.Errorf("IsSupportedReference(%q) = false, want true", importpath)
 			}


### PR DESCRIPTION
Begins to address #190, based on work in #229 

With this change, if your working directory is within `$GOPATH/src`, you can run `ko publish ./some/local/import/path` (assuming that path is valid and points to a `package main`).

This does not yet support `ko publish ./...`, but this is a prerequisite.