### PR TITLE
Add -p flag to crane config

### DIFF
--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -13,7 +13,8 @@ crane config [flags]
 ### Options
 
 ```
-  -h, --help   help for config
+  -h, --help     help for config
+  -p, --pretty   If true, pretty-print JSON
 ```
 
 ### SEE ALSO

--- a/pkg/crane/config.go
+++ b/pkg/crane/config.go
@@ -15,8 +15,10 @@
 package crane
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -24,23 +26,37 @@ import (
 func init() { Root.AddCommand(NewCmdConfig()) }
 
 func NewCmdConfig() *cobra.Command {
-	return &cobra.Command{
+	var pretty bool
+	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Get the config of an image",
 		Args:  cobra.ExactArgs(1),
-		Run:   config,
+		Run: func(_ *cobra.Command, args []string) {
+			config(args[0], pretty)
+		},
 	}
+	cmd.Flags().BoolVarP(&pretty, "pretty", "p", false, "If true, pretty-print JSON")
+	return cmd
 }
 
-func config(_ *cobra.Command, args []string) {
-	ref := args[0]
+func config(ref string, pretty bool) {
 	i, _, err := getImage(ref)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	config, err := i.RawConfigFile()
-	if err != nil {
-		log.Fatalln(err)
+	if !pretty {
+		config, err := i.RawConfigFile()
+		if err != nil {
+			log.Fatalln(err)
+		}
+		fmt.Print(string(config))
+	} else {
+		config, err := i.ConfigFile()
+		if err != nil {
+			log.Fatalln(err)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(config)
 	}
-	fmt.Print(string(config))
 }


### PR DESCRIPTION
I got sick of writing `crane config <foo> | python -m json.tool`

If you pass `-p`, the config JSON will be pretty-printed with indentation making it easier to read. The default is still printing the ugly-printed JSON which is actually stored in the blob and referenced by digest in the manifest.