### PR TITLE
PoC: Prototype go module support

### DIFF
--- a/pkg/ko/resolve/resolve.go
+++ b/pkg/ko/resolve/resolve.go
@@ -20,12 +20,10 @@ import (
 	"io"
 	"sync"
 
-	yaml "gopkg.in/yaml.v2"
-
-	"golang.org/x/sync/errgroup"
-
 	"github.com/google/go-containerregistry/pkg/ko/build"
 	"github.com/google/go-containerregistry/pkg/ko/publish"
+	"golang.org/x/sync/errgroup"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // ImageReferences resolves supported references to images within the input yaml

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -28,4 +28,3 @@ dep ensure
 # Delete all vendored broken symlinks.
 # From https://stackoverflow.com/questions/22097130/delete-all-broken-symbolic-links-with-a-line
 find vendor/ -type l -exec sh -c 'for x; do [ -e "$x" ] || rm "$x"; done' _ {} +
-


### PR DESCRIPTION
Playing with a solution to https://github.com/google/go-containerregistry/issues/298

Really what we need is for `gobuild` to be smart enough to just find these import paths, but I'm not sure how to do make it do that.

Also, ideally, we could use the modload package, but it's internal :(