### PR TITLE
Change the default behavior to use flat image names.

### DIFF
--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -169,10 +169,6 @@ spec:
         - containerPort: 8080
 ```
 
-*Note that DockerHub does not currently support these multi-level names. We may
-employ alternate naming strategies in the future to broaden support, but this
-would sacrifice some amount of identifiability.*
-
 ### `ko apply`
 
 `ko apply` is intended to parallel `kubectl apply`, but acts on the same
@@ -188,6 +184,31 @@ to whatever `kubectl` context is active.
 
 `ko delete` simply passes through to `kubectl delete`. It is exposed purely out
 of convenience for cleaning up resources created through `ko apply`.
+
+
+## With DockerHub
+
+Unfortunately, DockerHub does not support this sort of multi-level names, so you may see an error like:
+
+```shell
+$ KO_DOCKER_REPO=docker.io/mattmoor ko publish ./cmd/crane
+2018/07/19 03:25:56 Using base gcr.io/distroless/base:latest for github.com/google/go-containerregistry/cmd/crane
+2018/07/19 03:25:56 Publishing index.docker.io/mattmoor/github.com/google/go-containerregistry/cmd/crane:latest
+2018/07/19 03:25:57 error publishing github.com/google/go-containerregistry/cmd/crane: UNAUTHORIZED: "authentication required"
+```
+
+To support this, we have a flag that will flatten the import path to `{package}-{hash of import path}`:
+
+```shell
+$ KO_DOCKER_REPO=docker.io/mattmoor ko publish --flat ./cmd/crane
+2018/07/19 03:27:50 Using base gcr.io/distroless/base:latest for github.com/google/go-containerregistry/cmd/crane
+2018/07/19 03:27:51 Publishing index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f:latest
+2018/07/19 03:27:53 pushed blob sha256:edb0321a975b7d1ab56e0318449734cf66b1eb840fe8d4e3d731ebfdbadc77b7
+2018/07/19 03:27:54 pushed blob sha256:ea67e6e9b37c7641c0af30e7c3a1c121a98bedc81de5248f0ffa32a762b41844
+2018/07/19 03:27:55 pushed blob sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
+2018/07/19 03:27:55 index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f:latest: digest: sha256:fae03fbb07136f37a0991629201ec6862ca232502dd2bee9ed6ce85cdb26296c size: 592
+2018/07/19 03:27:55 Published index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f@sha256:fae03fbb07136f37a0991629201ec6862ca232502dd2bee9ed6ce85cdb26296c
+```
 
 
 ## With `minikube`

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -1,6 +1,6 @@
 # `ko`
 
-`ko` is an **experimental** CLI to support rapid development of Go containers
+`ko` is a CLI to support rapid development of Go containers
 with Kubernetes and minimal configuration.
 
 ## Installation
@@ -74,38 +74,35 @@ For example, any of the following would be matched:
 * `github.com/mattmoor/examples/cmd/foo`
 * `github.com/mattmoor/examples/bar`
 
-`ko` does not (currently) support `vendor`d binaries, or building other
-binaries from `GOPATH` (outside of the current scope).
-
 ### Results
 
 Employing this convention enables `ko` to have effectively zero configuration
 and enable very fast development iteration. For
 [warm-image](https://github.com/mattmoor/warm-image), `ko` is able to
 build, containerize, and redeploy a non-trivial Kubernetes controller app in
-roughly 10 seconds (dominated by two `go build`s).
+seconds (dominated by two `go build`s).
 
 ```shell
