### PR TITLE
Upload config concurrently if we can

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -59,9 +59,9 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		})
 	}
 
-	if l, err := partial.ConfigLayer(img); err != nil {
-		// We can't read the ConfigLayer, which probably means that some layers are
-		// streaming layers and the config hasn't been calculated yet.
+	if l, err := partial.ConfigLayer(img); err == stream.ErrNotComputed {
+		// We can't read the ConfigLayer, because of streaming layers, since the
+		// config hasn't been calculated yet.
 		if err := g.Wait(); err != nil {
 			return err
 		}
@@ -74,6 +74,9 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		if err := w.uploadOne(l); err != nil {
 			return err
 		}
+	} else if err != nil {
+		// This is an actual error, not a streaming error, just return it.
+		return err
 	} else {
 		// We *can* read the ConfigLayer, so upload it concurrently with the layers.
 		g.Go(func() error {


### PR DESCRIPTION
https://github.com/google/go-containerregistry/pull/301 introduced a
pretty big regression in upload speed. To get around this, attempt to
read the config blob before waiting for layer uploads to finish. If we
can read it, add it to the errgroup, otherwise wait for the layers to
finish before attempting to upload the config again.

In my testing, this change shaves ~3s off of ko publishing.