### PR TITLE
Working extension invocation.

### DIFF
--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -17,21 +17,13 @@ package main
 import (
 	"log"
 
-	"github.com/spf13/cobra"
+	"github.com/google/go-containerregistry/pkg/ko/cmd"
 )
 
 func main() {
-	// Parent command to which all subcommands are added.
-	cmds := &cobra.Command{
-		Use:   "ko",
-		Short: "Rapidly iterate with Go, Containers, and Kubernetes.",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
-	}
-	addKubeCommands(cmds)
+	command := cmd.NewDefaultKoCommand()
 
-	if err := cmds.Execute(); err != nil {
+	if err := command.Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)
 	}
 }

--- a/pkg/ko/cmd/cmd.go
+++ b/pkg/ko/cmd/cmd.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+)
+
+func NewDefaultKoCommand() *cobra.Command {
+	return NewDefaultKoCommandWithArgs(&defaultExtensionHandler{}, os.Environ(), os.Args, os.Stdin, os.Stdout, os.Stderr)
+}
+
+func NewDefaultKoCommandWithArgs(extensionHandler ExtensionHandler, env, args []string, in io.Reader, out, errout io.Writer) *cobra.Command {
+	cmd := NewKoCommand(env, args, in, out, errout)
+
+	if extensionHandler == nil {
+		return cmd
+	}
+
+	if len(args) > 1 {
+		cmdPathPieces := args[1:]
+
+		// only look for suitable extension executables if
+		// the specified command does not already exist
+		if _, _, err := cmd.Find(cmdPathPieces); err != nil {
+			if err := handleExtensions(extensionHandler, env, cmdPathPieces); err != nil {
+				fmt.Fprintf(errout, "%v\n", err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	return cmd
+}
+
+func NewKoCommand(env, args []string, in io.Reader, out, err io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "ko",
+		Short: "Rapidly iterate with Go, Containers, and Kubernetes.",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+	addKubeCommands(cmds, env, args, in, out, err)
+	return cmds
+}

--- a/pkg/ko/cmd/config.go
+++ b/pkg/ko/cmd/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/pkg/ko/cmd/extensions.go
+++ b/pkg/ko/cmd/extensions.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+const cmdName = "ko"
+
+type ExtensionHandler interface {
+	Lookup(filename string) (string, error)
+	Execute(executablePath string, cmdArgs, environment []string) error
+}
+
+type defaultExtensionHandler struct{}
+
+func (h *defaultExtensionHandler) Lookup(filename string) (string, error) {
+	// if on Windows, append the "exe" extension
+	// to the filename that we are looking up.
+	if runtime.GOOS == "windows" {
+		filename = filename + ".exe"
+	}
+	return exec.LookPath(filename)
+}
+
+func (h *defaultExtensionHandler) Execute(executablePath string, cmdArgs, environment []string) error {
+	return syscall.Exec(executablePath, cmdArgs, environment)
+}
+
+func handleExtensions(handler ExtensionHandler, env, cmdArgs []string) error {
+	remainingArgs := []string(nil)
+
+	for idx := range cmdArgs {
+		if strings.HasPrefix(cmdArgs[idx], "-") {
+			break
+		}
+		remainingArgs = append(remainingArgs, strings.Replace(cmdArgs[idx], "-", "_", -1))
+	}
+
+	foundBinaryPath := ""
+
+	for len(remainingArgs) > 0 {
+		path, err := handler.Lookup(fmt.Sprintf("%s-%s", cmdName, strings.Join(remainingArgs, "-")))
+		if err != nil || len(path) == 0 {
+			remainingArgs = remainingArgs[:len(remainingArgs)-1]
+			continue
+		}
+
+		foundBinaryPath = path
+		break
+	}
+
+	if len(foundBinaryPath) == 0 {
+		return nil
+	}
+
+	if err := handler.Execute(foundBinaryPath, append([]string{foundBinaryPath}, cmdArgs[len(remainingArgs):]...), env); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ko/cmd/filestuff.go
+++ b/pkg/ko/cmd/filestuff.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"os"

--- a/pkg/ko/cmd/flatname.go
+++ b/pkg/ko/cmd/flatname.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"crypto/md5"

--- a/pkg/ko/cmd/local.go
+++ b/pkg/ko/cmd/local.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"github.com/spf13/cobra"

--- a/pkg/ko/cmd/publish.go
+++ b/pkg/ko/cmd/publish.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/pkg/ko/cmd/publish_test.go
+++ b/pkg/ko/cmd/publish_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import "testing"
 

--- a/pkg/ko/cmd/resolve.go
+++ b/pkg/ko/cmd/resolve.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"


### PR DESCRIPTION
I moved the cmd setup into pkg and decoupled the commands from `os.*` This should make testing much easier when there are tests.


The change adds kubectl/git style plugins. For example:

```
⦿ ls ~/bin/ | grep ko
ko-scott
```

```
⦿ cat ~/bin/ko-scott
#! /bin/bash
echo "hello, extension!"
```

```
⦿ go run cmd/ko/main.go scott
hello, extension!
```