-~/go/src/github.com/mattmoor/warm-image$ ko apply -f config/
-2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
-2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/controller
-2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
-2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
-2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
-2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
-2018/04/25 17:11:37 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller:latest
-2018/04/25 17:11:37 mounted sha256:dc0dd55edef1443e976c835825479c3dc713bb689547f8a170f8a0d14f9ff734
-2018/04/25 17:11:37 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
-2018/04/25 17:11:37 mounted sha256:fbc44e14a1d848ed485b5c3f03611c3e21aaa197fcba579255e5f8416a1b7172
-2018/04/25 17:11:38 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller:latest
-2018/04/25 17:11:38 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/controller@sha256:78794915fca48d0c4b339dc1df91a72f1e4bc6a7b33beaeef8aecda0947d5d31
-clusterrolebinding "warmimage-controller-admin" configured
-deployment "warmimage-controller" unchanged
-namespace "warmimage-system" configured
-serviceaccount "warmimage-controller" unchanged
-customresourcedefinition "warmimages.mattmoor.io" configured
+$ ko apply -f config/
+2018/07/19 14:56:41 Using base gcr.io/distroless/base:latest for github.com/mattmoor/warm-image/cmd/sleeper
+2018/07/19 14:56:42 Publishing us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest
+2018/07/19 14:56:43 mounted blob: sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
+2018/07/19 14:56:43 mounted blob: sha256:59df9d5b488aea2753ab7774ae41a9a3e96903f87ac699f3505960e744f36f7d
+2018/07/19 14:56:43 mounted blob: sha256:739b3deec2edb17c512f507894c55c2681f9724191d820cdc01f668330724ca7
+2018/07/19 14:56:44 us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest: digest: sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326 size: 592
+2018/07/19 14:56:44 Published us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37@sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326
+2018/07/19 14:56:45 Using base gcr.io/distroless/base:latest for github.com/mattmoor/warm-image/cmd/controller
+2018/07/19 14:56:46 Publishing us.gcr.io/my-project/controller-9e91872fd7c48124dbe6ea83944b87e9:latest
+2018/07/19 14:56:46 mounted blob: sha256:007782ba6738188a59bf21b4d8e974f218615ee948c6357535d07e7248b2a560
+2018/07/19 14:56:46 mounted blob: sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
+2018/07/19 14:56:46 mounted blob: sha256:7fec050f965d7fba3de4bd19739746dce5a5125331b7845bf02185ff5d4cc374
+2018/07/19 14:56:47 us.gcr.io/my-project/controller-9e91872fd7c48124dbe6ea83944b87e9:latest: digest: sha256:5a81029bb0cfd519c321aeeea2bc1b7dc6488b6c72003d3613442b4d5e4ed14d size: 593
+2018/07/19 14:56:47 Published us.gcr.io/my-project/controller-9e91872fd7c48124dbe6ea83944b87e9@sha256:5a81029bb0cfd519c321aeeea2bc1b7dc6488b6c72003d3613442b4d5e4ed14d
+namespace/warmimage-system configured
+clusterrolebinding.rbac.authorization.k8s.io/warmimage-controller-admin configured
+deployment.apps/warmimage-controller unchanged
+serviceaccount/warmimage-controller unchanged
+customresourcedefinition.apiextensions.k8s.io/warmimages.mattmoor.io configured
 ```
 
 ## Usage
@@ -126,13 +123,26 @@ an argument. It prints the images' published digests after each image is publish
 
 ```shell
 $ ko publish github.com/mattmoor/warm-image/cmd/sleeper
