### PR TITLE
Refresh Bearer token

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -46,38 +46,34 @@ var _ http.RoundTripper = (*bearerTransport)(nil)
 
 // RoundTrip implements http.RoundTripper
 func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
-	hdr, err := bt.bearer.Authorization()
-	if err != nil {
-		return nil, err
-	}
-
-	// http.Client handles redirects at a layer above the http.RoundTripper
-	// abstraction, so to avoid forwarding Authorization headers to places
-	// we are redirected, only set it when the authorization header matches
-	// the registry with which we are interacting.
-	if in.Host == bt.registry.RegistryStr() {
-		in.Header.Set("Authorization", hdr)
-	}
-	in.Header.Set("User-Agent", transportName)
-
-	res, err := bt.inner.RoundTrip(in)
-
-	// Perform a token refresh() and retry the request in case the token has expired
-	if err == nil && res.StatusCode == http.StatusUnauthorized {
-		if err = bt.refresh(); err != nil {
-			return nil, err
-		}
-		hdr, err = bt.bearer.Authorization()
+	sendRequest := func() (*http.Response, error) {
+		hdr, err := bt.bearer.Authorization()
 		if err != nil {
 			return nil, err
 		}
 
+		// http.Client handles redirects at a layer above the http.RoundTripper
+		// abstraction, so to avoid forwarding Authorization headers to places
+		// we are redirected, only set it when the authorization header matches
+		// the registry with which we are interacting.
 		if in.Host == bt.registry.RegistryStr() {
 			in.Header.Set("Authorization", hdr)
 		}
 		in.Header.Set("User-Agent", transportName)
+		return bt.inner.RoundTrip(in)
+	}
 
-		res, err = bt.inner.RoundTrip(in)
+	res, err := sendRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	// Perform a token refresh() and retry the request in case the token has expired
+	if res.StatusCode == http.StatusUnauthorized {
+		if err = bt.refresh(); err != nil {
+			return nil, err
+		}
+		return sendRequest()
 	}
 
 	return res, err


### PR DESCRIPTION
Currently, a `bearerTransport` requests only one token during it's lifetime. After that token expires, all further requests will fail (`401`).

This seems to be the root cause of https://github.com/GoogleContainerTools/kaniko/issues/245

This PR enables `bearerTransport.RoundTrip` to refresh an expired token and retry the request.