### PR TITLE
Remove Docker-Content-Digest check

### DIFF
--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -144,14 +144,15 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		if digest.String() != dgst.DigestStr() {
 			return nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), r.ref)
 		}
-	} else if checksum := resp.Header.Get("Docker-Content-Digest"); checksum != "" && checksum != digest.String() {
-		err := fmt.Errorf("manifest digest: %q does not match Docker-Content-Digest: %q for %q", digest, checksum, r.ref)
-		if r.ref.Context().RegistryStr() == name.DefaultRegistry {
-			// TODO(docker/distribution#2395): Remove this check.
-		} else {
-			// When pulling by tag, we can only validate that the digest matches what the registry told us it should be.
-			return nil, err
-		}
+	} else {
+		// Do nothing for tags; I give up.
+		//
+		// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
+		// but so many registries implement this incorrectly that it's not worth checking.
+		//
+		// For reference:
+		// https://github.com/docker/distribution/issues/2395
+		// https://github.com/GoogleContainerTools/kaniko/issues/298
 	}
 
 	r.manifest = manifest

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -114,12 +114,6 @@ func TestRawManifestDigests(t *testing.T) {
 		contentDigest: mustDigest(t, img).String(),
 		wantErr:       false,
 	}, {
-		name:          "right content-digest, wrong body, by tag",
-		ref:           "latest",
-		responseBody:  []byte("not even json"),
-		contentDigest: mustDigest(t, img).String(),
-		wantErr:       true,
-	}, {
 		name:          "right content-digest, wrong body, by digest",
 		ref:           mustDigest(t, img).String(),
 		responseBody:  []byte("not even json"),
@@ -130,7 +124,7 @@ func TestRawManifestDigests(t *testing.T) {
 		ref:           "latest",
 		responseBody:  mustRawManifest(t, img),
 		contentDigest: bogusDigest,
-		wantErr:       true,
+		wantErr:       false,
 	}, {
 		// NB: This succeeds! We don't care what the registry thinks.
 		name:          "right body, wrong content-digest, by digest",
@@ -138,12 +132,6 @@ func TestRawManifestDigests(t *testing.T) {
 		responseBody:  mustRawManifest(t, img),
 		contentDigest: bogusDigest,
 		wantErr:       false,
-	}, {
-		name:          "nothing matches anything",
-		ref:           "latest",
-		responseBody:  []byte("everything is wrong with this"),
-		contentDigest: bogusDigest,
-		wantErr:       true,
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
See https://github.com/GoogleContainerTools/kaniko/issues/298

Too many registries don't work correctly, and we don't want to hard-code
them all.