### PR TITLE
Fix bug where ko layers didn't include tar trailers

### DIFF
--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -115,7 +115,7 @@ func build(ip string) (string, error) {
 	return file, nil
 }
 
-func tarBinary(binary string) (io.Reader, error) {
+func tarBinary(binary string) (*bytes.Buffer, error) {
 	buf := bytes.NewBuffer(nil)
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
@@ -160,7 +160,7 @@ func kodataPath(s string) (string, error) {
 // Where kodata lives in the image.
 const kodataRoot = "/var/run/ko"
 
-func tarKoData(importpath string) (io.Reader, error) {
+func tarKoData(importpath string) (*bytes.Buffer, error) {
 	buf := bytes.NewBuffer(nil)
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
@@ -239,8 +239,9 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+	dataLayerBytes := dataLayerBuf.Bytes()
 	dataLayer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return v1util.NopReadCloser(dataLayerBuf), nil
+		return v1util.NopReadCloser(bytes.NewBuffer(dataLayerBytes)), nil
 	})
 	if err != nil {
 		return nil, err
@@ -252,8 +253,9 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+	binaryLayerBytes := binaryLayerBuf.Bytes()
 	binaryLayer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return v1util.NopReadCloser(binaryLayerBuf), nil
+		return v1util.NopReadCloser(bytes.NewBuffer(binaryLayerBytes)), nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -107,11 +107,6 @@ func TestGoBuildNoKoData(t *testing.T) {
 		t.Fatalf("Layers() = %v", err)
 	}
 
-	dig, err := img.Digest()
-	if err != nil {
-		t.Fatalf("Digest() = %v", err)
-	}
-
 	// Check that we have the expected number of layers.
 	t.Run("check layer count", func(t *testing.T) {
 		// We get a layer for the go binary and a layer for the kodata/
@@ -122,15 +117,16 @@ func TestGoBuildNoKoData(t *testing.T) {
 
 	// Check that rebuilding the image again results in the same image digest.
 	t.Run("check determinism", func(t *testing.T) {
-		img2, err := ng.Build(filepath.Join(importpath, "cmd", "crane"))
-		if err != nil {
-			t.Fatalf("Build() = %v", err)
+		expectedHash := v1.Hash{
+			Algorithm: "sha256",
+			Hex:       "a688c9bc444d0a34cbc24abd62aa2fa263f61f2060963bb7a4fc3fa92075a2bf",
 		}
+		appLayer := ls[baseLayers+1]
 
-		if got, err := img2.Digest(); err != nil {
-			t.Fatalf("Digest() = %v", err)
-		} else if got != dig {
-			t.Errorf("Digest() = %v, want %v", got, dig)
+		if got, err := appLayer.Digest(); err != nil {
+			t.Errorf("Digest() = %v", err)
+		} else if got != expectedHash {
+			t.Errorf("Digest() = %v, want %v", got, expectedHash)
 		}
 	})
 
@@ -188,11 +184,6 @@ func TestGoBuild(t *testing.T) {
 		t.Fatalf("Layers() = %v", err)
 	}
 
-	dig, err := img.Digest()
-	if err != nil {
-		t.Fatalf("Digest() = %v", err)
-	}
-
 	// Check that we have the expected number of layers.
 	t.Run("check layer count", func(t *testing.T) {
 		// We get a layer for the go binary and a layer for the kodata/
@@ -203,20 +194,32 @@ func TestGoBuild(t *testing.T) {
 
 	// Check that rebuilding the image again results in the same image digest.
 	t.Run("check determinism", func(t *testing.T) {
-		img2, err := ng.Build(filepath.Join(importpath, "cmd", "ko", "test"))
-		if err != nil {
-			t.Fatalf("Build() = %v", err)
+		expectedHash := v1.Hash{
+			Algorithm: "sha256",
+			Hex:       "71912d718600c5a2b8db3a127a14073bba61dded0dac8e1a6ebdeb4a37f2ce8d",
 		}
+		appLayer := ls[baseLayers+1]
 
-		if got, err := img2.Digest(); err != nil {
-			t.Fatalf("Digest() = %v", err)
-		} else if got != dig {
-			t.Errorf("Digest() = %v, want %v", got, dig)
+		if got, err := appLayer.Digest(); err != nil {
+			t.Errorf("Digest() = %v", err)
+		} else if got != expectedHash {
+			t.Errorf("Digest() = %v, want %v", got, expectedHash)
 		}
 	})
 
 	t.Run("check app layer contents", func(t *testing.T) {
-		appLayer := ls[baseLayers+1]
+		expectedHash := v1.Hash{
+			Algorithm: "sha256",
+			Hex:       "63b6e090921b79b61e7f5fba44d2ea0f81215d9abac3d005dda7cb9a1f8a025d",
+		}
+		appLayer := ls[baseLayers]
+
+		if got, err := appLayer.Digest(); err != nil {
+			t.Errorf("Digest() = %v", err)
+		} else if got != expectedHash {
+			t.Errorf("Digest() = %v, want %v", got, expectedHash)
+		}
+
 		r, err := appLayer.Uncompressed()
 		if err != nil {
 			t.Errorf("Uncompressed() = %v", err)


### PR DESCRIPTION
Because `buf.Bytes()` was called before `defer tw.Close()` in `tarKoData` and `tarBinary`, the returned `[]byte` didn't include tar trailer data added by `tw.Close()`.

Instead, return the `bytes.Buffer` and get its `Bytes()` after the func has returned and `tw.Close()` has been called.

Go's tar package seems to handle trailer-less tar data just fine, as evidenced by the fact that our tests and Docker itself had no problem with these images, but the Python implementation failed to extract layers without the trailer data.