### PR TITLE
Fix anonymous credential fallback when using keychain credentials.

### DIFF
--- a/pkg/authn/helper.go
+++ b/pkg/authn/helper.go
@@ -76,7 +76,7 @@ func (h *helper) Authorization() (string, error) {
 
 	// If we see this specific message, it means the domain wasn't found
 	// and we should fall back on anonymous auth.
-	output := out.String()
+	output := strings.TrimSpace(out.String())
 	if output == magicNotFoundMessage {
 		return Anonymous.Authorization()
 	}


### PR DESCRIPTION
The credentials helpers used to access osxkeychain and thelike print to stdout which is promne to contain spacing characters. Trimming before comparing to the "magicNotFoundString" fixes a bug where a fallback to anonymous credentials did not work if the user was not logged into the respective registry at all.

Fixes #233