### PR TITLE
Fix transport Host checking on redirect

### DIFF
--- a/pkg/v1/remote/transport/basic.go
+++ b/pkg/v1/remote/transport/basic.go
@@ -39,7 +39,8 @@ func (bt *basicTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	// abstraction, so to avoid forwarding Authorization headers to places
 	// we are redirected, only set it when the authorization header matches
 	// the host with which we are interacting.
-	if in.Host == bt.target {
+	// In case of redirect http.Client can use an empty Host, check URL too.
+	if in.Host == bt.target || in.URL.Host == bt.target {
 		in.Header.Set("Authorization", hdr)
 	}
 	in.Header.Set("User-Agent", transportName)

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -56,7 +56,8 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		// abstraction, so to avoid forwarding Authorization headers to places
 		// we are redirected, only set it when the authorization header matches
 		// the registry with which we are interacting.
-		if in.Host == bt.registry.RegistryStr() {
+		// In case of redirect http.Client can use an empty Host, check URL too.
+		if in.Host == bt.registry.RegistryStr() || in.URL.Host == bt.registry.RegistryStr() {
 			in.Header.Set("Authorization", hdr)
 		}
 		in.Header.Set("User-Agent", transportName)

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -103,7 +103,10 @@ func TestBearerTransport(t *testing.T) {
 			if got, want := r.Header.Get("Authorization"), "Bearer "+expectedToken; got != want {
 				t.Errorf("Header.Get(Authorization); got %v, want %v", got, want)
 			}
-
+			if r.URL.Path == "/v2/auth" {
+				http.Redirect(w, r, "/redirect", http.StatusMovedPermanently)
+				return
+			}
 			if strings.Contains(r.URL.Path, "blobs") {
 				http.Redirect(w, r, blobServer.URL, http.StatusFound)
 				return


### PR DESCRIPTION
Transport roundTripper ensure that we are not sending sensitive
authentication information to incorrect URLs by checking it against the
Host value of the request. Sometimes it's emptied if it's not a relative
redirect for example in case of an http to https redirect.

See https://github.com/golang/go/blob/release-branch.go1.10/src/net/http/client.go#L543
for details, in case of an http to https redirect req.Host and
req.URL.Host are equals and so the Host value empty.