### PR TITLE
Allow to publish images without appended md5 hash

### DIFF
--- a/cmd/ko/flatname.go
+++ b/cmd/ko/flatname.go
@@ -24,11 +24,14 @@ import (
 
 type NameOptions struct {
 	PreserveImportPaths bool
+	BaseImportPaths     bool
 }
 
 func addNamingArgs(cmd *cobra.Command, no *NameOptions) {
 	cmd.Flags().BoolVarP(&no.PreserveImportPaths, "preserve-import-paths", "P", no.PreserveImportPaths,
 		"Whether to preserve the full import path after KO_DOCKER_REPO.")
+	cmd.Flags().BoolVarP(&no.BaseImportPaths, "base-import-paths", "B", no.BaseImportPaths,
+		"Whether to use the base path without MD5 hash after KO_DOCKER_REPO.")
 }
 
 func packageWithMD5(importpath string) string {
@@ -39,4 +42,8 @@ func packageWithMD5(importpath string) string {
 
 func preserveImportPath(importpath string) string {
 	return importpath
+}
+
+func baseImportPaths(importpath string) string {
+	return filepath.Base(importpath)
 }

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -76,6 +76,8 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 		var namer publish.Namer
 		if no.PreserveImportPaths {
 			namer = preserveImportPath
+		} else if no.BaseImportPaths {
+			namer = baseImportPaths
 		} else {
 			namer = packageWithMD5
 		}


### PR DESCRIPTION
A new `-B` or `--base-import-paths` option allows to publish images without appended md5 hash at the end. It is mutually exclusive with existing `-P` option.