-2018/04/25 17:11:28 Go building github.com/mattmoor/warm-image/cmd/sleeper
-2018/04/25 17:11:29 Publishing gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 mounted sha256:eb05f3dbdb543cc610527248690575bacbbcebabe6ecf665b189cf18b541e3ca
-2018/04/25 17:11:30 mounted sha256:3ca7d60fa89dc8a1faea3046fd3516f23dab93489f3888ae539df4abc0973e52
-2018/04/25 17:11:30 mounted sha256:e2cc7c829942a768015dbcfdad7205c104cb85b84a79573555a8f4381b98110c
-2018/04/25 17:11:30 pushed gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper:latest
-2018/04/25 17:11:30 Published gcr.io/my-project/github.com/mattmoor/warm-image/cmd/sleeper@sha256:193acdbeff1ea9f105f49d97a6ceb7adbd30b3d64a8b9949382f4be9569cd06d
+2018/07/19 14:57:34 Using base gcr.io/distroless/base:latest for github.com/mattmoor/warm-image/cmd/sleeper
+2018/07/19 14:57:35 Publishing us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest
+2018/07/19 14:57:35 mounted blob: sha256:739b3deec2edb17c512f507894c55c2681f9724191d820cdc01f668330724ca7
+2018/07/19 14:57:35 mounted blob: sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
+2018/07/19 14:57:35 mounted blob: sha256:59df9d5b488aea2753ab7774ae41a9a3e96903f87ac699f3505960e744f36f7d
+2018/07/19 14:57:36 us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest: digest: sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326 size: 592
+2018/07/19 14:57:36 Published us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37@sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326
+```
+
+`ko publish` also supports relative import paths, when in the context of a repo on `GOPATH`.
+
+```shell
+$ ko publish ./cmd/sleeper
+2018/07/19 14:58:16 Using base gcr.io/distroless/base:latest for github.com/mattmoor/warm-image/cmd/sleeper
+2018/07/19 14:58:16 Publishing us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest
+2018/07/19 14:58:17 mounted blob: sha256:59df9d5b488aea2753ab7774ae41a9a3e96903f87ac699f3505960e744f36f7d
+2018/07/19 14:58:17 mounted blob: sha256:739b3deec2edb17c512f507894c55c2681f9724191d820cdc01f668330724ca7
+2018/07/19 14:58:17 mounted blob: sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
+2018/07/19 14:58:18 us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37:latest: digest: sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326 size: 592
+2018/07/19 14:58:18 Published us.gcr.io/my-project/sleeper-ebdb8b8b13d4bbe1d3592de055016d37@sha256:6c7b96a294cad3ce613aac23c8aca5f9dd12a894354ab276c157fb5c1c2e3326
 ```
 
 ### `ko resolve`
@@ -162,12 +172,43 @@ spec:
     spec:
       containers:
       - name: hello-world
+        # This is the digest of the published image containing the go binary.
+        image: gcr.io/your-project/helloworld-badf00d@sha256:deadbeef
+        ports:
+        - containerPort: 8080
+```
+
+Some Docker Registries (e.g. gcr.io) support multi-level repository names.  For
+these registries, it is often useful for discoverability and provenance to
+preserve the full import path, for this we expose `--preserve-import-paths`,
+or `-P` for short.
+
+```shell
+# Command
+export PROJECT_ID=$(gcloud config get-value core/project)
+export KO_DOCKER_REPO="gcr.io/${PROJECT_ID}"
+ko resolve -P -f deployment.yaml
+
+# Output
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: hello-world
         # This is the digest of the published image containing the go binary
         # at the embedded import path.
         image: gcr.io/your-project/github.com/mattmoor/examples/http/cmd/helloworld@sha256:deadbeef
         ports:
         - containerPort: 8080
 ```
+
+It is notable that this is not the default (anymore) because certain popular
+registries (including Docker Hub) do not support multi-level repository names.
 
 ### `ko apply`
 
@@ -184,31 +225,6 @@ to whatever `kubectl` context is active.
 
 `ko delete` simply passes through to `kubectl delete`. It is exposed purely out
 of convenience for cleaning up resources created through `ko apply`.
-
-
-## With DockerHub
-
-Unfortunately, DockerHub does not support this sort of multi-level names, so you may see an error like:
-
-```shell
-$ KO_DOCKER_REPO=docker.io/mattmoor ko publish ./cmd/crane
-2018/07/19 03:25:56 Using base gcr.io/distroless/base:latest for github.com/google/go-containerregistry/cmd/crane
-2018/07/19 03:25:56 Publishing index.docker.io/mattmoor/github.com/google/go-containerregistry/cmd/crane:latest
-2018/07/19 03:25:57 error publishing github.com/google/go-containerregistry/cmd/crane: UNAUTHORIZED: "authentication required"
-```
-
-To support this, we have a flag that will flatten the import path to `{package}-{hash of import path}`:
-
-```shell
-$ KO_DOCKER_REPO=docker.io/mattmoor ko publish --flat ./cmd/crane
-2018/07/19 03:27:50 Using base gcr.io/distroless/base:latest for github.com/google/go-containerregistry/cmd/crane
-2018/07/19 03:27:51 Publishing index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f:latest
-2018/07/19 03:27:53 pushed blob sha256:edb0321a975b7d1ab56e0318449734cf66b1eb840fe8d4e3d731ebfdbadc77b7
-2018/07/19 03:27:54 pushed blob sha256:ea67e6e9b37c7641c0af30e7c3a1c121a98bedc81de5248f0ffa32a762b41844
-2018/07/19 03:27:55 pushed blob sha256:57752e7f9593cbfb7101af994b136a369ecc8174332866622db32a264f3fbefd
-2018/07/19 03:27:55 index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f:latest: digest: sha256:fae03fbb07136f37a0991629201ec6862ca232502dd2bee9ed6ce85cdb26296c size: 592
-2018/07/19 03:27:55 Published index.docker.io/mattmoor/crane-5b4c7912e1f3680ea9ead8164184577f@sha256:fae03fbb07136f37a0991629201ec6862ca232502dd2bee9ed6ce85cdb26296c
-```
 
 
 ## With `minikube`
