### PR TITLE
fix the example `Deployment` yaml in ko README

### DIFF
--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -47,8 +47,14 @@ kind: Deployment
 metadata:
   name: hello-world
 spec:
+  selector:
+    matchLabels:
+      foo: bar
   replicas: 1
   template:
+    metadata:
+      labels:
+        foo: bar
     spec:
       containers:
       - name: hello-world


### PR DESCRIPTION
The `Deployment` yaml now requires `spec.selector` and `spec.template.metadata.labels`, otherwise  there will be an error:

```
$ ko apply -f ko.yaml
The Deployment "hello-world" is invalid:
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`
2018/08/24 11:27:08 error executing "kubectl apply": exit status 1
```