### PR TITLE
Fix `gcloud builds submit` for crane builder image

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,6 @@
+# These vendored deps contain symlinks to external repos, which confuses
+# `gcloud builds submit` -- ignoring them has no impact on the repo's ability
+# to build.
+vendor/k8s.io/*
+vendor/github.com/docker/docker/integration-cli/*
+vendor/github.com/docker/docker/project/*

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -24,8 +24,3 @@ pushd ${PROJECT_ROOT}
 trap popd EXIT
 
 dep ensure
-
-# These vendored deps include symlinks outside the repo,
-# which confuses "gcloud container builds submit"
-rm vendor/github.com/docker/docker/project/CONTRIBUTORS.md
-rm -r vendor/github.com/docker/docker/hack/make/


### PR DESCRIPTION
Before this change, `./scripts/update-deps.sh` deleted vendored files that caused problems for `gcloud builds submit`, by being symlinks to other repos which might not exist when you run that command locally.

Instead of deleting them in `update-deps.sh` (which we might forget to run), we can just ignore them when uploading to GCB to build. This enables `gcloud builds submit` to run and produce the GCB builder image `gcr.io/go-containerregistry/crane`, which we should probably automate.