### PR TITLE
Add remote.StreamableLayer which enables streaming layer uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language:
 
 go:
   - "1.10"
+  - "1.11"
 
 git:
   depth: 1

--- a/pkg/v1/remote/stream.go
+++ b/pkg/v1/remote/stream.go
@@ -35,22 +35,26 @@ type StreamableLayer struct {
 
 var _ v1.Layer = (*StreamableLayer)(nil)
 
+// ErrNotComputed is returned when the requested value is not yet computed
+// because the stream has not been consumed yet.
+var ErrNotComputed = errors.New("value not computed until stream is consumed")
+
 func (s *StreamableLayer) Digest() (v1.Hash, error) {
 	if s.digest == nil {
-		return v1.Hash{}, errors.New("digest not yet computed")
+		return v1.Hash{}, ErrNotComputed
 	}
 	return *s.digest, nil
 }
 
 func (s *StreamableLayer) DiffID() (v1.Hash, error) {
 	if s.diffID == nil {
-		return v1.Hash{}, errors.New("diffID not yet computed")
+		return v1.Hash{}, ErrNotComputed
 	}
 	return *s.diffID, nil
 }
 func (s *StreamableLayer) Size() (int64, error) {
 	if s.size == 0 {
-		return 0, errors.New("size not yet computed")
+		return 0, ErrNotComputed
 	}
 	return s.size, nil
 }

--- a/pkg/v1/remote/stream.go
+++ b/pkg/v1/remote/stream.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"errors"
+	"io"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+)
+
+type StreamableLayer struct {
+	Blob io.ReadCloser
+}
+
+var _ v1.Layer = (*StreamableLayer)(nil)
+
+func (s *StreamableLayer) Digest() (v1.Hash, error) {
+	return v1.Hash{}, errors.New("don't know digest of streamed layer")
+}
+
+func (s *StreamableLayer) DiffID() (v1.Hash, error) {
+	return v1.Hash{}, errors.New("don't know digest of streamed layer")
+}
+
+func (s *StreamableLayer) Uncompressed() (io.ReadCloser, error) {
+	return nil, errors.New("refusing to decompress streamed layer")
+}
+
+func (s *StreamableLayer) Compressed() (io.ReadCloser, error) { return s.Blob, nil }
+
+func (s *StreamableLayer) Size() (int64, error) {
+	return 0, errors.New("don't know size of streamed layer")
+}

