### PR TITLE
Format markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Go Report Card](https://goreportcard.com/badge/google/go-containerregistry)](https://goreportcard.com/report/google/go-containerregistry)
 [![Code Coverage](https://codecov.io/gh/google/go-containerregistry/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-containerregistry)
 
-
 ## Introduction
 
 This is a golang library for working with container registries. It's largely based on the [Python library of the same name](https://github.com/google/containerregistry), but more hip and uses GitHub as the source of truth.

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -18,14 +18,13 @@ crane [flags]
 
 ### SEE ALSO
 
-* [crane append](crane_append.md)	 - Append contents of a tarball to a remote image
-* [crane config](crane_config.md)	 - Get the config of an image
-* [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst
-* [crane delete](crane_delete.md)	 - Delete an image reference from its registry
-* [crane digest](crane_digest.md)	 - Get the digest of an image
-* [crane ls](crane_ls.md)	 - List the tags in a repo
-* [crane manifest](crane_manifest.md)	 - Get the manifest of an image
-* [crane pull](crane_pull.md)	 - Pull a remote image by reference and store its contents in a tarball
-* [crane push](crane_push.md)	 - Push image contents as a tarball to a remote registry
-* [crane rebase](crane_rebase.md)	 - Rebase an image onto a new base image
-
+- [crane append](crane_append.md) - Append contents of a tarball to a remote image
+- [crane config](crane_config.md) - Get the config of an image
+- [crane copy](crane_copy.md) - Efficiently copy a remote image from src to dst
+- [crane delete](crane_delete.md) - Delete an image reference from its registry
+- [crane digest](crane_digest.md) - Get the digest of an image
+- [crane ls](crane_ls.md) - List the tags in a repo
+- [crane manifest](crane_manifest.md) - Get the manifest of an image
+- [crane pull](crane_pull.md) - Pull a remote image by reference and store its contents in a tarball
+- [crane push](crane_push.md) - Push image contents as a tarball to a remote registry
+- [crane rebase](crane_rebase.md) - Rebase an image onto a new base image

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -22,5 +22,4 @@ crane append [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -18,5 +18,4 @@ crane config [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -18,5 +18,4 @@ crane copy [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -18,5 +18,4 @@ crane delete [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -18,5 +18,4 @@ crane digest [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -18,5 +18,4 @@ crane ls [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -18,5 +18,4 @@ crane manifest [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -18,5 +18,4 @@ crane pull [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -18,5 +18,4 @@ crane push [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -22,5 +22,4 @@ crane rebase [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -18,6 +18,7 @@ tags, manifests, and sub-repositories.
 By default, it will print any images that do not have tags pointing to them.
 
 This can be composed with `gcrane delete` to actually garbage collect them:
+
 ```shell
 gcrane gc gcr.io/${PROJECT_ID}/repo | xargs -n1 gcrane delete
 ```

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -57,11 +57,11 @@ spec:
         foo: bar
     spec:
       containers:
-      - name: hello-world
-        # This is the import path for the Go binary to build and run.
-        image: github.com/mattmoor/examples/http/cmd/helloworld
-        ports:
-        - containerPort: 8080
+        - name: hello-world
+          # This is the import path for the Go binary to build and run.
+          image: github.com/mattmoor/examples/http/cmd/helloworld
+          ports:
+            - containerPort: 8080
 ```
 
 ### Determining supported import paths
@@ -76,9 +76,10 @@ path to be `github.com/mattmoor/examples`, and any references to subpackages
 of this will be built, containerized and published.
 
 For example, any of the following would be matched:
-* `github.com/mattmoor/examples`
-* `github.com/mattmoor/examples/cmd/foo`
-* `github.com/mattmoor/examples/bar`
+
+- `github.com/mattmoor/examples`
+- `github.com/mattmoor/examples/cmd/foo`
+- `github.com/mattmoor/examples/bar`
 
 ### Results
 
@@ -114,13 +115,12 @@ customresourcedefinition.apiextensions.k8s.io/warmimages.mattmoor.io configured
 ## Usage
 
 `ko` has four commands, most of which build and publish images as part of
-their execution.  By default, `ko` publishes images to a Docker Registry
+their execution. By default, `ko` publishes images to a Docker Registry
 specified via `KO_DOCKER_REPO`.
 
 However, these same commands can be directed to operate locally as well via
-the `--local` or `-L` command (or setting `KO_DOCKER_REPO=ko.local`).  See
+the `--local` or `-L` command (or setting `KO_DOCKER_REPO=ko.local`). See
 the [`minikube` section](./README.md#with-minikube) for more detail.
-
 
 ### `ko publish`
 
@@ -184,7 +184,7 @@ spec:
         - containerPort: 8080
 ```
 
-Some Docker Registries (e.g. gcr.io) support multi-level repository names.  For
+Some Docker Registries (e.g. gcr.io) support multi-level repository names. For
 these registries, it is often useful for discoverability and provenance to
 preserve the full import path, for this we expose `--preserve-import-paths`,
 or `-P` for short.
@@ -232,11 +232,10 @@ to whatever `kubectl` context is active.
 `ko delete` simply passes through to `kubectl delete`. It is exposed purely out
 of convenience for cleaning up resources created through `ko apply`.
 
-
 ## With `minikube`
 
 You can use `ko` with `minikube` via a Docker Registry, but this involves
-publishing images only to pull them back down to your machine again.  To avoid
+publishing images only to pull them back down to your machine again. To avoid
 this, `ko` exposes `--local` or `-L` options to instead publish the images to
 the local machine's Docker daemon.
 
@@ -281,9 +280,10 @@ If neither is present, then `ko` will rely on its default behaviors.
 By default, `ko` makes use of `gcr.io/distroless/base:latest` as the base image
 for containers. There are a wide array of scenarios in which overriding this
 makes sense, for example:
+
 1. Pinning to a particular digest of this image for repeatable builds,
 1. Replacing this streamlined base image with another with better debugging
-  tools (e.g. a shell, like `docker.io/library/ubuntu`).
+   tools (e.g. a shell, like `docker.io/library/ubuntu`).
 
 The default base image `ko` uses can be changed by simply adding the following
 line to `.ko.yaml`:
@@ -314,7 +314,6 @@ and get checked in and versioned alongside your source code. This also means
 that the configured values will be shared across developers on a project, which
 for `KO_DOCKER_REPO` is actually undesireable because each developer is (likely)
 using their own docker repository and cluster.
-
 
 ## Including static assets
 
@@ -390,7 +389,6 @@ This resulting configuration may then be installed onto Kubernetes clusters via:
 ```shell
 kubectl apply -f release.yaml
 ```
-
 
 ## Acknowledgements
 

--- a/pkg/authn/k8schain/README.md
+++ b/pkg/authn/k8schain/README.md
@@ -1,8 +1,6 @@
 # `k8schain`
 
-This is an implementation of the [github.com/google/go-containerregistry](
-https://github.com/google/go-containerregistry) library's [`authn.Keychain`](
-https://godoc.org/github.com/google/go-containerregistry/authn#Keychain)
+This is an implementation of the [github.com/google/go-containerregistry](https://github.com/google/go-containerregistry) library's [`authn.Keychain`](https://godoc.org/github.com/google/go-containerregistry/authn#Keychain)
 interface based on the authentication semantics used by the Kubelet when
 performing the pull of a Pod's images.
 

--- a/pkg/v1/mutate/testdata/README.md
+++ b/pkg/v1/mutate/testdata/README.md
@@ -1,4 +1,4 @@
-# whiteout\_image.tar
+# whiteout_image.tar
 
 Including whiteout files in our source caused [issues](https://github.com/google/go-containerregistry/issues/305)
 when cloning this repo inside a docker build. Removing the whiteout file from


### PR DESCRIPTION
Produced via: `prettier --write $(find -name '*.md' | grep -v vendor)`