### PR TITLE
ko: log the import paths we are building

### DIFF
--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -106,6 +106,7 @@ func build(ip string) (string, error) {
 	cmd.Stderr = &output
 	cmd.Stdout = &output
 
+	log.Printf("Building %s", ip)
 	if err := cmd.Run(); err != nil {
 		os.RemoveAll(tmpDir)
 		log.Printf("Unexpected error running \"go build\": %v\n%v", err, output.String())


### PR DESCRIPTION
When you run a ko command, it outputs nothing for a few seconds while it
builds go binaries. This change logs the import paths before we invoke
`go build` so that you know what it's doing.