--- a/pkg/v1/remote/stream_test.go
+++ b/pkg/v1/remote/stream_test.go
@@ -1,0 +1,142 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+)
+
+const (
+	n          = 10000
+	wantDigest = "sha256:4aaecd841543b43d8815fa086939ee183462c1fea721a16fd28c825aa1af571f"
+	wantDiffID = "sha256:27dd1f61b867b6a0f6e9d8a41c43231de52107e53ae424de8f847b821db4b711"
+)
+
+func TestStreamableLayerZeroes(t *testing.T) {
+	sl := NewStreamableLayer(ioutil.NopCloser(bytes.NewBufferString(strings.Repeat("a", n))))
+
+	// All methods should return zero data and no errors until the stream
+	// has been consumed.
+	if size, err := sl.Size(); err != nil {
+		t.Errorf("Size: %v", err)
+	} else if size != 0 {
+		t.Errorf("Size got %d, want 0", size)
+	}
+	if dig, err := sl.Digest(); err != nil {
+		t.Errorf("Digest: %v", err)
+	} else if dig.String() != (v1.Hash{}).String() {
+		t.Errorf("Digest got %v, want %v", dig, v1.Hash{})
+	}
+	if diffID, err := sl.DiffID(); err != nil {
+		t.Errorf("DiffID: %v", err)
+	} else if diffID.String() != (v1.Hash{}).String() {
+		t.Errorf("DiffID got %v, want %v", diffID, v1.Hash{})
+	}
+}
+
+func TestStreamableLayerCompressed(t *testing.T) {
+	sl := NewStreamableLayer(ioutil.NopCloser(bytes.NewBufferString(strings.Repeat("a", n))))
+
+	// This will consume the originally uncompressed data and produce
+	// compressed data, and closing will populate the StreamableLayer's
+	// digest, diffID and size.
+	rc, err := sl.Compressed()
+	if err != nil {
+		t.Fatalf("Compressed: %v", err)
+	}
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		t.Fatalf("Reading layer: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Now that the stream has been consumed, data should be available.
+	if dig, err := sl.Digest(); err != nil {
+		t.Errorf("Digest: %v", err)
+	} else if dig.String() != wantDigest {
+		t.Errorf("Digest got %q, want %q", dig, wantDigest)
+	}
+	if diffID, err := sl.DiffID(); err != nil {
+		t.Errorf("DiffID: %v", err)
+	} else if diffID.String() != wantDiffID {
+		t.Errorf("DiffID got %q, want %q", diffID, wantDiffID)
+	}
+	if size, err := sl.Size(); err != nil {
+		t.Errorf("Size: %v", err)
+	} else if size != int64(n) {
+		t.Errorf("Size got %d, want %d", size, n)
+	}
+}
+
+func TestStreamableLayerUncompressed(t *testing.T) {
+	sl := NewStreamableLayer(ioutil.NopCloser(bytes.NewBufferString(strings.Repeat("a", n))))
+
+	// This will consume the given ReadCloser, and closing will populate
+	// the StreamableLayer's digest, diffID and size.
+	rc, err := sl.Uncompressed()
+	if err != nil {
+		t.Fatalf("Compressed: %v", err)
+	}
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		t.Fatalf("Reading layer: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Now that the stream has been consumed, data should be available.
+	if dig, err := sl.Digest(); err != nil {
+		t.Errorf("Digest: %v", err)
+	} else if dig.String() != wantDigest {
+		t.Errorf("Digest got %q, want %q", dig, wantDigest)
+	}
+	if diffID, err := sl.DiffID(); err != nil {
+		t.Errorf("DiffID: %v", err)
+	} else if diffID.String() != wantDiffID {
+		t.Errorf("DiffID got %q, want %q", diffID, wantDiffID)
+	}
+	if size, err := sl.Size(); err != nil {
+		t.Errorf("Size: %v", err)
+	} else if size != int64(n) {
+		t.Errorf("Size got %d, want %d", size, n)
+	}
+}
+
+// Streaming a huge random layer through StreamableLayer computes its
+// digest/diffID/size, without buffering.
+func TestLargeStreamedLayer(t *testing.T) {
+	n := int64(100000000)
+	sl := NewStreamableLayer(ioutil.NopCloser(io.LimitReader(rand.Reader, n)))
+	rc, err := sl.Uncompressed()
+	if err != nil {
+		t.Fatalf("Uncompressed: %v", err)
+	}
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		t.Fatalf("Reading layer: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if dig, err := sl.Digest(); err != nil {
+		t.Errorf("Digest: %v", err)
+	} else if dig.String() == (v1.Hash{}).String() {
+		t.Errorf("Digest got %q, want anything else", (v1.Hash{}).String())
+	}
+	if diffID, err := sl.DiffID(); err != nil {
+		t.Errorf("DiffID: %v", err)
+	} else if diffID.String() == (v1.Hash{}).String() {
+		t.Errorf("DiffID got %q, want anything else", (v1.Hash{}).String())
+	}
+	if size, err := sl.Size(); err != nil {
+		t.Errorf("Size: %v", err)
+	} else if size != n {
+		t.Errorf("Size got %d, want %d", size, n)
+	}
+}

--- a/pkg/v1/remote/stream_test.go
+++ b/pkg/v1/remote/stream_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remote
 
 import (

--- a/pkg/v1/remote/stream_test.go
+++ b/pkg/v1/remote/stream_test.go
@@ -1,8 +1,10 @@
 package remote
 
 import (
+	"archive/tar"
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -17,25 +19,18 @@ const (
 	wantDiffID = "sha256:27dd1f61b867b6a0f6e9d8a41c43231de52107e53ae424de8f847b821db4b711"
 )
 
-func TestStreamableLayerZeroes(t *testing.T) {
+func TestStreamableLayerZero(t *testing.T) {
 	sl := NewStreamableLayer(ioutil.NopCloser(bytes.NewBufferString(strings.Repeat("a", n))))
 
-	// All methods should return zero data and no errors until the stream
-	// has been consumed.
-	if size, err := sl.Size(); err != nil {
-		t.Errorf("Size: %v", err)
-	} else if size != 0 {
-		t.Errorf("Size got %d, want 0", size)
+	// All methods should return errors until the stream has been consumed and closed.
+	if _, err := sl.Size(); err == nil {
+		t.Error("Size: got nil error, wanted error")
 	}
-	if dig, err := sl.Digest(); err != nil {
-		t.Errorf("Digest: %v", err)
-	} else if dig.String() != (v1.Hash{}).String() {
-		t.Errorf("Digest got %v, want %v", dig, v1.Hash{})
+	if _, err := sl.Digest(); err == nil {
+		t.Error("Digest: got nil error, wanted error")
 	}
-	if diffID, err := sl.DiffID(); err != nil {
-		t.Errorf("DiffID: %v", err)
-	} else if diffID.String() != (v1.Hash{}).String() {
-		t.Errorf("DiffID got %v, want %v", diffID, v1.Hash{})
+	if _, err := sl.DiffID(); err == nil {
+		t.Error("DiffID: got nil error, wanted error")
 	}
 }
 
@@ -138,5 +133,52 @@ func TestLargeStreamedLayer(t *testing.T) {
 		t.Errorf("Size: %v", err)
 	} else if size != n {
 		t.Errorf("Size got %d, want %d", size, n)
+	}
+}
+
+func TestStreamableLayerFromTarball(t *testing.T) {
+	pr, pw := io.Pipe()
+	tw := tar.NewWriter(pw)
+
+	go func() {
+		// "Stream" a bunch of files into the layer.
+		pw.CloseWithError(func() error {
+			for i := 0; i < 1000; i++ {
+				name := fmt.Sprintf("file-%d.txt", i)
+				body := fmt.Sprintf("i am file number %d", i)
+				if err := tw.WriteHeader(&tar.Header{
+					Name: name,
+					Mode: 0600,
+					Size: int64(len(body)),
+				}); err != nil {
+					return err
+				}
+				if _, err := tw.Write([]byte(body)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}())
+	}()
+
+	sl := NewStreamableLayer(pr)
+	rc, err := sl.Compressed()
+	if err != nil {
+		t.Fatalf("Compressed: %v", err)
+	}
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	wantDigest := "sha256:a50b9da8ea0a16cc6397af5cbb134ecbcd6e673fad3ea0a85b14146aae7de793"
+	got, err := sl.Digest()
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+	if got.String() != wantDigest {
+		t.Errorf("Digest: got %q, want %q", got.String(), wantDigest)
 	}
 }

--- a/pkg/v1/remote/stream_test.go
+++ b/pkg/v1/remote/stream_test.go
@@ -36,15 +36,16 @@ const (
 func TestStreamableLayerZero(t *testing.T) {
 	sl := NewStreamableLayer(ioutil.NopCloser(bytes.NewBufferString(strings.Repeat("a", n))))
 
-	// All methods should return errors until the stream has been consumed and closed.
-	if _, err := sl.Size(); err == nil {
-		t.Error("Size: got nil error, wanted error")
+	// All methods should return ErrNotComputed until the stream has been
+	// consumed and closed.
+	if _, err := sl.Size(); err != ErrNotComputed {
+		t.Errorf("Size: got %v, want %v", err, ErrNotComputed)
 	}
 	if _, err := sl.Digest(); err == nil {
-		t.Error("Digest: got nil error, wanted error")
+		t.Errorf("Digest: got %v, want %v", err, ErrNotComputed)
 	}
 	if _, err := sl.DiffID(); err == nil {
-		t.Error("DiffID: got nil error, wanted error")
+		t.Errorf("DiffID: got %v, want %v", err, ErrNotComputed)
 	}
 }
 

--- a/pkg/v1/remote/stream_test.go
+++ b/pkg/v1/remote/stream_test.go
@@ -161,9 +161,10 @@ func TestStreamableLayerFromTarball(t *testing.T) {
 				name := fmt.Sprintf("file-%d.txt", i)
 				body := fmt.Sprintf("i am file number %d", i)
 				if err := tw.WriteHeader(&tar.Header{
-					Name: name,
-					Mode: 0600,
-					Size: int64(len(body)),
+					Name:     name,
+					Mode:     0600,
+					Size:     int64(len(body)),
+					Typeflag: tar.TypeReg,
 				}); err != nil {
 					return err
 				}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -23,11 +23,12 @@ import (
 	"net/http"
 	"net/url"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-	"golang.org/x/sync/errgroup"
 )
 
 // Write pushes the provided img to the specified image reference.
@@ -219,6 +220,9 @@ func (w *writer) uploadOne(l v1.Layer) error {
 	if _, ok := l.(*StreamableLayer); !ok {
 		// Layer isn't streamable, we should take advantage of that to
 		// skip uploading if possible.
+		// By sending ?digest= in the request, we'll also check that
+		// our computed digest matches the one computed by the
+		// registry.
 		h, err := l.Digest()
 		if err != nil {
 			return err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -266,8 +266,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 	if err := w.commitBlob(location, digest); err != nil {
 		return err
 	}
-	log.Printf("pushed blob %v", digest)
-
+	log.Printf("pushed blob %s", digest)
 	return nil
 }
 

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -27,12 +27,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
-
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
@@ -582,7 +580,7 @@ func TestUploadOne(t *testing.T) {
 	}
 }
 
-func TestUploadOneStreamable(t *testing.T) {
+func TestUploadOneStreamableLayer(t *testing.T) {
 	expectedRepo := "baz/blah"
 	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
 	streamPath := "/path/to/upload"
@@ -601,17 +599,16 @@ func TestUploadOneStreamable(t *testing.T) {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPatch)
 			}
 			/*
-				got, err := ioutil.ReadAll(r.Body)
-				if err != nil {
-					t.Errorf("ReadAll(Body) = %v", err)
+				if got, err := ioutil.ReadAll(r.Body); err != nil {
+					t.Errorf("ReadAll: %v", err)
 				}
-				want, err := img.RawConfigFile()
-				if err != nil {
-					t.Errorf("RawConfigFile() = %v", err)
-				}
-				if bytes.Compare(got, want) != 0 {
-					t.Errorf("bytes.Compare(); got %v, want %v", got, want)
-				}
+					want, err := img.RawConfigFile()
+					if err != nil {
+						t.Errorf("RawConfigFile() = %v", err)
+					}
+					if bytes.Compare(got, want) != 0 {
+						t.Errorf("bytes.Compare(); got %v, want %v", got, want)
+					}
 			*/
 			w.Header().Set("Location", commitPath)
 			http.Error(w, "Initiated", http.StatusAccepted)
@@ -799,7 +796,6 @@ func TestWriteWithErrors(t *testing.T) {
 }
 
 func TestScopesForUploadingImage(t *testing.T) {
-
 	referenceToUpload, err := name.NewTag("example.com/sample/sample:latest", name.WeakValidation)
 	if err != nil {
 		t.Fatalf("name.NewTag() = %v", err)

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -264,7 +264,7 @@ func TestInitiateUploadNoMountsExists(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(h)
+	_, mounted, err := w.initiateUpload("", h.String())
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -301,7 +301,7 @@ func TestInitiateUploadNoMountsInitiated(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload(h)
+	location, mounted, err := w.initiateUpload("", h.String())
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -339,7 +339,7 @@ func TestInitiateUploadNoMountsBadStatus(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload(h)
+	location, mounted, err := w.initiateUpload("", h.String())
 	if err == nil {
 		t.Errorf("intiateUpload() = %v, %v; wanted error", location, mounted)
 	}
@@ -377,7 +377,7 @@ func TestInitiateUploadMountsWithMountFromDifferentRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(h)
+	_, mounted, err := w.initiateUpload("", h.String())
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -427,7 +427,7 @@ func TestInitiateUploadMountsWithMountFromTheSameRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(h)
+	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String())
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -470,7 +470,16 @@ func TestStreamBlob(t *testing.T) {
 
 	streamLocation := w.url(expectedPath)
 
-	commitLocation, err := w.streamBlob(h, streamLocation.String())
+	l, err := img.LayerByDigest(h)
+	if err != nil {
+		t.Fatalf("LayerByDigest: %v", err)
+	}
+	blob, err := l.Compressed()
+	if err != nil {
+		t.Fatalf("layer.Compressed: %v", err)
+	}
+
+	commitLocation, err := w.streamBlob(blob, streamLocation.String())
 	if err != nil {
 		t.Errorf("streamBlob() = %v", err)
 	}
@@ -506,7 +515,7 @@ func TestCommitBlob(t *testing.T) {
 
 	commitLocation := w.url(expectedPath)
 
-	if err := w.commitBlob(h, commitLocation.String()); err != nil {
+	if _, err := w.commitBlob(commitLocation.String(), h.String()); err != nil {
 		t.Errorf("commitBlob() = %v", err)
 	}
 }
@@ -564,7 +573,11 @@ func TestUploadOne(t *testing.T) {
 	}
 	defer closer.Close()
 
-	if err := w.uploadOne(h); err != nil {
+	l, err := img.LayerByDigest(h)
+	if err != nil {
+		t.Fatalf("LayerByDigest: %v", err)
+	}
+	if err := w.uploadOne(l); err != nil {
 		t.Errorf("uploadOne() = %v", err)
 	}
 }

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -598,18 +598,7 @@ func TestUploadOneStreamableLayer(t *testing.T) {
 			if r.Method != http.MethodPatch {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPatch)
 			}
-			/*
-				if got, err := ioutil.ReadAll(r.Body); err != nil {
-					t.Errorf("ReadAll: %v", err)
-				}
-					want, err := img.RawConfigFile()
-					if err != nil {
-						t.Errorf("RawConfigFile() = %v", err)
-					}
-					if bytes.Compare(got, want) != 0 {
-						t.Errorf("bytes.Compare(); got %v, want %v", got, want)
-					}
-			*/
+			// TODO(jasonhall): What should we check here?
 			w.Header().Set("Location", commitPath)
 			http.Error(w, "Initiated", http.StatusAccepted)
 		case commitPath:


### PR DESCRIPTION
Today, pushing an image requires every layer to be at least buffered into memory before pushing, because `remote.Write` uploads each layer by its digest. The registry API doesn't actually require this, and allows blob writes without specifying digest.

This buffering negatively impacts kaniko in cases where kaniko's layer snapshot diff exceeds available memory, resulting in OOMs. It walks a file tree accumulating files in a layer, but has to buffer it all before writing. 👎 

While reading the layer contents (e.g., during remote upload), we'll capture the digest, diff ID and size of the layer for later use in constructing the config and manifest.

This is only the first step in enabling streaming layer writes for kaniko; the next step is teaching `mutate.Append` not to assume each layer is buffered and to only calculate the image's config and manifest on-demand after layers have already been streamily read.

cc @dlorenc 