### PR TITLE
ko apply --watch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -341,6 +341,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c355e11e817a8f0cf464c922302f859e6ad922d7f849f42c0594a2a26ec2d806"
+  name = "github.com/mattmoor/dep-notify"
+  packages = ["pkg/graph"]
+  pruneopts = "NUT"
+  revision = "bee9543ee54bd7d7e5cce945cfc651082bb21f34"
+
+[[projects]]
+  branch = "master"
   digest = "1:5fe20cfe4ef484c237cec9f947b2a6fa90bad4b8610fd014f0e4211e13d82d5d"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -865,6 +873,7 @@
     "github.com/docker/docker/client",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
+    "github.com/mattmoor/dep-notify/pkg/graph",
     "github.com/pkg/errors",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -231,8 +231,8 @@ to whatever `kubectl` context is active.
 
 The `--watch` flag (`-W` for short) does an initial `apply` as above, but as it
 does, it builds up a dependency graph of your program and starts to continuously
-monitor the filesystem for changes and on-change, it re-applies any yamls that
-are affected.
+monitor the filesystem for changes. When a file changes, it re-applies any yamls
+that are affected.
 
 For example, if I edit `github.com/foo/bar/pkg/baz/blah.go`, the tool sees that
 the `github.com/foo/bar/pkg/baz` package has changed, and perhaps both

--- a/cmd/ko/README.md
+++ b/cmd/ko/README.md
@@ -227,6 +227,25 @@ rebuild, repush, and redeploy their changes.
 `ko apply` will invoke `kubectl apply` under the covers, and therefore apply
 to whatever `kubectl` context is active.
 
+### `ko apply --watch` (EXPERIMENTAL)
+
+The `--watch` flag (`-W` for short) does an initial `apply` as above, but as it
+does, it builds up a dependency graph of your program and starts to continuously
+monitor the filesystem for changes and on-change, it re-applies any yamls that
+are affected.
+
+For example, if I edit `github.com/foo/bar/pkg/baz/blah.go`, the tool sees that
+the `github.com/foo/bar/pkg/baz` package has changed, and perhaps both
+`github.com/foo/bar/cmd/one` and `github.com/foo/bar/cmd/two` consume that library
+and were referenced by `config/one-deploy.yaml` and `config/two-deploy.yaml`.
+The edit would effectively result in a re-application of:
+
+```
+ko apply -f config/one-deploy.yaml -f config/two-deploy.yaml
+```
+
+This flag is still experimental, and feedback is very welcome.
+
 ### `ko delete`
 
 `ko delete` simply passes through to `kubectl delete`. It is exposed purely out

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -20,6 +20,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sync"
+
+	"github.com/mattmoor/dep-notify/pkg/graph"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/ko/build"
@@ -51,11 +54,45 @@ func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions
 	if err != nil {
 		log.Fatalf("error setting up builder options: %v", err)
 	}
+	builder, err := build.NewGo(opt...)
+	if err != nil {
+		log.Fatalf("error creating builder: %v", err)
+	}
 
-	// TODO(mattmoor): By having this as a channel, we can hook this up to a filesystem
-	// watcher and leave `fs` open to stream the names of yaml files affected by code
-	// changes (including the modification of existing or creation of new yaml files).
+	// By having this as a channel, we can hook this up to a filesystem
+	// watcher and leave `fs` open to stream the names of yaml files
+	// affected by code changes (including the modification of existing or
+	// creation of new yaml files).
 	fs := enumerateFiles(fo)
+
+	// This tracks filename -> []importpath
+	var sm sync.Map
+
+	var g graph.Interface
+	var errCh chan error
+	if fo.Watch {
+		// Start a dep-notify process that on notifications scans the
+		// file-to-recorded-build map and for each affected file resends
+		// the filename along the channel.
+		g, errCh, err = graph.New(func(ss graph.StringSet) {
+			sm.Range(func(k, v interface{}) bool {
+				key := k.(string)
+				value := v.([]string)
+
+				for _, ip := range value {
+					if ss.Has(ip) {
+						fs <- key
+					}
+				}
+				return true
+			})
+		})
+		if err != nil {
+			log.Fatalf("Error creating dep-notify graph: %v", err)
+		}
+		// Cleanup the fsnotify hooks when we're done.
+		defer g.Shutdown()
+	}
 
 	var futures []resolvedFuture
 	for {
@@ -93,26 +130,56 @@ func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions
 			// the future.
 			go func(f string) {
 				defer close(ch)
-				b, err := resolveFile(f, no, lo, opt...)
-				if err != nil {
-					log.Fatalf("error processing import paths in %q: %v", f, err)
+				// Record the builds we do via this builder.
+				recordingBuilder := &build.Recorder{
+					Builder: builder,
 				}
+				b, err := resolveFile(f, no, lo, recordingBuilder)
+				if err != nil {
+					// Don't let build errors disrupt the watch.
+					lg := log.Fatalf
+					if fo.Watch {
+						lg = log.Printf
+					}
+					lg("error processing import paths in %q: %v", f, err)
+					return
+				}
+				// Associate with this file the collection of binary import paths.
+				sm.Store(f, recordingBuilder.ImportPaths)
 				ch <- b
+				if fo.Watch {
+					for _, ip := range recordingBuilder.ImportPaths {
+						// Technically we never remove binary targets from the graph,
+						// which will increase our graph's watch load, but the
+						// notifications that they change will result in no affected
+						// yamls, and no new builds or deploys.
+						if err := g.Add(ip); err != nil {
+							log.Fatalf("Error adding importpath to dep graph: %v", err)
+						}
+					}
+				}
 			}(f)
 
-		case b := <-bf:
+		case b, ok := <-bf:
 			// Once the head channel returns something, dequeue it.
 			// We listen to the futures in order to be respectful of
 			// the kubectl apply ordering, which matters!
 			futures = futures[1:]
+			if ok {
+				// Write the next body and a trailing delimiter.
+				// We write the delimeter LAST so that when streamed to
+				// kubectl it knows that the resource is complete and may
+				// be applied.
+				out.Write(append(b, []byte("\n---\n")...))
+			}
 
-			// Write a delimiter and the next resolved body.
-			out.Write(append([]byte("---\n"), b...))
+		case err := <-errCh:
+			log.Fatalf("Error watching dependencies: %v", err)
 		}
 	}
 }
 
