### PR TITLE
Support short path for --local usage.

### DIFF
--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -76,7 +76,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
   # Then, feed the resulting yaml into "kubectl apply".
   # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local and --preserve-import-paths were passed.
+  # --local was passed.
   ko apply -f config/
 
   # Build and publish import path references to a Docker
@@ -89,9 +89,8 @@ func addKubeCommands(topLevel *cobra.Command) {
   # daemon as:
   #   ko.local/<import path>
   # Then, feed the resulting yaml into "kubectl apply".
-  # This always preserves import paths.
   ko apply --local -f config/
-  
+
   # Apply from stdin:
   cat config.yaml | ko apply -f -`,
 		Args: cobra.NoArgs,

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -88,20 +88,23 @@ func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions
 func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Option) ([]byte, error) {
 	var pub publish.Interface
 	repoName := os.Getenv("KO_DOCKER_REPO")
+
+	var namer publish.Namer
+	if no.PreserveImportPaths {
+		namer = preserveImportPath
+	} else {
+		namer = packageWithMD5
+	}
+
 	if lo.Local || repoName == publish.LocalDomain {
-		pub = publish.NewDaemon(daemon.WriteOptions{})
+		pub = publish.NewDaemon(daemon.WriteOptions{}, namer)
 	} else {
 		_, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {
 			return nil, fmt.Errorf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 		}
 
-		opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain)}
-		if no.PreserveImportPaths {
-			opts = append(opts, publish.WithNamer(preserveImportPath))
-		} else {
-			opts = append(opts, publish.WithNamer(packageWithMD5))
-		}
+		opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain), publish.WithNamer(namer)}
 
 		pub, err = publish.NewDefault(repoName, opts...)
 		if err != nil {

--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -30,12 +30,13 @@ const (
 
 // demon is intentionally misspelled to avoid name collision (and drive Jon nuts).
 type demon struct {
-	wo daemon.WriteOptions
+	wo    daemon.WriteOptions
+	namer Namer
 }
 
 // NewDaemon returns a new publish.Interface that publishes images to a container daemon.
-func NewDaemon(wo daemon.WriteOptions) Interface {
-	return &demon{wo}
+func NewDaemon(wo daemon.WriteOptions, namer Namer) Interface {
+	return &demon{wo, namer}
 }
 
 // Publish implements publish.Interface
@@ -47,7 +48,7 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 	if err != nil {
 		return nil, err
 	}
-	tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", LocalDomain, s, h.Hex), name.WeakValidation)
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", LocalDomain, d.namer(s), h.Hex), name.WeakValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -47,10 +47,10 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def := NewDaemon(daemon.WriteOptions{})
+	def := NewDaemon(daemon.WriteOptions{}, md5Hash)
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
-	} else if got, want := d.String(), "ko.local/"+importpath; !strings.HasPrefix(got, want) {
+	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {
 		t.Errorf("Publish() = %v, wanted prefix %v", got, want)
 	}
 }


### PR DESCRIPTION
To achieve parity between different environments, `--local` should also support short paths.

Fixes #275