### PR TITLE
Don't log anonymous fallback except in WithAuthFromKeychain

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -99,16 +100,19 @@ var (
 func (dk *defaultKeychain) Resolve(reg name.Registry) (Authenticator, error) {
 	dir, err := configDir()
 	if err != nil {
+		log.Printf("Unable to determine config dir: %v", err)
 		return Anonymous, nil
 	}
 	file := filepath.Join(dir, "config.json")
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
+		log.Printf("Unable to read %q: %v", file, err)
 		return Anonymous, nil
 	}
 
 	var cf cfg
 	if err := json.Unmarshal(content, &cf); err != nil {
+		log.Printf("Unable to parse %q: %v", file, err)
 		return Anonymous, nil
 	}
 

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -100,19 +99,16 @@ var (
 func (dk *defaultKeychain) Resolve(reg name.Registry) (Authenticator, error) {
 	dir, err := configDir()
 	if err != nil {
-		log.Printf("Unable to determine config dir, falling back on anonymous: %v", err)
 		return Anonymous, nil
 	}
 	file := filepath.Join(dir, "config.json")
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Printf("Unable to read %q, falling back on anonymous: %v", file, err)
 		return Anonymous, nil
 	}
 
 	var cf cfg
 	if err := json.Unmarshal(content, &cf); err != nil {
-		log.Printf("Unable to parse %q, falling back on anonymous: %v", file, err)
 		return Anonymous, nil
 	}
 
@@ -147,6 +143,6 @@ func (dk *defaultKeychain) Resolve(reg name.Registry) (Authenticator, error) {
 		}
 	}
 
-	log.Printf("No matching credentials found for %v, falling back on anonymous", reg)
+	// Fallback on anonymous.
 	return Anonymous, nil
 }

--- a/pkg/ko/publish/options.go
+++ b/pkg/ko/publish/options.go
@@ -15,6 +15,7 @@
 package publish
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -24,7 +25,7 @@ import (
 // on a default publisher.
 func WithTransport(t http.RoundTripper) Option {
 	return func(i *defaultOpener) error {
-		i.setTransport(t)
+		i.t = t
 		return nil
 	}
 }
@@ -33,7 +34,7 @@ func WithTransport(t http.RoundTripper) Option {
 // on a default publisher.
 func WithAuth(auth authn.Authenticator) Option {
 	return func(i *defaultOpener) error {
-		i.setAuth(auth)
+		i.auth = auth
 		return nil
 	}
 }
@@ -46,17 +47,10 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 		if err != nil {
 			return err
 		}
-		i.setAuth(auth)
+		if auth == authn.Anonymous {
+			log.Println("No matching credentials were found, falling back on anonymous")
+		}
+		i.auth = auth
 		return nil
 	}
-}
-
-// Set client on image using provided transport, and the default authenticator
-func (i *defaultOpener) setTransport(t http.RoundTripper) {
-	i.t = t
-}
-
-// Set client on image using provided authenticator, and the default transport
-func (i *defaultOpener) setAuth(auth authn.Authenticator) {
-	i.auth = auth
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -25,7 +25,7 @@ import (
 // on a remote image
 func WithTransport(t http.RoundTripper) ImageOption {
 	return func(i *imageOpener) error {
-		return i.setTransport(t)
+		i.transport = t
 		return nil
 	}
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -15,6 +15,7 @@
 package remote
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -25,6 +26,7 @@ import (
 func WithTransport(t http.RoundTripper) ImageOption {
 	return func(i *imageOpener) error {
 		return i.setTransport(t)
+		return nil
 	}
 }
 
@@ -32,7 +34,8 @@ func WithTransport(t http.RoundTripper) ImageOption {
 // on a remote image
 func WithAuth(auth authn.Authenticator) ImageOption {
 	return func(i *imageOpener) error {
-		return i.setAuth(auth)
+		i.auth = auth
+		return nil
 	}
 }
 
@@ -44,18 +47,10 @@ func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
 		if err != nil {
 			return err
 		}
-		return i.setAuth(auth)
+		if auth == authn.Anonymous {
+			log.Println("No matching credentials were found, falling back on anonymous")
+		}
+		i.auth = auth
+		return nil
 	}
-}
-
-// Set client on image using provided transport, and the default authenticator
-func (i *imageOpener) setTransport(t http.RoundTripper) error {
-	i.transport = t
-	return nil
-}
-
-// Set client on image using provided authenticator, and the default transport
-func (i *imageOpener) setAuth(auth authn.Authenticator) error {
-	i.auth = auth
-	return nil
 }


### PR DESCRIPTION
With this change, if a user calls `someKeychain.Resolve(...)` and the result is `authn.Anonymous`, no logs will be emitted. It would be up to them to log the anonymous fallback, if they wanted to. Users calling `remote.WithAuthFromKeychain` _would_ see a log message if the final result of that keychain's `Resolve` was `authn.Anonymous`.

The benefit is that if `WithAuthFromKeychain` is passed an `authn.MultiKeychain`, the user won't see confusing `falling back on anonymous` messages in their logs that might not be true if a later keychain in the list picked up real creds.
