### PR TITLE
 compressedImageExtender.LayerByDigest properly finds config layer 

### DIFF
--- a/pkg/v1/partial/compressed.go
+++ b/pkg/v1/partial/compressed.go
@@ -125,6 +125,11 @@ func (i *compressedImageExtender) Layers() ([]v1.Layer, error) {
 
 // LayerByDigest implements v1.Image
 func (i *compressedImageExtender) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	if cfgName, err := i.ConfigName(); err != nil {
+		return nil, err
+	} else if cfgName == h {
+		return ConfigLayer(i)
+	}
 	cl, err := i.CompressedImageCore.LayerByDigest(h)
 	if err != nil {
 		return nil, err

--- a/pkg/v1/partial/configlayer_test.go
+++ b/pkg/v1/partial/configlayer_test.go
@@ -1,0 +1,97 @@
+package partial
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type testUIC struct {
+	configFile []byte
+}
+
+func (t testUIC) RawConfigFile() ([]byte, error) {
+	return t.configFile, nil
+}
+
+func (t testUIC) MediaType() (types.MediaType, error) {
+	return "", nil
+}
+
+func (t testUIC) LayerByDiffID(h v1.Hash) (UncompressedLayer, error) {
+	return nil, fmt.Errorf("no layer by diff ID %v", h)
+}
+
+func TestUncompressedLayerByDigest(t *testing.T) {
+	uic := testUIC{
+		configFile: []byte("{}"),
+	}
+	uie := &uncompressedImageExtender{
+		UncompressedImageCore: uic,
+	}
+	testLayerByDigestForConfigHash(t, uie)
+}
+
+type testCIC struct {
+	configFile []byte
+}
+
+func (t testCIC) RawConfigFile() ([]byte, error) {
+	return t.configFile, nil
+}
+
+func (t testCIC) MediaType() (types.MediaType, error) {
+	return "", nil
+}
+
+func (testCIC) RawManifest() ([]byte, error) {
+	return nil, nil
+}
+
+func (t testCIC) LayerByDigest(h v1.Hash) (CompressedLayer, error) {
+	return nil, fmt.Errorf("no layer by diff ID %v", h)
+}
+
+func TestCompressedLayersByDigest(t *testing.T) {
+	cic := testCIC{
+		configFile: []byte("{}"),
+	}
+	cie := &compressedImageExtender{
+		CompressedImageCore: cic,
+	}
+	testLayerByDigestForConfigHash(t, cie)
+}
+
+func testLayerByDigestForConfigHash(t *testing.T, image v1.Image) {
+	hash, err := image.ConfigName()
+	if err != nil {
+		t.Fatalf("Error getting config name: %v", err)
+	}
+
+	layer, err := image.LayerByDigest(hash)
+	if err != nil {
+		t.Fatalf("Error getting layer by digest: %v", err)
+	}
+
+	lr, err := layer.Uncompressed()
+	if err != nil {
+		t.Fatalf("Error getting uncompressed layer: %v", err)
+	}
+
+	cfgLayerBytes, err := ioutil.ReadAll(lr)
+	if err != nil {
+		t.Fatalf("Error reading config layer bytes: %v", err)
+	}
+
+	cfgFile, err := image.RawConfigFile()
+	if err != nil {
+		t.Fatalf("Error getting raw config file: %v", err)
+	}
+
+	if string(cfgFile) != string(cfgLayerBytes) {
+		t.Errorf("Config file layer doesn't match raw config file")
+	}
+}

--- a/pkg/v1/partial/configlayer_test.go
+++ b/pkg/v1/partial/configlayer_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 type testUIC struct {
+	UncompressedImageCore
 	configFile []byte
 }
 
@@ -17,81 +17,61 @@ func (t testUIC) RawConfigFile() ([]byte, error) {
 	return t.configFile, nil
 }
 
-func (t testUIC) MediaType() (types.MediaType, error) {
-	return "", nil
-}
-
-func (t testUIC) LayerByDiffID(h v1.Hash) (UncompressedLayer, error) {
-	return nil, fmt.Errorf("no layer by diff ID %v", h)
-}
-
-func TestUncompressedLayerByDigest(t *testing.T) {
-	uic := testUIC{
-		configFile: []byte("{}"),
-	}
-	uie := &uncompressedImageExtender{
-		UncompressedImageCore: uic,
-	}
-	testLayerByDigestForConfigHash(t, uie)
-}
-
 type testCIC struct {
+	CompressedImageCore
 	configFile []byte
-}
-
-func (t testCIC) RawConfigFile() ([]byte, error) {
-	return t.configFile, nil
-}
-
-func (t testCIC) MediaType() (types.MediaType, error) {
-	return "", nil
-}
-
-func (testCIC) RawManifest() ([]byte, error) {
-	return nil, nil
 }
 
 func (t testCIC) LayerByDigest(h v1.Hash) (CompressedLayer, error) {
 	return nil, fmt.Errorf("no layer by diff ID %v", h)
 }
 
-func TestCompressedLayersByDigest(t *testing.T) {
-	cic := testCIC{
-		configFile: []byte("{}"),
-	}
-	cie := &compressedImageExtender{
-		CompressedImageCore: cic,
-	}
-	testLayerByDigestForConfigHash(t, cie)
+func (t testCIC) RawConfigFile() ([]byte, error) {
+	return t.configFile, nil
 }
 
-func testLayerByDigestForConfigHash(t *testing.T, image v1.Image) {
-	hash, err := image.ConfigName()
-	if err != nil {
-		t.Fatalf("Error getting config name: %v", err)
+func TestConfigLayersByDigest(t *testing.T) {
+	cases := []v1.Image{
+		&compressedImageExtender{
+			CompressedImageCore: testCIC{
+				configFile: []byte("{}"),
+			},
+		},
+		&uncompressedImageExtender{
+			UncompressedImageCore: testUIC{
+				configFile: []byte("{}"),
+			},
+		},
 	}
 
-	layer, err := image.LayerByDigest(hash)
-	if err != nil {
-		t.Fatalf("Error getting layer by digest: %v", err)
-	}
+	for _, image := range cases {
+		hash, err := image.ConfigName()
+		if err != nil {
+			t.Fatalf("Error getting config name: %v", err)
+		}
 
-	lr, err := layer.Uncompressed()
-	if err != nil {
-		t.Fatalf("Error getting uncompressed layer: %v", err)
-	}
+		layer, err := image.LayerByDigest(hash)
+		if err != nil {
+			t.Fatalf("Error getting layer by digest: %v", err)
+		}
 
-	cfgLayerBytes, err := ioutil.ReadAll(lr)
-	if err != nil {
-		t.Fatalf("Error reading config layer bytes: %v", err)
-	}
+		lr, err := layer.Uncompressed()
+		if err != nil {
+			t.Fatalf("Error getting uncompressed layer: %v", err)
+		}
 
-	cfgFile, err := image.RawConfigFile()
-	if err != nil {
-		t.Fatalf("Error getting raw config file: %v", err)
-	}
+		cfgLayerBytes, err := ioutil.ReadAll(lr)
+		if err != nil {
+			t.Fatalf("Error reading config layer bytes: %v", err)
+		}
 
-	if string(cfgFile) != string(cfgLayerBytes) {
-		t.Errorf("Config file layer doesn't match raw config file")
+		cfgFile, err := image.RawConfigFile()
+		if err != nil {
+			t.Fatalf("Error getting raw config file: %v", err)
+		}
+
+		if string(cfgFile) != string(cfgLayerBytes) {
+			t.Errorf("Config file layer doesn't match raw config file")
+		}
 	}
 }


### PR DESCRIPTION
This behaviour mirrors `uncompressedImageExtender.LayerByDigest`.

Fixes #284 