### PR TITLE
Implement googley auth methods

### DIFF
--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -1,0 +1,138 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"golang.org/x/oauth2"
+	googauth "golang.org/x/oauth2/google"
+)
+
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// Exposed so we can test this.
+var GetGcloudCmd = func() *exec.Cmd {
+	// This is odd, but basically what docker-credential-gcr does.
+	//
+	// config-helper is undocumented, but it's purportedly the only supported way
+	// of accessing tokens (`gcloud auth print-access-token` is discouraged).
+	//
+	// --force-auth-refresh means we are getting a token that is valid for about
+	// an hour (we reuse it until it's expired).
+	return exec.Command("gcloud", "config", "config-helper", "--force-auth-refresh", "--format=json(credential)")
+}
+
+// NewEnvAuthenticator returns an authn.Authenticator that generates access
+// tokens from the environment we're running in.
+//
+// See: https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials
+func NewEnvAuthenticator() (authn.Authenticator, error) {
+	ts, err := googauth.DefaultTokenSource(context.Background(), cloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenSourceAuth{oauth2.ReuseTokenSource(nil, ts)}, nil
+}
+
+// NewGcloudAuthenticator returns an oauth2.TokenSource that generates access
+// tokens by shelling out to the gcloud sdk.
+func NewGcloudAuthenticator() (authn.Authenticator, error) {
+	ts := gcloudSource{GetGcloudCmd()}
+
+	// Attempt to fetch a token to ensure gcloud is installed and we can run it.
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenSourceAuth{oauth2.ReuseTokenSource(token, ts)}, nil
+}
+
+// tokenSourceAuth turns an oauth2.TokenSource into an authn.Authenticator.
+type tokenSourceAuth struct {
+	oauth2.TokenSource
+}
+
+// Authorization implements authn.Authenticator.
+func (tsa *tokenSourceAuth) Authorization() (string, error) {
+	token, err := tsa.Token()
+	if err != nil {
+		return "", err
+	}
+
+	return "Bearer " + token.AccessToken, nil
+}
+
+// gcloudOutput represents the output of the gcloud command we invoke.
+//
+// `gcloud config config-helper --format=json(credential)` looks something like:
+//
+// {
+//   "credential": {
+//     "access_token": "ya29.abunchofnonsense",
+//     "token_expiry": "2018-12-02T04:08:13Z"
+//   }
+// }
+type gcloudOutput struct {
+	Credential struct {
+		AccessToken string `json:"access_token"`
+		TokenExpiry string `json:"token_expiry"`
+	} `json:"credential"`
+}
+
+type gcloudSource struct {
+	// This is passed in so that we mock out gcloud and test Token.
+	cmd *exec.Cmd
+}
+
+// Token implements oauath2.TokenSource.
+func (gs gcloudSource) Token() (*oauth2.Token, error) {
+	cmd := gs.cmd
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	// Don't attempt to interpret stderr, just pass it through.
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("error executing `gcloud config config-helper`: %v", err)
+	}
+
+	creds := gcloudOutput{}
+	if err := json.Unmarshal(out.Bytes(), &creds); err != nil {
+		return nil, fmt.Errorf("failed to parse `gcloud config config-helper` output: %v", err)
+	}
+
+	expiry, err := time.Parse(time.RFC3339, creds.Credential.TokenExpiry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse gcloud token expiry: %v", err)
+	}
+
+	token := oauth2.Token{
+		AccessToken: creds.Credential.AccessToken,
+		Expiry:      expiry,
+	}
+
+	return &token, nil
+}

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -1,0 +1,261 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// Fails to parse as JSON at all.
+	badoutput = ""
+
+	// Fails to parse token_expiry format.
+	badexpiry = `
+{
+  "credential": {
+    "access_token": "mytoken",
+    "token_expiry": "2018/12/02"
+  }
+}`
+
+	// Expires in 6,000 years. Hopefully nobody is using my software then.
+	success = `
+{
+  "credential": {
+    "access_token": "mytoken",
+    "token_expiry": "8018-12-02T04:08:13Z"
+  }
+}`
+)
+
+// We'll invoke ourselves with a special environment variable in order to mock
+// out the gcloud dependency of gcloudSource. The exec package does this, too.
+//
+// See: https://www.joeshaw.org/testing-with-os-exec-and-testmain/
+func TestMain(m *testing.M) {
+	switch os.Getenv("GO_TEST_MODE") {
+	case "":
+		// Normal test mode
+		os.Exit(m.Run())
+
+	case "error":
+		// Makes cmd.Run() return an error.
+		os.Exit(2)
+
+	case "badoutput":
+		// Makes the gcloudOutput Unmarshaler fail.
+		fmt.Println(badoutput)
+
+	case "badexpiry":
+		// Makes the token_expiry time parser fail.
+		fmt.Println(badexpiry)
+
+	case "success":
+		// Returns a seemingly valid token.
+		fmt.Println(success)
+	}
+}
+
+func newGcloudCmdMock(env string) func() *exec.Cmd {
+	return func() *exec.Cmd {
+		cmd := exec.Command(os.Args[0])
+		cmd.Env = []string{fmt.Sprintf("GO_TEST_MODE=%s", env)}
+		return cmd
+	}
+}
+
+func TestGcloudErrors(t *testing.T) {
+	cases := []struct {
+		env string
+
+		// Just look for the prefix because we can't control other packages' errors.
+		wantPrefix string
+	}{{
+		env:        "error",
+		wantPrefix: "error executing `gcloud config config-helper`:",
+	}, {
+		env:        "badoutput",
+		wantPrefix: "failed to parse `gcloud config config-helper` output:",
+	}, {
+		env:        "badexpiry",
+		wantPrefix: "failed to parse gcloud token expiry:",
+	}}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("cases[%d]", i), func(t *testing.T) {
+			GetGcloudCmd = newGcloudCmdMock(tc.env)
+
+			if _, err := NewGcloudAuthenticator(); err == nil {
+				t.Errorf("wanted error, got nil")
+			} else if got := err.Error(); !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("wanted error prefix %q, got %q", tc.wantPrefix, got)
+			}
+		})
+	}
+}
+
+func TestGcloudSuccess(t *testing.T) {
+	GetGcloudCmd = newGcloudCmdMock("success")
+
+	auth, err := NewGcloudAuthenticator()
+	if err != nil {
+		t.Fatalf("NewGcloudAuthenticator got error %v", err)
+	}
+
+	token, err := auth.Authorization()
+	if err != nil {
+		t.Fatalf("Authorization got error %v", err)
+	}
+
+	if want, got := "Bearer mytoken", token; want != got {
+		t.Errorf("wanted token %q, got %q", want, got)
+	}
+}
+
+//
+// Keychain tests are in here so we can reuse the fake gcloud stuff.
+//
+
+func mustRegistry(r string) name.Registry {
+	reg, err := name.NewRegistry(r, name.StrictValidation)
+	if err != nil {
+		panic(err)
+	}
+	return reg
+}
+
+func TestKeychainDockerHub(t *testing.T) {
+	if auth, err := Keychain.Resolve(mustRegistry("index.docker.io")); err != nil {
+		t.Errorf("expected success, got: %v", err)
+	} else if auth != authn.Anonymous {
+		t.Errorf("expected anonymous, got: %v", auth)
+	}
+}
+
+func TestKeychainGCR(t *testing.T) {
+	cases := []string{
+		"gcr.io",
+		"us.gcr.io",
+		"asia.gcr.io",
+		"eu.gcr.io",
+		"staging-k8s.gcr.io",
+		"global.gcr.io",
+	}
+
+	// Env should fail.
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
+		t.Fatalf("unexpected err os.Setenv: %v", err)
+	}
+
+	// Gcloud should succeed.
+	GetGcloudCmd = newGcloudCmdMock("success")
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("cases[%d]", i), func(t *testing.T) {
+			if auth, err := Keychain.Resolve(mustRegistry(tc)); err != nil {
+				t.Errorf("expected success, got: %v", err)
+			} else if auth == authn.Anonymous {
+				t.Errorf("expected not anonymous auth, got: %v", auth)
+			}
+		})
+	}
+}
+
+func TestKeychainEnv(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("unexpected err os.Getwd: %v", err)
+	}
+
+	keyFile := filepath.Join(wd, "testdata", "key.json")
+
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyFile); err != nil {
+		t.Fatalf("unexpected err os.Setenv: %v", err)
+	}
+
+	if auth, err := Keychain.Resolve(mustRegistry("gcr.io")); err != nil {
+		t.Errorf("expected success, got: %v", err)
+	} else if auth == authn.Anonymous {
+		t.Errorf("expected not anonymous auth, got: %v", auth)
+	}
+}
+
+func TestKeychainError(t *testing.T) {
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
+		t.Fatalf("unexpected err os.Setenv: %v", err)
+	}
+
+	GetGcloudCmd = newGcloudCmdMock("badoutput")
+
+	if _, err := Keychain.Resolve(mustRegistry("gcr.io")); err == nil {
+		t.Fatalf("expected err, got: %v", err)
+	}
+}
+
+type badSource struct{}
+
+func (bs badSource) Token() (*oauth2.Token, error) {
+	return nil, fmt.Errorf("oops")
+}
+
+// This test is silly, but coverage.
+func TestTokenSourceAuthError(t *testing.T) {
+	auth := tokenSourceAuth{badSource{}}
+
+	_, err := auth.Authorization()
+	if err == nil {
+		t.Errorf("expected err, got nil")
+	}
+}
+
+func TestNewEnvAuthenticatorFailure(t *testing.T) {
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
+		t.Fatalf("unexpected err os.Setenv: %v", err)
+	}
+
+	// Expect error.
+	_, err := NewEnvAuthenticator()
+	if err == nil {
+		t.Errorf("expected err, got nil")
+	}
+}
+
+func TestNewEnvAuthenticatorSuccess(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("unexpected err os.Getwd: %v", err)
+	}
+
+	keyFile := filepath.Join(wd, "testdata", "key.json")
+
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyFile); err != nil {
+		t.Fatalf("unexpected err os.Setenv: %v", err)
+	}
+
+	_, err = NewEnvAuthenticator()
+	if err != nil {
+		t.Fatalf("unexpected err NewEnvAuthenticator: %v", err)
+	}
+}

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -36,11 +36,11 @@ const (
 {
   "credential": {
     "access_token": "mytoken",
-    "token_expiry": "2018/12/02"
+    "token_expiry": "most-definitely-not-a-date"
   }
 }`
 
-	// Expires in 6,000 years. Hopefully nobody is using my software then.
+	// Expires in 6,000 years. Hopefully nobody is using software then.
 	success = `
 {
   "credential": {
@@ -103,8 +103,8 @@ func TestGcloudErrors(t *testing.T) {
 		wantPrefix: "failed to parse gcloud token expiry:",
 	}}
 
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("cases[%d]", i), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
 			GetGcloudCmd = newGcloudCmdMock(tc.env)
 
 			if _, err := NewGcloudAuthenticator(); err == nil {

--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+var Keychain authn.Keychain = &googleKeychain{}
+
+type googleKeychain struct{}
+
+// Resolve implements authn.Keychain a la docker-credential-gcr.
+//
+// This behaves similarly to the GCR credential helper, but reuses tokens until
+// they expire.
+//
+// We can't easily add this behavior to our credential helper implementation
+// of authn.Authenticator because the credential helper protocol doesn't include
+// expiration information, see here:
+// https://godoc.org/github.com/docker/docker-credential-helpers/credentials#Credentials
+//
+// In addition to being a performance optimization, the reuse of these access
+// tokens works around a bug in gcloud. It appears that attempting to invoke
+// `gcloud config config-helper` multiple times too quickly will fail:
+// https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/54
+//
+// We could upstream this behavior into docker-credential-gcr by parsing
+// gcloud's output and persisting its tokens across invocations, but then
+// we have to deal with invalidating caches across multiple runs (no fun).
+//
+// In general, we don't worry about that here because we expect to use the same
+// gcloud configuration in the scope of this one process.
+func (gk *googleKeychain) Resolve(reg name.Registry) (authn.Authenticator, error) {
+	// Only authenticate GCR so it works with authn.NewMultiKeychain to fallback.
+	if !strings.HasSuffix(reg.String(), "gcr.io") {
+		return authn.Anonymous, nil
+	}
+
+	auth, envErr := NewEnvAuthenticator()
+	if envErr == nil {
+		return auth, nil
+	}
+
+	auth, gErr := NewGcloudAuthenticator()
+	if gErr == nil {
+		return auth, nil
+	}
+
+	return nil, fmt.Errorf("failed to create token source from env: %v or gcloud: %v", envErr, gErr)
+}

--- a/pkg/v1/google/testdata/README.md
+++ b/pkg/v1/google/testdata/README.md
@@ -1,0 +1,4 @@
+# testdata
+
+This key is cribbed from [here](https://github.com/golang/oauth2/blob/d668ce993890a79bda886613ee587a69dd5da7a6/google/testdata/gcloud/credentials).
+It's invalid but parses sufficiently to test `NewEnvAuthenticator`.

--- a/pkg/v1/google/testdata/key.json
+++ b/pkg/v1/google/testdata/key.json
@@ -1,0 +1,35 @@
+{
+  "_class": "OAuth2Credentials",
+  "_module": "oauth2client.client",
+  "access_token": "foo_access_token",
+  "client_id": "foo_client_id",
+  "client_secret": "foo_client_secret",
+  "id_token": {
+    "at_hash": "foo_at_hash",
+    "aud": "foo_aud",
+    "azp": "foo_azp",
+    "cid": "foo_cid",
+    "email": "foo@example.com",
+    "email_verified": true,
+    "exp": 1420573614,
+    "iat": 1420569714,
+    "id": "1337",
+    "iss": "accounts.google.com",
+    "sub": "1337",
+    "token_hash": "foo_token_hash",
+    "verified_email": true
+  },
+  "invalid": false,
+  "refresh_token": "foo_refresh_token",
+  "revoke_uri": "https://accounts.google.com/o/oauth2/revoke",
+  "token_expiry": "3015-01-09T00:51:51Z",
+  "token_response": {
+    "access_token": "foo_access_token",
+    "expires_in": 3600,
+    "id_token": "foo_id_token",
+    "token_type": "Bearer"
+  },
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "user_agent": "Cloud SDK Command Line Tool",
+  "type": "authorized_user"
+}


### PR DESCRIPTION
This caches tokens until they're expired, so it's much faster than using
the default keychain.