### PR TITLE
Add support for `ko run`.

### DIFF
--- a/cmd/ko/binary.go
+++ b/cmd/ko/binary.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type BinaryOptions struct {
+	Path string
+}
+
+func addImageArg(cmd *cobra.Command, lo *BinaryOptions) {
+	cmd.Flags().StringVarP(&lo.Path, "image", "i", lo.Path,
+		"The import path of the binary to publish.")
+}

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -38,7 +38,7 @@ func qualifyLocalImport(importpath, gopathsrc, pwd string) (string, error) {
 	return filepath.Join(strings.TrimPrefix(pwd, gopathsrc+string(filepath.Separator)), importpath), nil
 }
 
-func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
+func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) map[string]name.Reference {
 	opt, err := gobuildOptions()
 	if err != nil {
 		log.Fatalf("error setting up builder options: %v", err)
@@ -47,6 +47,7 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 	if err != nil {
 		log.Fatalf("error creating go builder: %v", err)
 	}
+	imgs := make(map[string]name.Reference)
 	for _, importpath := range importpaths {
 		if gb.IsLocalImport(importpath) {
 			// Qualify relative imports to their fully-qualified
@@ -94,8 +95,11 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) {
 				log.Fatalf("error setting up default image publisher: %v", err)
 			}
 		}
-		if _, err := pub.Publish(img, importpath); err != nil {
+		ref, err := pub.Publish(img, importpath)
+		if err != nil {
 			log.Fatalf("error publishing %s: %v", importpath, err)
 		}
+		imgs[importpath] = ref
 	}
+	return imgs
 }


### PR DESCRIPTION
This adds support for a `ko run` shortcut that effectively composes
`ko publish` and `kubectl run`.  With this users can containerize and
run a Go binary on Kubernetes in a single command without any yaml.

```
ko run <deployment name> --image=./cmd/binary-name
```