### PR TITLE
Assume RFC1918 addresses are insecure registries

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -63,9 +64,27 @@ func (r Registry) Scope(string) string {
 	return "registry:catalog:*"
 }
 
+func (r Registry) isRFC1918() bool {
+	ipStr := strings.Split(r.Name(), ":")[0]
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+		_, block, _ := net.ParseCIDR(cidr)
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // Scheme returns https scheme for all the endpoints except localhost or when explicitly defined.
 func (r Registry) Scheme() string {
 	if r.insecure {
+		return "http"
+	}
+	if r.isRFC1918() {
 		return "http"
 	}
 	if strings.HasPrefix(r.Name(), "localhost:") {

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -136,6 +136,42 @@ func TestRegistryScopes(t *testing.T) {
 	}
 }
 
+func TestIsRFC1918(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		reg    string
+		result bool
+	}{{
+		reg:    "index.docker.io",
+		result: false,
+	}, {
+		reg:    "10.2.3.4:5000",
+		result: true,
+	}, {
+		reg:    "8.8.8.8",
+		result: false,
+	}, {
+		reg:    "172.16.3.4:3000",
+		result: true,
+	}, {
+		reg:    "192.168.3.4",
+		result: true,
+	}, {
+		reg:    "10.256.0.0:5000",
+		result: false,
+	}}
+	for _, test := range tests {
+		reg, err := NewRegistry(test.reg, WeakValidation)
+		if err != nil {
+			t.Errorf("NewRegistry(%s) = %v", test.reg, err)
+		}
+		got := reg.isRFC1918()
+		if got != test.result {
+			t.Errorf("isRFC1918(); got %v, want %v", got, test.result)
+		}
+	}
+}
+
 func TestRegistryScheme(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -161,6 +197,9 @@ func TestRegistryScheme(t *testing.T) {
 		scheme: "https",
 	}, {
 		domain: "::1",
+		scheme: "http",
+	}, {
+		domain: "10.2.3.4:5000",
 		scheme: "http",
 	}}
 


### PR DESCRIPTION
This change assumes RFC1918 addresses are insecure and use the
http scheme.  This is the same as we assume for .local addresses.

With this change images can be built from local insecure registries,
not just pushed.

Fix: #289

Signed-off-by: Berndt Jung <bjung@vmware.com>