### PR TITLE
Improve structured error printing

### DIFF
--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
@@ -75,7 +74,7 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 	}
 	defer resp.Body.Close()
 
-	if err := remote.CheckError(resp, http.StatusOK); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
 		return nil, err
 	}
 

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -125,7 +125,7 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusOK); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
 		return nil, err
 	}
 
@@ -207,7 +207,7 @@ func (rl *remoteLayer) Compressed() (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	if err := CheckError(resp, http.StatusOK); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
 		resp.Body.Close()
 		return nil, err
 	}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -51,7 +51,7 @@ func List(repo name.Repository, auth authn.Authenticator, t http.RoundTripper) (
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusOK); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
 		return nil, err
 	}
 

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -15,9 +15,8 @@
 package transport
 
 import (
-	"fmt"
-
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -102,6 +101,10 @@ func (bt *bearerTransport) refresh() error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if err := CheckError(resp, http.StatusOK); err != nil {
+		return err
+	}
 
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -57,7 +57,7 @@ type Diagnostic struct {
 
 // String stringifies the Diagnostic
 func (d Diagnostic) String() string {
-	return fmt.Sprintf("%s: %q", d.Code, d.Message)
+	return fmt.Sprintf("%s: %s", d.Code, d.Message)
 }
 
 // ErrorCode is an enumeration of supported error codes.

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -55,9 +55,13 @@ type Diagnostic struct {
 	Detail  interface{} `json:"detail,omitempty"`
 }
 
-// String stringifies the Diagnostic
+// String stringifies the Diagnostic in the form: $Code: $Message[; $Detail]
 func (d Diagnostic) String() string {
-	return fmt.Sprintf("%s: %s", d.Code, d.Message)
+	msg := fmt.Sprintf("%s: %s", d.Code, d.Message)
+	if d.Detail != nil {
+		msg = fmt.Sprintf("%s; %v", msg, d.Detail)
+	}
+	return msg
 }
 
 // ErrorCode is an enumeration of supported error codes.

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package remote
+package transport
 
 import (
 	"encoding/json"
@@ -35,7 +35,7 @@ var _ error = (*Error)(nil)
 func (e *Error) Error() string {
 	switch len(e.Errors) {
 	case 0:
-		return "<empty remote.Error response>"
+		return "<empty transport.Error response>"
 	case 1:
 		return e.Errors[0].String()
 	default:

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package remote
+package transport
 
 import (
 	"bytes"
@@ -109,7 +109,7 @@ func TestCheckErrorWithError(t *testing.T) {
 		if err := CheckError(resp, http.StatusOK); err == nil {
 			t.Errorf("CheckError(%d, %s) = nil, wanted error", test.code, string(b))
 		} else if se, ok := err.(*Error); !ok {
-			t.Errorf("CheckError(%d, %s) = %T, wanted *remote.Error", test.code, string(b), se)
+			t.Errorf("CheckError(%d, %s) = %T, wanted *transport.Error", test.code, string(b), se)
 		} else if diff := cmp.Diff(test.error, se); diff != "" {
 			t.Errorf("CheckError(%d, %s); (-want +got) %s", test.code, string(b), diff)
 		}

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -72,6 +72,7 @@ func TestCheckErrorWithError(t *testing.T) {
 	tests := []struct {
 		code  int
 		error *Error
+		msg   string
 	}{{
 		code: http.StatusBadRequest,
 		error: &Error{
@@ -80,9 +81,11 @@ func TestCheckErrorWithError(t *testing.T) {
 				Message: "a message for you",
 			}},
 		},
+		msg: "NAME_INVALID: a message for you",
 	}, {
 		code:  http.StatusBadRequest,
 		error: &Error{},
+		msg:   "<empty transport.Error response>",
 	}, {
 		code: http.StatusBadRequest,
 		error: &Error{
@@ -92,8 +95,10 @@ func TestCheckErrorWithError(t *testing.T) {
 			}, {
 				Code:    SizeInvalidErrorCode,
 				Message: "another message for you",
+				Detail:  "with some details",
 			}},
 		},
+		msg: "multiple errors returned: NAME_INVALID: a message for you;SIZE_INVALID: another message for you; with some details",
 	}}
 
 	for _, test := range tests {
@@ -112,6 +117,8 @@ func TestCheckErrorWithError(t *testing.T) {
 			t.Errorf("CheckError(%d, %s) = %T, wanted *transport.Error", test.code, string(b), se)
 		} else if diff := cmp.Diff(test.error, se); diff != "" {
 			t.Errorf("CheckError(%d, %s); (-want +got) %s", test.code, string(b), diff)
+		} else if diff := cmp.Diff(test.msg, test.error.Error()); diff != "" {
+			t.Errorf("CheckError(%d, %s).Error(); (-want +got) %s", test.code, string(b), diff)
 		}
 	}
 }

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -139,7 +139,7 @@ func (w *writer) checkExisting(h v1.Hash) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusOK, http.StatusNotFound); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound); err != nil {
 		return false, err
 	}
 
@@ -170,7 +170,7 @@ func (w *writer) initiateUpload(from, mount string) (location string, mounted bo
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusCreated, http.StatusAccepted); err != nil {
+	if err := transport.CheckError(resp, http.StatusCreated, http.StatusAccepted); err != nil {
 		return "", false, err
 	}
 
@@ -205,7 +205,7 @@ func (w *writer) streamBlob(blob io.ReadCloser, streamLocation string) (commitLo
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusNoContent, http.StatusAccepted, http.StatusCreated); err != nil {
+	if err := transport.CheckError(resp, http.StatusNoContent, http.StatusAccepted, http.StatusCreated); err != nil {
 		return "", err
 	}
 
@@ -236,7 +236,7 @@ func (w *writer) commitBlob(location, digest string) error {
 	}
 	defer resp.Body.Close()
 
-	return CheckError(resp, http.StatusCreated)
+	return transport.CheckError(resp, http.StatusCreated)
 }
 
 // uploadOne performs a complete upload of a single layer.
@@ -331,7 +331,7 @@ func (w *writer) commitImage() error {
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted); err != nil {
 		return err
 	}
 

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -790,9 +790,9 @@ func TestWriteWithErrors(t *testing.T) {
 	headPathPrefix := fmt.Sprintf("/v2/%s/blobs/", expectedRepo)
 	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
 
-	expectedError := &Error{
-		Errors: []Diagnostic{{
-			Code:    NameInvalidErrorCode,
+	expectedError := &transport.Error{
+		Errors: []transport.Diagnostic{{
+			Code:    transport.NameInvalidErrorCode,
 			Message: "some explanation of how things were messed up.",
 		}},
 	}
@@ -831,7 +831,7 @@ func TestWriteWithErrors(t *testing.T) {
 
 	if err := Write(tag, img, authn.Anonymous, http.DefaultTransport); err == nil {
 		t.Error("Write() = nil; wanted error")
-	} else if se, ok := err.(*Error); !ok {
+	} else if se, ok := err.(*transport.Error); !ok {
 		t.Errorf("Write() = %T; wanted *remote.Error", se)
 	} else if diff := cmp.Diff(expectedError, se); diff != "" {
 		t.Errorf("Write(); (-want +got) = %s", diff)


### PR DESCRIPTION
Fixes #340 

Before:
```
$ crane manifest gcr.io//bad/image
2019/01/08 22:50:02 reading image "gcr.io//bad/image:latest": no token in bearer response:
{"errors":[{"code":"NAME_INVALID","message":"Invalid resource name: \"repository:/bad/image:pull\", must match: \"[a-z0-9._-]+(?:/[a-z0-9._-]+)*\""}]}
```

After:
```
$ crane manifest gcr.io//bad/image
2019/01/08 22:49:19 reading image "gcr.io//bad/image:latest": NAME_INVALID: Invalid resource name: "repository:/bad/image:pull", must match: "[a-z0-9._-]+(?:/[a-z0-9._-]+)*"
```

Note that this moves `CheckError` into the `transport` package so we can use it there as well as in `remote`.