@@ -242,6 +258,7 @@ use `imagePullPolicy: IfNotPresent`, which should work well with `ko` in
 all contexts.
 
 Images will appear in the Docker daemon as `ko.local/import.path.com/foo/cmd/bar`.
+With `--local` import paths are always preserved (see `--preserve-import-paths`).
 
 ## Configuration via `.ko.yaml`
 
@@ -303,6 +320,10 @@ export PROJECT_ID=<YOUR RELEASE PROJECT>
 export KO_DOCKER_REPO="gcr.io/${PROJECT_ID}"
 ko resolve -f config/ > release.yaml
 ```
+
+> Note that in this context it is recommended that you also provide `-P`, if
+> supported by your Docker registry. This improves users' ability to tie release
+> binaries back to their source.
 
 This will publish all of the binary components as container images to
 `gcr.io/my-releases/...` and create a `release.yaml` file containing all of the

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -64,6 +64,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 	})
 
 	lo := &LocalOptions{}
+	no := &NameOptions{}
 	fo := &FilenameOptions{}
 	apply := &cobra.Command{
 		Use:   "apply -f FILENAME",
@@ -86,7 +87,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO(mattmoor): Use io.Pipe to avoid buffering the whole thing.
 			buf := bytes.NewBuffer(nil)
-			resolveFilesToWriter(fo, lo, buf)
+			resolveFilesToWriter(fo, no, lo, buf)
 
 			// Issue a "kubectl apply" command reading from stdin,
 			// to which we will pipe the resolved files.
@@ -106,6 +107,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 		},
 	}
 	addLocalArg(apply, lo)
+	addNamingArgs(apply, no)
 	addFileArg(apply, fo)
 	topLevel.AddCommand(apply)
 
@@ -126,10 +128,11 @@ func addKubeCommands(topLevel *cobra.Command) {
   ko resolve -L -f config/`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			resolveFilesToWriter(fo, lo, os.Stdout)
+			resolveFilesToWriter(fo, no, lo, os.Stdout)
 		},
 	}
 	addLocalArg(resolve, lo)
+	addNamingArgs(resolve, no)
 	addFileArg(resolve, fo)
 	topLevel.AddCommand(resolve)
 
@@ -150,9 +153,10 @@ func addKubeCommands(topLevel *cobra.Command) {
   ko publish -L github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			publishImages(args, lo)
+			publishImages(args, no, lo)
 		},
 	}
 	addLocalArg(publish, lo)