-func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Option) ([]byte, error) {
+func resolveFile(f string, no *NameOptions, lo *LocalOptions, builder build.Interface) ([]byte, error) {
 	var pub publish.Interface
 	repoName := os.Getenv("KO_DOCKER_REPO")
 
@@ -146,11 +213,6 @@ func resolveFile(f string, no *NameOptions, lo *LocalOptions, opt ...build.Optio
 	} else {
 		b, err = ioutil.ReadFile(f)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	builder, err := build.NewGo(opt...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ko/build/future.go
+++ b/pkg/ko/build/future.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func newFuture(work func() (v1.Image, error)) *future {
+	// Create a channel on which to send the result.
+	ch := make(chan *result)
+	// Initiate the actual work, sending it's result
+	// along the above channel.
+	go func() {
+		img, err := work()
+		ch <- &result{img: img, err: err}
+	}()
+	// Return a future for the above work.  Callers should
+	// call .Get() on this result (as many times as needed).
+	// One of these calls will receive the result, store it,
+	// and close the channel so that the rest of the callers
+	// can consume it.
+	return &future{
+		promise: ch,
+	}
+}
+
+type result struct {
+	img v1.Image
+	err error
+}
+
+type future struct {
+	m sync.RWMutex
+
+	result  *result
+	promise chan *result
+}
+
+// Get blocks on the result of the future.
+func (f *future) Get() (v1.Image, error) {
+	// Block on the promise of a result until we get one.
+	result, ok := <-f.promise
+	if ok {
+		func() {
+			f.m.Lock()
+			defer f.m.Unlock()
+			// If we got the result, then store it so that
+			// others may access it.
+			f.result = result
+			// Close the promise channel so that others
+			// are signaled that the result is available.
+			close(f.promise)
+		}()
+	}
+
+	f.m.RLock()
+	defer f.m.RUnlock()
+
+	return f.result.img, f.result.err
+}

--- a/pkg/ko/build/future.go
+++ b/pkg/ko/build/future.go
@@ -23,7 +23,7 @@ import (
 func newFuture(work func() (v1.Image, error)) *future {
 	// Create a channel on which to send the result.
 	ch := make(chan *result)
-	// Initiate the actual work, sending it's result
+	// Initiate the actual work, sending its result
 	// along the above channel.
 	go func() {
 		img, err := work()

--- a/pkg/ko/build/future_test.go
+++ b/pkg/ko/build/future_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func makeImage() (v1.Image, error) {
+	return random.Image(256, 8)
+}
+
+func digest(t *testing.T, img v1.Image) string {
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatalf("Digest() = %v", err)
+	}
+	return d.String()
+}
+
+func TestSameFutureSameImage(t *testing.T) {
+	f := newFuture(makeImage)
+
+	i1, err := f.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d1 := digest(t, i1)
+
+	i2, err := f.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d2 := digest(t, i2)
+
+	if d1 != d2 {
+		t.Errorf("Got different digests %s and %s", d1, d2)
+	}
+}
+
+func TestDiffFutureDiffImage(t *testing.T) {
+	f1 := newFuture(makeImage)
+	f2 := newFuture(makeImage)
+
+	i1, err := f1.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d1 := digest(t, i1)
+
+	i2, err := f2.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d2 := digest(t, i2)
+
+	if d1 == d2 {
+		t.Errorf("Got same digest %s, wanted different", d1)
+	}
+}

--- a/pkg/ko/build/shared.go
+++ b/pkg/ko/build/shared.go
@@ -34,7 +34,7 @@ type Caching struct {
 var _ Interface = (*Caching)(nil)
 
 // NewCaching wraps the provided build.Interface in an implementation that
-// shared build results for a given path until the result has been invalidated.
+// shares build results for a given path until the result has been invalidated.
 func NewCaching(inner Interface) (*Caching, error) {
 	return &Caching{
 		inner:   inner,

--- a/pkg/ko/build/shared.go
+++ b/pkg/ko/build/shared.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Caching wraps a builder implementation in a layer that shares build results
+// for the same inputs using a simple "future" implementation.  Cached results
+// may be invalidated by calling Invalidate with the same input passed to Build.
+type Caching struct {
+	inner Interface
+
+	m       sync.Mutex
+	results map[string]*future
+}
+
+// Caching implements Interface
+var _ Interface = (*Caching)(nil)
+
+// NewCaching wraps the provided build.Interface in an implementation that
+// shared build results for a given path until the result has been invalidated.
+func NewCaching(inner Interface) (*Caching, error) {
+	return &Caching{
+		inner:   inner,
+		results: make(map[string]*future),
+	}, nil
+}
+
+// Build implements Interface
+func (c *Caching) Build(ip string) (v1.Image, error) {
+	f := func() *future {
+		// Lock the map of futures.
+		c.m.Lock()
+		defer c.m.Unlock()
+
+		// If a future for "ip" exists, then return it.
+		f, ok := c.results[ip]
+		if ok {
+			return f
+		}
+		// Otherwise create and record a future for a Build of "ip".
+		f = newFuture(func() (v1.Image, error) {
+			return c.inner.Build(ip)
+		})
+		c.results[ip] = f
+		return f
+	}()
+
+	return f.Get()
+}
+
+// IsSupportedReference implements Interface
+func (c *Caching) IsSupportedReference(ip string) bool {
+	return c.inner.IsSupportedReference(ip)
+}
+
+// Invalidate removes an import path's cached results.
+func (c *Caching) Invalidate(ip string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	delete(c.results, ip)
+}

--- a/pkg/ko/build/shared_test.go
+++ b/pkg/ko/build/shared_test.go
@@ -1,0 +1,94 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+type slowbuild struct {
+	sleep time.Duration
+}
+
+// slowbuild implements Interface
+var _ Interface = (*slowbuild)(nil)
+
+func (sb *slowbuild) IsSupportedReference(string) bool {
+	return true
+}
+
+func (sb *slowbuild) Build(string) (v1.Image, error) {
+	time.Sleep(sb.sleep)
+	return random.Image(256, 8)
+}
+
+func TestCaching(t *testing.T) {
+	duration := 100 * time.Millisecond
+	ip := "foo"
+
+	sb := &slowbuild{duration}
+	cb, _ := NewCaching(sb)
+
+	if !cb.IsSupportedReference(ip) {
+		t.Errorf("ISR(%q) = false, wanted true", ip)
+	}
+
+	previousDigest := "not-a-digest"
+	// Each iteration, we test that the first build is slow and subsequent
+	// builds are fast and return the same image.  Then we invalidate the
+	// cache and iterate.
+	for idx := 0; idx < 3; idx++ {
+		start := time.Now()
+		img1, err := cb.Build(ip)
+		if err != nil {
+			t.Errorf("Build() = %v", err)
+		}
+		end := time.Now()
+
+		elapsed := end.Sub(start)
+		if elapsed < duration {
+			t.Errorf("Elapsed time %v, wanted >= %s", elapsed, duration)
+		}
+		d1 := digest(t, img1)
+
+		if d1 == previousDigest {
+			t.Errorf("Got same digest as previous iteration, wanted different: %v", d1)
+		}
+		previousDigest = d1
+
+		start = time.Now()
+		img2, err := cb.Build(ip)
+		if err != nil {
+			t.Errorf("Build() = %v", err)
+		}
+		end = time.Now()
+
+		elapsed = end.Sub(start)
+		if elapsed >= duration {
+			t.Errorf("Elapsed time %v, wanted < %s", elapsed, duration)
+		}
+		d2 := digest(t, img2)
+
+		if d1 != d2 {
+			t.Error("Got different images, wanted same")
+		}
+
+		cb.Invalidate(ip)
+	}
+}

--- a/pkg/ko/publish/future.go
+++ b/pkg/ko/publish/future.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func newFuture(work func() (name.Reference, error)) *future {
+	// Create a channel on which to send the result.
+	ch := make(chan *result)
+	// Initiate the actual work, sending it's result
+	// along the above channel.
+	go func() {
+		ref, err := work()
+		ch <- &result{ref: ref, err: err}
+	}()
+	// Return a future for the above work.  Callers should
+	// call .Get() on this result (as many times as needed).
+	// One of these calls will receive the result, store it,
+	// and close the channel so that the rest of the callers
+	// can consume it.
+	return &future{
+		promise: ch,
+	}
+}
+
+type result struct {
+	ref name.Reference
+	err error
+}
+
+type future struct {
+	m sync.RWMutex
+
+	result  *result
+	promise chan *result
+}
+
+// Get blocks on the result of the future.
+func (f *future) Get() (name.Reference, error) {
+	// Block on the promise of a result until we get one.
+	result, ok := <-f.promise
+	if ok {
+		func() {
+			f.m.Lock()
+			defer f.m.Unlock()
+			// If we got the result, then store it so that
+			// others may access it.
+			f.result = result
+			// Close the promise channel so that others
+			// are signaled that the result is available.
+			close(f.promise)
+		}()
+	}
+
+	f.m.RLock()
+	defer f.m.RUnlock()
+
+	return f.result.ref, f.result.err
+}

--- a/pkg/ko/publish/future.go
+++ b/pkg/ko/publish/future.go
@@ -23,7 +23,7 @@ import (
 func newFuture(work func() (name.Reference, error)) *future {
 	// Create a channel on which to send the result.
 	ch := make(chan *result)
-	// Initiate the actual work, sending it's result
+	// Initiate the actual work, sending its result
 	// along the above channel.
 	go func() {
 		ref, err := work()

--- a/pkg/ko/publish/future_test.go
+++ b/pkg/ko/publish/future_test.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func makeRef() (name.Reference, error) {
+	img, err := random.Image(256, 8)
+	if err != nil {
+		return nil, err
+	}
+	d, err := img.Digest()
+	if err != nil {
+		return nil, err
+	}
+	return name.NewDigest(fmt.Sprintf("gcr.io/foo/bar@%s", d), name.WeakValidation)
+}
+
+func TestSameFutureSameReference(t *testing.T) {
+	f := newFuture(makeRef)
+
+	ref1, err := f.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d1 := ref1.String()
+
+	ref2, err := f.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d2 := ref2.String()
+
+	if d1 != d2 {
+		t.Errorf("Got different digests %s and %s", d1, d2)
+	}
+}
+
+func TestDiffFutureDiffReference(t *testing.T) {
+	f1 := newFuture(makeRef)
+	f2 := newFuture(makeRef)
+
+	ref1, err := f1.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d1 := ref1.String()
+
+	ref2, err := f2.Get()
+	if err != nil {
+		t.Errorf("Get() = %v", err)
+	}
+	d2 := ref2.String()
+
+	if d1 == d2 {
+		t.Errorf("Got same digest %s, wanted different", d1)
+	}
+}

--- a/pkg/ko/publish/shared.go
+++ b/pkg/ko/publish/shared.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Caching wraps a publisher implementation in a layer that shares publish results
+// for the same inputs using a simple "future" implementation.
+type Caching struct {
+	inner Interface
+
+	m       sync.Mutex
+	results map[string]*entry
+}
+
+// entry holds the last image published and the result of publishing it for a
+// particular reference.
+type entry struct {
+	img v1.Image
+	f   *future
+}
+
+// Caching implements Interface
+var _ Interface = (*Caching)(nil)
+
+// NewCaching wraps the provided publish.Interface in an implementation that
+// shares publish results for a given path until the passed image object changes.
+func NewCaching(inner Interface) (*Caching, error) {
+	return &Caching{
+		inner:   inner,
+		results: make(map[string]*entry),
+	}, nil
+}
+
+// Publish implements Interface
+func (c *Caching) Publish(img v1.Image, ref string) (name.Reference, error) {
+	f := func() *future {
+		// Lock the map of futures.
+		c.m.Lock()
+		defer c.m.Unlock()
+
+		// If a future for "ref" exists, then return it.
+		ent, ok := c.results[ref]
+		if ok {
+			// If the image matches, then return the same future.
+			if ent.img == img {
+				return ent.f
+			}
+		}
+		// Otherwise create and record a future for publishing "img" to "ref".
+		f := newFuture(func() (name.Reference, error) {
+			return c.inner.Publish(img, ref)
+		})
+		c.results[ref] = &entry{img: img, f: f}
+		return f
+	}()
+
+	return f.Get()
+}

--- a/pkg/ko/publish/shared.go
+++ b/pkg/ko/publish/shared.go
@@ -21,9 +21,9 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-// Caching wraps a publisher implementation in a layer that shares publish results
+// caching wraps a publisher implementation in a layer that shares publish results
 // for the same inputs using a simple "future" implementation.
-type Caching struct {
+type caching struct {
 	inner Interface
 
 	m       sync.Mutex
@@ -37,20 +37,20 @@ type entry struct {
 	f   *future
 }
 
-// Caching implements Interface
-var _ Interface = (*Caching)(nil)
+// caching implements Interface
+var _ Interface = (*caching)(nil)
 
-// NewCaching wraps the provided publish.Interface in an implementation that
+// Newcaching wraps the provided publish.Interface in an implementation that
 // shares publish results for a given path until the passed image object changes.
-func NewCaching(inner Interface) (*Caching, error) {
-	return &Caching{
+func NewCaching(inner Interface) (Interface, error) {
+	return &caching{
 		inner:   inner,
 		results: make(map[string]*entry),
 	}, nil
 }
 
 // Publish implements Interface
-func (c *Caching) Publish(img v1.Image, ref string) (name.Reference, error) {
+func (c *caching) Publish(img v1.Image, ref string) (name.Reference, error) {
 	f := func() *future {
 		// Lock the map of futures.
 		c.m.Lock()

--- a/pkg/ko/publish/shared_test.go
+++ b/pkg/ko/publish/shared_test.go
@@ -1,0 +1,88 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+type slowpublish struct {
+	sleep time.Duration
+}
+
+// slowpublish implements Interface
+var _ Interface = (*slowpublish)(nil)
+
+func (sb *slowpublish) Publish(img v1.Image, ref string) (name.Reference, error) {
+	time.Sleep(sb.sleep)
+	return makeRef()
+}
+
+func TestCaching(t *testing.T) {
+	duration := 100 * time.Millisecond
+	ref := "foo"
+
+	sb := &slowpublish{duration}
+	cb, _ := NewCaching(sb)
+
+	previousDigest := "not-a-digest"
+	// Each iteration, we test that the first publish is slow and subsequent
+	// publishs are fast and return the same reference.  For each of these
+	// iterations we use a new random image, which should invalidate the
+	// cached reference from previous iterations.
+	for idx := 0; idx < 3; idx++ {
+		img, _ := random.Image(256, 8)
+
+		start := time.Now()
+		ref1, err := cb.Publish(img, ref)
+		if err != nil {
+			t.Errorf("Publish() = %v", err)
+		}
+		end := time.Now()
+
+		elapsed := end.Sub(start)
+		if elapsed < duration {
+			t.Errorf("Elapsed time %v, wanted >= %s", elapsed, duration)
+		}
+		d1 := ref1.String()
+
+		if d1 == previousDigest {
+			t.Errorf("Got same digest as previous iteration, wanted different: %v", d1)
+		}
+		previousDigest = d1
+
+		start = time.Now()
+		ref2, err := cb.Publish(img, ref)
+		if err != nil {
+			t.Errorf("Publish() = %v", err)
+		}
+		end = time.Now()
+
+		elapsed = end.Sub(start)
+		if elapsed >= duration {
+			t.Errorf("Elapsed time %v, wanted < %s", elapsed, duration)
+		}
+		d2 := ref2.String()
+
+		if d1 != d2 {
+			t.Error("Got different references, wanted same")
+		}
+	}
+}

--- a/vendor/github.com/mattmoor/dep-notify/LICENSE
+++ b/vendor/github.com/mattmoor/dep-notify/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/doc.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package graph holds the utilities for building/maintaining the dependency
+// graph and notifying on changes.
+package graph

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/interface.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/interface.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+// Interface for manipulating the dependency graph.
+type Interface interface {
+	// This adds a given importpath to the collection of roots that we are tracking.
+	Add(importpath string) error
+
+	// Shutdown stops tracking all Add'ed import paths for changes.
+	Shutdown() error
+}
+
+// Observer is the type for the callback that will happen on changes.
+// The callback is supplied with the transitive dependents (aka "affected
+// targets") of the file that has changed.
+type Observer func(affected StringSet)

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/manager.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/manager.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"fmt"
+	gb "go/build"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// New creates a new Interface for building up dependency graphs.
+// It starts in the provided working directory, and will call the provided
+// Observer for any changes.
+//
+// The returned graph is empty, but new targets may be added via the returned
+// Interface.  New also returns any immediate errors, and a channel through which
+// errors watching for changes in the dependencies will be returned until the
+// graph is Shutdown.
+//   // Create our empty graph
+//   g, errCh, err := New(...)
+//   if err != nil { ... }
+//   // Cleanup when we're done.  This closes errCh.
+//   defer g.Shutdown()
+//   // Start tracking this target.
+//   err := g.Add("github.com/mattmoor/warm-image/cmd/controller")
+//   if err != nil { ... }
+//   select {
+//     case err := <- errCh:
+//       // Handle errors that occur while watching the above target.
+//     case <-stopCh:
+//       // When some stop signal happens, we're done.
+//   }
+func New(obs Observer) (Interface, chan error, error) {
+	return NewWithOptions(obs, DefaultOptions...)
+}
+
+var DefaultOptions = []Option{WithCurrentDirectory, WithContext(&gb.Default), WithFSNotify,
+	WithFileFilter(OmitTest, OmitNonGo), WithPackageFilter(OmitVendor), WithOutsideWorkDirFilter}
+
+func NewWithOptions(obs Observer, opts ...Option) (Interface, chan error, error) {
+	m := &manager{
+		packages: make(map[string]*node),
+	}
+
+	for _, opt := range opts {
+		if err := opt(m); err != nil {
+			if m.watcher != nil {
+				m.watcher.Close()
+			}
+			return nil, nil, err
+		}
+	}
+
+	// Start listening for events via the filesystem watcher.
+	go func() {
+		for {
+			event, ok := <-m.eventCh
+			if !ok {
+				// When the channel has been closed, the watcher is shutting down
+				// and we should return to cleanup the go routine.
+				return
+			}
+
+			// Apply our file filters to improve the signal-to-noise.
+			skip := false
+			for _, f := range m.fileFilters {
+				if f(event.Name) {
+					skip = true
+				}
+			}
+			if skip {
+				continue
+			}
+
+			// Determine what package contains this file
+			// and signal the change.  Call our Observer
+			// on affected targets when we're done.
+			if n := m.enclosingPackage(event.Name); n != nil {
+				m.onChange(n, func(n *node) {
+					obs(m.affectedTargets(n))
+				})
+			}
+		}
+	}()
+
+	return m, m.errCh, nil
+}
+
+// notification is a callback that internal consumers of manager may use to get
+// a crack at a node after it has been updated.
+type notification func(*node)
+
+// empty implements notification and does nothing.
+func empty(n *node) {}
+
+type watcher interface {
+	Add(string) error
+	Remove(string) error
+	Close() error
+}
+
+type manager struct {
+	m sync.Mutex
+
+	ctx *gb.Context
+
+	pkgFilters  []PackageFilter
+	fileFilters []FileFilter
+
+	packages map[string]*node
+	watcher  watcher
+
+	// The working directory relative to which import paths are evaluated.
+	workdir string
+
+	errCh   chan error
+	eventCh chan fsnotify.Event
+}
+
+// manager implements Interface
+var _ Interface = (*manager)(nil)
+
+// manager implements fmt.Stringer
+var _ fmt.Stringer = (*manager)(nil)
+
+// Add implements Interface
+func (m *manager) Add(importpath string) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	_, _, err := m.add(importpath, nil)
+	return err
+}
+
+// add adds the provided importpath (if it doesn't exist) and optionally
+// adds the dependent node (if provided) as a dependent of the target.
+// This returns the node for the provided importpath, whether the dependency
+// structure has changed, and any errors that may have occurred adding the node.
+func (m *manager) add(importpath string, dependent *node) (*node, bool, error) {
+	// INVARIANT m.m must be held to call this.
+	if pkg, ok := m.packages[importpath]; ok {
+		return pkg, pkg.addDependent(dependent), nil
+	}
+
+	// New nodes always start as a simple shell, then we set up the
+	// fsnotify and immediate simulate a change to prompt the package
+	// to load its data.  A good analogy would be how the "diff" in
+	// a code review for new files looks like everything being added;
+	// so too does this first simulated change pull in the rest of the
+	// dependency graph.
+	newNode := &node{
+		name: importpath,
+	}
+	m.packages[importpath] = newNode
+	newNode.addDependent(dependent)
+
+	// Load the package once to determine it's filesystem location,
+	// and set up a watch on that location.
+	pkg, err := m.ctx.Import(importpath, m.workdir, gb.ImportComment)
+	if err != nil {
+		newNode.removeDependent(dependent)
+		delete(m.packages, importpath)
+		return nil, false, err
+	}
+	if err := m.watcher.Add(pkg.Dir); err != nil {
+		newNode.removeDependent(dependent)
+		delete(m.packages, importpath)
+		return nil, false, err
+	}
+
+	// This is done via go routine so that it can take over the lock.
+	go m.onChange(newNode, empty)
+
+	return newNode, true, nil
+}
+
+// affectedTargets returns the set of targets that would be affected by a
+// change to the target represented by the given node.  This set is comprised
+// of the transitive dependents of the node, including itself.
+func (m *manager) affectedTargets(n *node) StringSet {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	return n.transitiveDependents()
+}
+
+// enclosingPackage returns the node for the package covering the
+// watched path.
+func (m *manager) enclosingPackage(path string) *node {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	dir := filepath.Dir(path)
+	for k, v := range m.packages {
+		if strings.HasSuffix(dir, k) {
+			return v
+		}
+	}
+	return nil
+}
+
+// onChange updates the graph based on the current state of the package
+// represented by the given node.  Once the graph has been updated, the
+// notification function is called on the node.
+func (m *manager) onChange(changed *node, not notification) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	// Load the package information and update dependencies.
+	pkg, err := m.ctx.Import(changed.name, m.workdir, gb.ImportComment)
+	if err != nil {
+		m.errCh <- err
+		return
+	}
+
+	// haveDepsChanged := false
+	seen := make(StringSet)
+	for _, ip := range pkg.Imports {
+		if ip == "C" {
+			// skip cgo
+			continue
+		}
+		subpkg, err := m.ctx.Import(ip, m.workdir, gb.ImportComment)
+		if err != nil {
+			m.errCh <- err
+			return
+		}
+
+		skip := false
+		for _, f := range m.pkgFilters {
+			if f(subpkg) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		n, chg, err := m.add(subpkg.ImportPath, changed)
+		if err != nil {
+			m.errCh <- err
+			return
+		} else if chg {
+			// haveDepsChanged = true
+		}
+		if changed.addDependency(n) {
+			// haveDepsChanged = true
+		}
+		seen.Add(subpkg.ImportPath)
+	}
+
+	// Remove dependencies that we no longer have.
+	removed := changed.removeUnseenDependencies(seen)
+	if len(removed) > 0 {
+		// haveDepsChanged = true
+	}
+	for _, dependency := range removed {
+		d := dependency
+		go m.maybeGC(d)
+	}
+
+	// log.Printf("Processing %s, have deps changed: %v", changed.name, haveDepsChanged)
+	// Done via go routine so that we can be passed a callback that
+	// takes the lock on manager.
+	go not(changed)
+}
+
+func (m *manager) maybeGC(n *node) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if len(n.dependents) > 0 {
+		// It has dependents, so it should not be removed.
+		return
+	}
+
+	// If it has zero dependents, then remove it from the packages map.
+	delete(m.packages, n.name)
+
+	// Lookup the package information, so that we know what directory to stop watching.
+	subpkg, err := m.ctx.Import(n.name, m.workdir, gb.ImportComment)
+	if err != nil {
+		m.errCh <- err
+		return
+	}
+
+	// Remove the watch on the package's directory
+	if err := m.watcher.Remove(subpkg.Dir); err != nil {
+		m.errCh <- err
+		return
+	}
+
+	for _, dependency := range n.dependencies {
+		dependency.removeDependent(n)
+
+		d := dependency
+		go m.maybeGC(d)
+	}
+}
+
+// Shutdown implements Interface.
+func (m *manager) Shutdown() error {
+	return m.watcher.Close()
+}
+
+// String implements fmt.Stringer
+func (m *manager) String() string {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	// WTB Topo sort.
+	order := []string{}
+	for k := range m.packages {
+		order = append(order, k)
+	}
+	sort.Strings(order)
+
+	parts := []string{}
+	for _, key := range order {
+		parts = append(parts, m.packages[key].String())
+	}
+	return strings.Join(parts, "\n")
+}

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/manager_options.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/manager_options.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	gb "go/build"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// PackageFilter is the type of functions that determine whether to omit a
+// particular Go package from the dependency graph.
+type PackageFilter func(*gb.Package) bool
+
+// OmitVendor implements PackageFilter to exclude packages in the vendor directory.
+func OmitVendor(pkg *gb.Package) bool {
+	return strings.Contains(pkg.ImportPath, "/vendor/")
+}
+
+// FileFilter is the type of functions that determine whether to omit a particular
+// file from triggering a package-level event.
+type FileFilter func(string) bool
+
+// OmitNonGo implements FileFilter to exclude non-Go files from triggering package
+// change notifications.
+func OmitNonGo(path string) bool {
+	return filepath.Ext(path) != ".go"
+}
+
+// OmitTests implements FileFilter to exclude Go test files from triggering package
+// change notifications.
+func OmitTest(path string) bool {
+	return strings.HasSuffix(path, "_test.go")
+}
+
+// Option is used to mutate the underlying graph implementation during construction.
+// Since the implementation's type is private this may only be implemented from within
+// this package.
+type Option func(*manager) error
+
+// WithWorkDir configures the graph to use the provided working directory.
+func WithWorkDir(workdir string) Option {
+	return func(m *manager) error {
+		m.workdir = workdir
+		return nil
+	}
+}
+
+// WithCurrentDirectory configures the working directory to be the current directory
+func WithCurrentDirectory(m *manager) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return WithWorkDir(wd)(m)
+}
+
+// WithContext configures the graph to use the provided Go build context.
+func WithContext(ctx *gb.Context) Option {
+	return func(m *manager) error {
+		m.ctx = ctx
+		return nil
+	}
+}
+
+// WithFSNotify configures the graph to use fsnotify to implement its watcher and error channel.
+func WithFSNotify(m *manager) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	m.watcher = watcher
+	m.errCh = watcher.Errors
+	m.eventCh = watcher.Events
+	return nil
+}
+
+// WithFileFilter configures the graph implementation with the provided file filters.
+func WithFileFilter(ff ...FileFilter) Option {
+	return func(m *manager) error {
+		m.fileFilters = append(m.fileFilters, ff...)
+		return nil
+	}
+}
+
+// WithPackageFilter configures the graph implementation with the provided package filters.
+func WithPackageFilter(ff ...PackageFilter) Option {
+	return func(m *manager) error {
+		m.pkgFilters = append(m.pkgFilters, ff...)
+		return nil
+	}
+}
+
+// WithOutsideWorkDirFilter configures the graph with a package filter that omits files outside
+// of the configured working directory.
+func WithOutsideWorkDirFilter(m *manager) error {
+	m.pkgFilters = append(m.pkgFilters, func(pkg *gb.Package) bool {
+		return !strings.HasPrefix(pkg.Dir, m.workdir)
+	})
+	return nil
+}

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/node.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/node.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"fmt"
+)
+
+// node holds a single node in our dependency graph and its immediately adjacent neighbors.
+type node struct {
+	// The canonical import path for this node.
+	name string
+
+	// The dependency structure
+	dependencies []*node
+	dependents   []*node
+}
+
+// node implements fmt.Stringer
+var _ fmt.Stringer = (*node)(nil)
+
+// String implements fmt.Stringer
+func (n *node) String() string {
+	return fmt.Sprintf(`---
+name: %s
+depdnt: %v
+depdncy: %v`, n.name, names(n.dependents), names(n.dependencies))
+}
+
+// addDependent adds the given dependent to the list of dependents for
+// the given dependency.  Dependent may be nil.
+// This returns whether the node's neighborhood changes.
+// The manager's lock must be held before calling this.
+func (dependency *node) addDependent(dependent *node) bool {
+	if dependent == nil {
+		return false
+	}
+
+	for _, depdnt := range dependency.dependents {
+		if depdnt == dependent {
+			// Already a dependent
+			return false
+		}
+	}
+
+	// log.Printf("Adding %s <- %s", dependent.name, dependency.name)
+	dependency.dependents = append(dependency.dependents, dependent)
+	return true
+}
+
+// addDependency adds the given dependency to the list of dependencies for
+// the given dependent.  Neither parameter may be nil.
+// This returns whether the node's neighborhood changes.
+// The manager's lock must be held before calling this.
+func (dependent *node) addDependency(dependency *node) bool {
+	for _, depdcy := range dependent.dependencies {
+		if depdcy == dependency {
+			// Already a dependency
+			return false
+		}
+	}
+
+	// log.Printf("Adding %s -> %s", dependent.name, dependency.name)
+	dependent.dependencies = append(dependent.dependencies, dependency)
+	return true
+}
+
+// removeDependent removes the given dependent to the list of dependents for
+// the given dependency.  Dependent may be nil.
+// This returns whether the node's neighborhood changes.
+// The manager's lock must be held before calling this.
+func (dependency *node) removeDependent(dependent *node) bool {
+	for i, depdnt := range dependency.dependents {
+		if depdnt == dependent {
+			dependency.dependents = append(
+				dependency.dependents[:i], dependency.dependents[i+1:]...)
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeDependency removes the given dependency to the list of dependencies for
+// the given dependent.  Neither parameter may be nil.
+// This returns whether the node's neighborhood changes.
+// The manager's lock must be held before calling this.
+func (dependent *node) removeDependency(dependency *node) bool {
+	for i, depdcy := range dependent.dependencies {
+		if depdcy == dependency {
+			dependent.dependencies = append(
+				dependent.dependencies[:i], dependent.dependencies[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// removeUnseenDependencies removes dependencies that aren't in the list of seen
+// names.  Returns the list of nodes that correspond to the named dependencies removed.
+func (dependent *node) removeUnseenDependencies(seen StringSet) []*node {
+	keep := make([]*node, 0, len(dependent.dependencies))
+	toss := make([]*node, 0, len(dependent.dependencies))
+	for _, dep := range dependent.dependencies {
+		if seen.Has(dep.name) {
+			keep = append(keep, dep)
+		} else {
+			toss = append(toss, dep)
+			dependent.removeDependency(dep)
+			dep.removeDependent(dependent)
+		}
+	}
+	dependent.dependencies = keep
+	return toss
+}
+
+// transitiveDependents collects the set of node names transitively reachable
+// by following the "dependents" edges.
+func (n *node) transitiveDependents() StringSet {
+	return n.transitiveFoo(func(n *node) []*node {
+		return n.dependents
+	})
+}
+
+// transitiveDependencies collects the set of node names transitively reachable
+// by following the "dependencies" edges.
+func (n *node) transitiveDependencies() StringSet {
+	return n.transitiveFoo(func(n *node) []*node {
+		return n.dependencies
+	})
+}
+
+// neighbors defines a function for returning the neighbors of a
+// particular node.
+type neighbors func(*node) []*node
+
+// transitiveDependents collects the set of node names transitively reachable
+// by following the edges determines by the "neighbors" function.
+func (n *node) transitiveFoo(nbr neighbors) StringSet {
+	// We will use "set" as the visited group for our DFS.
+	set := make(StringSet)
+	queue := []*node{n}
+
+	for len(queue) != 0 {
+		// Pop the top element off of the queue.
+		top := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		// Check/Mark visited
+		if set.Has(top.name) {
+			continue
+		}
+		set.Add(top.name)
+
+		// Append this node's dependents to our search.
+		queue = append(queue, nbr(top)...)
+	}
+
+	return set
+}
+
+// names returns the deduplicated and sorted names of the provided nodes.
+func names(ns []*node) []string {
+	ss := make(StringSet, len(ns))
+	for _, n := range ns {
+		ss.Add(n.name)
+	}
+	return ss.InOrder()
+}

--- a/vendor/github.com/mattmoor/dep-notify/pkg/graph/set.go
+++ b/vendor/github.com/mattmoor/dep-notify/pkg/graph/set.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 Matt Moore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"sort"
+)
+
+// StringSet is a simple abstraction for holding a collection of deduplicated strings.
+type StringSet map[string]struct{}
+
+// Add inserts a provided key into our set.
+func (ss *StringSet) Add(key string) {
+	(*ss)[key] = struct{}{}
+}
+
+// Remove deletes a provided key from our set.
+func (ss *StringSet) Remove(key string) {
+	delete(*ss, key)
+}
+
+// Has returns whether the set contains the provided key.
+func (ss *StringSet) Has(key string) bool {
+	_, ok := (*ss)[key]
+	return ok
+}
+
+// InOrder returns the keys of the set in the ordering determined by sort.Strings.
+func (ss StringSet) InOrder() []string {
+	keys := make([]string, 0, len(ss))
+	for k := range ss {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}


### PR DESCRIPTION
This adds experimental support for fsnotify integration for `ko apply`.

With this change you can run: `ko apply --watch -f config/` and it will perform the typical deployment step, and then begin to monitor the referenced go paths from each of the yaml files for changes using github.com/mattmoor/dep-notify (a Go dependency graph library built around fsnotify).

When a change is found, only the yaml files that reference the image in question are re-applied.  In watch mode, compilation failures are ignored (so they may be remedied and picked up by the watch).
