### PR TITLE
Remove unused empty Options structs

### DIFF
--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/ko/build"
 	"github.com/google/go-containerregistry/pkg/ko/publish"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
 )
 
 func qualifyLocalImport(importpath, gopathsrc, pwd string) (string, error) {
@@ -82,7 +81,7 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 		}
 
 		if lo.Local || repoName == publish.LocalDomain {
-			pub = publish.NewDaemon(daemon.WriteOptions{}, namer)
+			pub = publish.NewDaemon(namer)
 		} else {
 			if _, err := name.NewRepository(repoName, name.WeakValidation); err != nil {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/ko/publish"
 	"github.com/google/go-containerregistry/pkg/ko/resolve"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
 )
 
 func gobuildOptions() ([]build.Option, error) {
@@ -97,7 +96,7 @@ func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Optio
 	}
 
 	if lo.Local || repoName == publish.LocalDomain {
-		pub = publish.NewDaemon(daemon.WriteOptions{}, namer)
+		pub = publish.NewDaemon(namer)
 	} else {
 		_, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -76,7 +76,7 @@ func doAppend(src, dst, tar, output string) {
 	}
 
 	if output != "" {
-		if err := tarball.WriteToFile(output, dstTag, image, &tarball.WriteOptions{}); err != nil {
+		if err := tarball.WriteToFile(output, dstTag, image); err != nil {
 			log.Fatalf("writing output %q: %v", output, err)
 		}
 		return
@@ -87,8 +87,7 @@ func doAppend(src, dst, tar, output string) {
 		log.Fatalf("getting creds for %q: %v", dstTag, err)
 	}
 
-	opts := remote.WriteOptions{}
-	if err := remote.Write(dstTag, image, dstAuth, http.DefaultTransport, opts); err != nil {
+	if err := remote.Write(dstTag, image, dstAuth, http.DefaultTransport); err != nil {
 		log.Fatalf("writing image %q: %v", dstTag, err)
 	}
 }

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -62,8 +62,7 @@ func doCopy(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", dstRef, err)
 	}
 
-	wo := remote.WriteOptions{}
-	if err := remote.Write(dstRef, img, dstAuth, http.DefaultTransport, wo); err != nil {
+	if err := remote.Write(dstRef, img, dstAuth, http.DefaultTransport); err != nil {
 		log.Fatalf("writing image %q: %v", dstRef, err)
 	}
 }

--- a/pkg/crane/delete.go
+++ b/pkg/crane/delete.go
@@ -48,7 +48,7 @@ func doDelete(_ *cobra.Command, args []string) {
 		log.Fatalf("getting creds for %q: %v", r, err)
 	}
 
-	if err := remote.Delete(r, auth, http.DefaultTransport, remote.DeleteOptions{}); err != nil {
+	if err := remote.Delete(r, auth, http.DefaultTransport); err != nil {
 		log.Fatalf("deleting image %q: %v", r, err)
 	}
 }

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -50,7 +50,7 @@ func pull(_ *cobra.Command, args []string) {
 		log.Fatalf("reading image %q: %v", t, err)
 	}
 
-	if err := tarball.WriteToFile(dst, t, i, &tarball.WriteOptions{}); err != nil {
+	if err := tarball.WriteToFile(dst, t, i); err != nil {
 		log.Fatalf("writing image %q: %v", dst, err)
 	}
 }

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -55,7 +55,7 @@ func push(_ *cobra.Command, args []string) {
 		log.Fatalf("reading image %q: %v", src, err)
 	}
 
-	if err := remote.Write(t, i, auth, http.DefaultTransport, remote.WriteOptions{}); err != nil {
+	if err := remote.Write(t, i, auth, http.DefaultTransport); err != nil {
 		log.Fatalf("writing image %q: %v", t, err)
 	}
 }

--- a/pkg/crane/rebase.go
+++ b/pkg/crane/rebase.go
@@ -75,7 +75,7 @@ func rebase(orig, oldBase, newBase, rebased string) {
 		log.Fatalf("parsing tag %q: %v", rebased, err)
 	}
 
-	rebasedImg, err := mutate.Rebase(origImg, oldBaseImg, newBaseImg, nil)
+	rebasedImg, err := mutate.Rebase(origImg, oldBaseImg, newBaseImg)
 	if err != nil {
 		log.Fatalf("rebasing: %v", err)
 	}
@@ -90,7 +90,7 @@ func rebase(orig, oldBase, newBase, rebased string) {
 		log.Fatalf("getting creds for %q: %v", rebasedTag, err)
 	}
 
-	if err := remote.Write(rebasedTag, rebasedImg, auth, http.DefaultTransport, remote.WriteOptions{}); err != nil {
+	if err := remote.Write(rebasedTag, rebasedImg, auth, http.DefaultTransport); err != nil {
 		log.Fatalf("writing image %q: %v", rebasedTag, err)
 	}
 	fmt.Print(dig.String())

--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -30,13 +30,12 @@ const (
 
 // demon is intentionally misspelled to avoid name collision (and drive Jon nuts).
 type demon struct {
-	wo    daemon.WriteOptions
 	namer Namer
 }
 
 // NewDaemon returns a new publish.Interface that publishes images to a container daemon.
-func NewDaemon(wo daemon.WriteOptions, namer Namer) Interface {
-	return &demon{wo, namer}
+func NewDaemon(namer Namer) Interface {
+	return &demon{namer}
 }
 
 // Publish implements publish.Interface
@@ -53,7 +52,7 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 		return nil, err
 	}
 	log.Printf("Loading %v", tag)
-	if _, err := daemon.Write(tag, img, d.wo); err != nil {
+	if _, err := daemon.Write(tag, img); err != nil {
 		return nil, err
 	}
 	log.Printf("Loaded %v", tag)

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -47,7 +47,7 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def := NewDaemon(daemon.WriteOptions{}, md5Hash)
+	def := NewDaemon(md5Hash)
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {

--- a/pkg/ko/publish/default.go
+++ b/pkg/ko/publish/default.go
@@ -92,7 +92,7 @@ func (d *defalt) Publish(img v1.Image, s string) (name.Reference, error) {
 		return nil, err
 	}
 	log.Printf("Publishing %v", tag)
-	if err := remote.Write(tag, img, d.auth, d.t, remote.WriteOptions{}); err != nil {
+	if err := remote.Write(tag, img, d.auth, d.t); err != nil {
 		return nil, err
 	}
 	h, err := img.Digest()

--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -44,14 +44,8 @@ var GetImageLoader = func() (ImageLoader, error) {
 	return cli, nil
 }
 
-// WriteOptions are used to expose optional information to guide or
-// control the image write.
-type WriteOptions struct {
-	// TODO(dlorenc): What kinds of knobs does the daemon expose?
-}
-
 // Write saves the image into the daemon as the given tag.
-func Write(tag name.Tag, img v1.Image, wo WriteOptions) (string, error) {
+func Write(tag name.Tag, img v1.Image) (string, error) {
 	cli, err := GetImageLoader()
 	if err != nil {
 		return "", err
@@ -59,7 +53,7 @@ func Write(tag name.Tag, img v1.Image, wo WriteOptions) (string, error) {
 
 	pr, pw := io.Pipe()
 	go func() {
-		pw.CloseWithError(tarball.Write(tag, img, &tarball.WriteOptions{}, pw))
+		pw.CloseWithError(tarball.Write(tag, img, pw))
 	}()
 
 	// write the image in docker save format first, then load it

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -28,7 +28,7 @@ import (
 
 type MockImageLoader struct{}
 
-func (m *MockImageLoader) ImageLoad(_ context.Context, _ io.Reader, _ bool) (types.ImageLoadResponse, error) {
+func (m *MockImageLoader) ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error) {
 	return types.ImageLoadResponse{
 		Body: ioutil.NopCloser(strings.NewReader("Loaded")),
 	}, nil
@@ -49,7 +49,7 @@ func TestWriteImage(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	response, err := Write(tag, image, WriteOptions{})
+	response, err := Write(tag, image)
 	if err != nil {
 		t.Errorf("Error writing image tar: %s", err.Error())
 	}

--- a/pkg/v1/mutate/rebase.go
+++ b/pkg/v1/mutate/rebase.go
@@ -21,11 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 )
 
-type RebaseOptions struct {
-	// TODO(jasonhall): Rebase seam hint.
-}
-
-func Rebase(orig, oldBase, newBase v1.Image, opts *RebaseOptions) (v1.Image, error) {
+func Rebase(orig, oldBase, newBase v1.Image) (v1.Image, error) {
 	// Verify that oldBase's layers are present in orig, otherwise orig is
 	// not based on oldBase at all.
 	origLayers, err := orig.Layers()

--- a/pkg/v1/mutate/rebase_test.go
+++ b/pkg/v1/mutate/rebase_test.go
@@ -85,7 +85,7 @@ func TestRebase(t *testing.T) {
 	newBaseLayerDigests := layerDigests(t, newBase)
 
 	// Rebase original image onto new base.
-	rebased, err := Rebase(orig, oldBase, newBase, nil)
+	rebased, err := Rebase(orig, oldBase, newBase)
 	if err != nil {
 		t.Fatalf("Rebase: %v", err)
 	}

--- a/pkg/v1/remote/delete.go
+++ b/pkg/v1/remote/delete.go
@@ -25,15 +25,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-// DeleteOptions are used to expose optional information to guide or
-// control the image deletion.
-type DeleteOptions struct {
-	// TODO(mattmoor): Fail on not found?
-	// TODO(mattmoor): Delete tag and manifest?
-}
-
 // Delete removes the specified image reference from the remote registry.
-func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper, do DeleteOptions) error {
+func Delete(ref name.Reference, auth authn.Authenticator, t http.RoundTripper) error {
 	scopes := []string{ref.Scope(transport.DeleteScope)}
 	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
 	if err != nil {

--- a/pkg/v1/remote/delete_test.go
+++ b/pkg/v1/remote/delete_test.go
@@ -52,7 +52,7 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("NewTag() = %v", err)
 	}
 
-	if err := Delete(tag, authn.Anonymous, http.DefaultTransport, DeleteOptions{}); err != nil {
+	if err := Delete(tag, authn.Anonymous, http.DefaultTransport); err != nil {
 		t.Errorf("Delete() = %v", err)
 	}
 }
@@ -84,7 +84,7 @@ func TestDeleteBadStatus(t *testing.T) {
 		t.Fatalf("NewTag() = %v", err)
 	}
 
-	if err := Delete(tag, authn.Anonymous, http.DefaultTransport, DeleteOptions{}); err == nil {
+	if err := Delete(tag, authn.Anonymous, http.DefaultTransport); err == nil {
 		t.Error("Delete() = nil; wanted error")
 	}
 }

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -28,16 +28,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-// WriteOptions are used to expose optional information to guide or
-// control the image write.
-type WriteOptions struct {
-	// TODO(mattmoor): Expose "threads" to limit parallelism?
-}
-
 // Write pushes the provided img to the specified image reference.
-func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.RoundTripper,
-	wo WriteOptions) error {
-
+func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.RoundTripper) error {
 	ls, err := img.Layers()
 	if err != nil {
 		return err
@@ -52,7 +44,6 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		ref:     ref,
 		client:  &http.Client{Transport: tr},
 		img:     img,
-		options: wo,
 	}
 
 	bs, err := img.BlobSet()
@@ -92,7 +83,6 @@ type writer struct {
 	ref     name.Reference
 	client  *http.Client
 	img     v1.Image
-	options WriteOptions
 }
 
 // url returns a url.Url for the specified path in the context of this remote image reference.

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -651,7 +651,7 @@ func TestWrite(t *testing.T) {
 		t.Fatalf("NewTag() = %v", err)
 	}
 
-	if err := Write(tag, img, authn.Anonymous, http.DefaultTransport, WriteOptions{}); err != nil {
+	if err := Write(tag, img, authn.Anonymous, http.DefaultTransport); err != nil {
 		t.Errorf("Write() = %v", err)
 	}
 }
@@ -701,7 +701,7 @@ func TestWriteWithErrors(t *testing.T) {
 		t.Fatalf("NewTag() = %v", err)
 	}
 
-	if err := Write(tag, img, authn.Anonymous, http.DefaultTransport, WriteOptions{}); err == nil {
+	if err := Write(tag, img, authn.Anonymous, http.DefaultTransport); err == nil {
 		t.Error("Write() = nil; wanted error")
 	} else if se, ok := err.(*Error); !ok {
 		t.Errorf("Write() = %T; wanted *remote.Error", se)

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -26,39 +26,33 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1"
 )
 
-// WriteOptions are used to expose optional information to guide or
-// control the image write.
-type WriteOptions struct {
-	// TODO(mattmoor): Whether to store things compressed?
-}
-
 // WriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.Write with a new file.
-func WriteToFile(p string, tag name.Tag, img v1.Image, wo *WriteOptions) error {
+func WriteToFile(p string, tag name.Tag, img v1.Image) error {
 	w, err := os.Create(p)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 
-	return Write(tag, img, wo, w)
+	return Write(tag, img, w)
 }
 
 // MultiWriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.MultiWrite with a new file.
-func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image, wo *WriteOptions) error {
+func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image) error {
 	w, err := os.Create(p)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 
-	return MultiWrite(tagToImage, wo, w)
+	return MultiWrite(tagToImage, w)
 }
 
 // Write is a wrapper to write a single image and tag to a tarball.
-func Write(tag name.Tag, img v1.Image, wo *WriteOptions, w io.Writer) error {
-	return MultiWrite(map[name.Tag]v1.Image{tag: img}, wo, w)
+func Write(tag name.Tag, img v1.Image, w io.Writer) error {
+	return MultiWrite(map[name.Tag]v1.Image{tag: img}, w)
 }
 
 // MultiWrite writes the contents of each image to the provided reader, in the compressed format.
@@ -66,7 +60,7 @@ func Write(tag name.Tag, img v1.Image, wo *WriteOptions, w io.Writer) error {
 // One manifest.json file at the top level containing information about several images.
 // One file for each layer, named after the layer's SHA.
 // One file for the config blob, named after its SHA.
-func MultiWrite(tagToImage map[name.Tag]v1.Image, wo *WriteOptions, w io.Writer) error {
+func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
 	tf := tar.NewWriter(w)
 	defer tf.Close()
 

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -45,7 +45,7 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating test tag.")
 	}
-	if err := WriteToFile(fp.Name(), tag, randImage, nil); err != nil {
+	if err := WriteToFile(fp.Name(), tag, randImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func TestMultiWriteSameImage(t *testing.T) {
 	tagToImage[tag2] = randImage
 
 	// Write the images with both tags to the tarball
-	if err := MultiWriteToFile(fp.Name(), tagToImage, nil); err != nil {
+	if err := MultiWriteToFile(fp.Name(), tagToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for tag := range tagToImage {
@@ -177,7 +177,7 @@ func TestMultiWriteDifferentImages(t *testing.T) {
 	tagToImage[tag2] = randImage2
 
 	// Write both images to the tarball.
-	if err := MultiWriteToFile(fp.Name(), tagToImage, nil); err != nil {
+	if err := MultiWriteToFile(fp.Name(), tagToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for tag, img := range tagToImage {


### PR DESCRIPTION
Lots of packages included empty `FooOptions` structs which we could use to allow callers to pass optional options to the methods.

In practice, these didn't add anything and just added a wart. Users had to pass `foo.FooOptions{}`, or `&foo.FooOptions{}`, or `nil` to lots of random methods. We weren't consistent about whether options should be accepted as a pointer or not, or whether absence of options should be expressed as a pointer to an empty struct, or `nil`.

If these methods want to add options in the future, they should do so using functional options, where we can add more options to the method args directly without breaking existing callers.