+	addNamingArgs(publish, no)
 	topLevel.AddCommand(publish)
 }

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -73,16 +73,24 @@ func addKubeCommands(topLevel *cobra.Command) {
 		Example: `
   # Build and publish import path references to a Docker
   # Registry as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # Then, feed the resulting yaml into "kubectl apply".
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local and --preserve-import-paths were passed.
+  ko apply -f config/
+
+  # Build and publish import path references to a Docker
+  # Registry preserving import path names as:
   #   ${KO_DOCKER_REPO}/<import path>
   # Then, feed the resulting yaml into "kubectl apply".
-  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
-  ko apply -f config/
+  ko apply --preserve-import-paths -f config/
 
   # Build and publish import path references to a Docker
   # daemon as:
   #   ko.local/<import path>
-  # Then, feed the resulting yaml into "kubectl apply"
-  ko apply -L -f config/`,
+  # Then, feed the resulting yaml into "kubectl apply".
+  # This always preserves import paths.
+  ko apply --local -f config/`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO(mattmoor): Use io.Pipe to avoid buffering the whole thing.
@@ -118,14 +126,23 @@ func addKubeCommands(topLevel *cobra.Command) {
 		Example: `
   # Build and publish import path references to a Docker
   # Registry as:
-  #   ${KO_DOCKER_REPO}/<import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local and --preserve-import-paths were passed.
   ko resolve -f config/
+
+  # Build and publish import path references to a Docker
+  # Registry preserving import path names as:
+  #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local was passed.
+  ko resolve --preserve-import-paths -f config/
 
   # Build and publish import path references to a Docker
   # daemon as:
   #   ko.local/<import path>
-  ko resolve -L -f config/`,
+  # This always preserves import paths.
+  ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			resolveFilesToWriter(fo, no, lo, os.Stdout)
@@ -143,14 +160,28 @@ func addKubeCommands(topLevel *cobra.Command) {
 		Example: `
   # Build and publish import path references to a Docker
   # Registry as:
-  #   ${KO_DOCKER_REPO}/<import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if -L were passed.
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local and --preserve-import-paths were passed.
   ko publish github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
+
+  # Build and publish a relative import path as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local and --preserve-import-paths were passed.
+  ko publish ./cmd/blah
+
+  # Build and publish a relative import path as:
+  #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if
+  # --local was passed.
+  ko publish --preserve-import-paths ./cmd/blah
 
   # Build and publish import path references to a Docker
   # daemon as:
   #   ko.local/<import path>
-  ko publish -L github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
+  # This always preserves import paths.
+  ko publish --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			publishImages(args, no, lo)

--- a/cmd/ko/flatname.go
+++ b/cmd/ko/flatname.go
@@ -23,16 +23,20 @@ import (
 )
 
 type NameOptions struct {
-	Flatten bool
+	PreserveImportPaths bool
 }
 
 func addNamingArgs(cmd *cobra.Command, no *NameOptions) {
-	cmd.Flags().BoolVarP(&no.Flatten, "flat", "F", no.Flatten,
-		"Whether to flatten import paths to a single path segment.")
+	cmd.Flags().BoolVarP(&no.PreserveImportPaths, "preserve-import-paths", "P", no.PreserveImportPaths,
+		"Whether to preserve the full import path after KO_DOCKER_REPO.")
 }
 
 func packageWithMD5(importpath string) string {
 	hasher := md5.New()
 	hasher.Write([]byte(importpath))
 	return filepath.Base(importpath) + "-" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+func preserveImportPath(importpath string) string {
+	return importpath
 }

--- a/cmd/ko/flatname.go
+++ b/cmd/ko/flatname.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+type NameOptions struct {
+	Flatten bool
+}
+
+func addNamingArgs(cmd *cobra.Command, no *NameOptions) {
+	cmd.Flags().BoolVarP(&no.Flatten, "flat", "F", no.Flatten,
+		"Whether to flatten import paths to a single path segment.")
+}
+
+func packageWithMD5(importpath string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(importpath))
+	return filepath.Base(importpath) + "-" + hex.EncodeToString(hasher.Sum(nil))
+}

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -80,7 +80,9 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 			}
 			opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain)}
-			if no.Flatten {
+			if no.PreserveImportPaths {
+				opts = append(opts, publish.WithNamer(preserveImportPath))
+			} else {
 				opts = append(opts, publish.WithNamer(packageWithMD5))
 			}
 			pub, err = publish.NewDefault(repoName, opts...)

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -39,7 +39,7 @@ func qualifyLocalImport(importpath, gopathsrc, pwd string) (string, error) {
 	return filepath.Join(strings.TrimPrefix(pwd, gopathsrc+string(filepath.Separator)), importpath), nil
 }
 
-func publishImages(importpaths []string, lo *LocalOptions) {
+func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 	opt, err := gobuildOptions()
 	if err != nil {
 		log.Fatalf("error setting up builder options: %v", err)
@@ -76,11 +76,14 @@ func publishImages(importpaths []string, lo *LocalOptions) {
 		if lo.Local || repoName == publish.LocalDomain {
 			pub = publish.NewDaemon(daemon.WriteOptions{})
 		} else {
-			repo, err := name.NewRepository(repoName, name.WeakValidation)
-			if err != nil {
+			if _, err := name.NewRepository(repoName, name.WeakValidation); err != nil {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 			}
-			pub, err = publish.NewDefault(repo, publish.WithAuthFromKeychain(authn.DefaultKeychain))
+			opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain)}
+			if no.Flatten {
+				opts = append(opts, publish.WithNamer(packageWithMD5))
+			}
+			pub, err = publish.NewDefault(repoName, opts...)
 			if err != nil {
 				log.Fatalf("error setting up default image publisher: %v", err)
 			}

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -97,7 +97,9 @@ func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Optio
 		}
 
 		opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain)}
-		if no.Flatten {
+		if no.PreserveImportPaths {
+			opts = append(opts, publish.WithNamer(preserveImportPath))
+		} else {
 			opts = append(opts, publish.WithNamer(packageWithMD5))
 		}
 

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -44,7 +44,7 @@ func gobuildOptions() ([]build.Option, error) {
 	return opts, nil
 }
 
-func resolveFilesToWriter(fo *FilenameOptions, lo *LocalOptions, out io.Writer) {
+func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions, out io.Writer) {
 	fs, err := enumerateFiles(fo)
 	if err != nil {
 		log.Fatalf("error enumerating files: %v", err)
@@ -61,7 +61,7 @@ func resolveFilesToWriter(fo *FilenameOptions, lo *LocalOptions, out io.Writer) 
 		go func(f string) {
 			defer wg.Done()
 
-			b, err := resolveFile(f, lo, opt...)
+			b, err := resolveFile(f, no, lo, opt...)
 			if err != nil {
 				log.Fatalf("error processing import paths in %q: %v", f, err)
 			}
@@ -85,18 +85,23 @@ func resolveFilesToWriter(fo *FilenameOptions, lo *LocalOptions, out io.Writer) 
 	}
 }
 
-func resolveFile(f string, lo *LocalOptions, opt ...build.Option) ([]byte, error) {
+func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Option) ([]byte, error) {
 	var pub publish.Interface
 	repoName := os.Getenv("KO_DOCKER_REPO")
 	if lo.Local || repoName == publish.LocalDomain {
 		pub = publish.NewDaemon(daemon.WriteOptions{})
 	} else {
-		repo, err := name.NewRepository(repoName, name.WeakValidation)
+		_, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {
 			return nil, fmt.Errorf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 		}
 
-		pub, err = publish.NewDefault(repo, publish.WithAuthFromKeychain(authn.DefaultKeychain))
+		opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain)}
+		if no.Flatten {
+			opts = append(opts, publish.WithNamer(packageWithMD5))
+		}
+
+		pub, err = publish.NewDefault(repoName, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ko/publish/options.go
+++ b/pkg/ko/publish/options.go
@@ -46,7 +46,7 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 	return func(i *defaultOpener) error {
 		// We parse this lazily because it is a repository prefix, which
 		// means that docker.io/mattmoor actually gets interpreted as
-		// dockerio/library/mattmoor, which gets tricky when we start
+		// docker.io/library/mattmoor, which gets tricky when we start
 		// appending things to it in the publisher.
 		repo, err := name.NewRepository(i.base, name.WeakValidation)
 		if err != nil {

--- a/pkg/ko/publish/options.go
+++ b/pkg/ko/publish/options.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 // WithTransport is a functional option for overriding the default transport
@@ -43,7 +44,15 @@ func WithAuth(auth authn.Authenticator) Option {
 // authenticator on a default publisher using an authn.Keychain
 func WithAuthFromKeychain(keys authn.Keychain) Option {
 	return func(i *defaultOpener) error {
-		auth, err := keys.Resolve(i.base.Registry)
+		// We parse this lazily because it is a repository prefix, which
+		// means that docker.io/mattmoor actually gets interpreted as
+		// dockerio/library/mattmoor, which gets tricky when we start
+		// appending things to it in the publisher.
+		repo, err := name.NewRepository(i.base, name.WeakValidation)
+		if err != nil {
+			return err
+		}
+		auth, err := keys.Resolve(repo.Registry)
 		if err != nil {
 			return err
 		}
@@ -51,6 +60,15 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		i.auth = auth
+		return nil
+	}
+}
+
+// WithNamer is a functional option for overriding the image naming behavior
+// in our default publisher.
+func WithNamer(n Namer) Option {
+	return func(i *defaultOpener) error {
+		i.namer = n
 		return nil
 	}
 }

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -79,7 +79,7 @@ func NewRepository(name string, strict Strictness) (Repository, error) {
 	if len(parts) == 2 && (strings.ContainsRune(parts[0], '.') || strings.ContainsRune(parts[0], ':')) {
 		// The first part of the repository is treated as the registry domain
 		// iff it contains a '.' or ':' character, otherwise it is all repository
-		// and the domain defaults to DockerHub.
+		// and the domain defaults to Docker Hub.
 		registry = parts[0]
 		repo = parts[1]
 	}


### PR DESCRIPTION
Add a functional option to `pkg/ko/publish` to control image names.

To enable the broadest possible support out-of-the-box, this changes our default naming behavior to use shortened names: `{package}-{hash of full import path}`.

The current behavior, which yields better discoverability, can be restored by passing `--preserve-import-paths` or `-P`.

I have verified with this flag that I can publish to DockerHub via `ko`.

Fixes: https://github.com/google/go-containerregistry/issues/160