### PR TITLE
Allow to override tags on publish

### DIFF
--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -131,7 +131,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 			if err != nil {
 				log.Fatalf("error piping to 'kubectl apply': %v", err)
 			}
-			go resolveFilesToWriter(fo, no, lo, stdin)
+			go resolveFilesToWriter(fo, no, lo, ta, stdin)
 
 			// Run it.
 			if err := kubectlCmd.Run(); err != nil {
@@ -142,6 +142,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 	addLocalArg(apply, lo)
 	addNamingArgs(apply, no)
 	addFileArg(apply, fo)
+	addTagsArg(apply, ta)
 
 	// Collect the ko-specific apply flags before registering the kubectl global
 	// flags so that we can ignore them when passing kubectl global flags through
@@ -182,12 +183,13 @@ func addKubeCommands(topLevel *cobra.Command) {
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			resolveFilesToWriter(fo, no, lo, os.Stdout)
+			resolveFilesToWriter(fo, no, lo, ta, os.Stdout)
 		},
 	}
 	addLocalArg(resolve, lo)
 	addNamingArgs(resolve, no)
 	addFileArg(resolve, fo)
+	addTagsArg(resolve, ta)
 	topLevel.AddCommand(resolve)
 
 	publish := &cobra.Command{
@@ -276,6 +278,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 	addLocalArg(run, lo)
 	addNamingArgs(run, no)
 	addImageArg(run, bo)
+	addTagsArg(run, ta)
 
 	topLevel.AddCommand(run)
 }

--- a/cmd/ko/commands.go
+++ b/cmd/ko/commands.go
@@ -69,6 +69,7 @@ func addKubeCommands(topLevel *cobra.Command) {
 	bo := &BinaryOptions{}
 	no := &NameOptions{}
 	fo := &FilenameOptions{}
+	ta := &TagsOptions{}
 	apply := &cobra.Command{
 		Use:   "apply -f FILENAME",
 		Short: "Apply the input files with image references resolved to built/pushed image digests.",
@@ -220,11 +221,12 @@ func addKubeCommands(topLevel *cobra.Command) {
   ko publish --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			publishImages(args, no, lo)
+			publishImages(args, no, lo, ta)
 		},
 	}
 	addLocalArg(publish, lo)
 	addNamingArgs(publish, no)
+	addTagsArg(publish, ta)
 	topLevel.AddCommand(publish)
 
 	run := &cobra.Command{
@@ -241,7 +243,7 @@ func addKubeCommands(topLevel *cobra.Command) {
   # This supports relative import paths as well.
   ko run foo --image=./cmd/baz`,
 		Run: func(cmd *cobra.Command, args []string) {
-			imgs := publishImages([]string{bo.Path}, no, lo)
+			imgs := publishImages([]string{bo.Path}, no, lo, ta)
 
 			// There's only one, but this is the simple way to access the
 			// reference since the import path may have been qualified.

--- a/cmd/ko/publish.go
+++ b/cmd/ko/publish.go
@@ -38,7 +38,7 @@ func qualifyLocalImport(importpath, gopathsrc, pwd string) (string, error) {
 	return filepath.Join(strings.TrimPrefix(pwd, gopathsrc+string(filepath.Separator)), importpath), nil
 }
 
-func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) map[string]name.Reference {
+func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions, ta *TagsOptions) map[string]name.Reference {
 	opt, err := gobuildOptions()
 	if err != nil {
 		log.Fatalf("error setting up builder options: %v", err)
@@ -84,12 +84,12 @@ func publishImages(importpaths []string, no *NameOptions, lo *LocalOptions) map[
 		}
 
 		if lo.Local || repoName == publish.LocalDomain {
-			pub = publish.NewDaemon(namer)
+			pub = publish.NewDaemon(namer, ta.Tags)
 		} else {
 			if _, err := name.NewRepository(repoName, name.WeakValidation); err != nil {
 				log.Fatalf("the environment variable KO_DOCKER_REPO must be set to a valid docker repository, got %v", err)
 			}
-			opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain), publish.WithNamer(namer)}
+			opts := []publish.Option{publish.WithAuthFromKeychain(authn.DefaultKeychain), publish.WithNamer(namer), publish.WithTags(ta.Tags)}
 			pub, err = publish.NewDefault(repoName, opts...)
 			if err != nil {
 				log.Fatalf("error setting up default image publisher: %v", err)

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -87,7 +87,7 @@ func makePublisher(no *NameOptions, lo *LocalOptions) (publish.Interface, error)
 
 		repoName := os.Getenv("KO_DOCKER_REPO")
 		if lo.Local || repoName == publish.LocalDomain {
-			return publish.NewDaemon(namer), nil
+			return publish.NewDaemon(namer, []string{}), nil
 		}
 		_, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {

--- a/cmd/ko/resolve.go
+++ b/cmd/ko/resolve.go
@@ -74,7 +74,7 @@ func makeBuilder() (*build.Caching, error) {
 	return build.NewCaching(innerBuilder)
 }
 
-func makePublisher(no *NameOptions, lo *LocalOptions) (publish.Interface, error) {
+func makePublisher(no *NameOptions, lo *LocalOptions, ta *TagsOptions) (publish.Interface, error) {
 	// Create the publish.Interface that we will use to publish image references
 	// to either a docker daemon or a container image registry.
 	innerPublisher, err := func() (publish.Interface, error) {
@@ -87,7 +87,7 @@ func makePublisher(no *NameOptions, lo *LocalOptions) (publish.Interface, error)
 
 		repoName := os.Getenv("KO_DOCKER_REPO")
 		if lo.Local || repoName == publish.LocalDomain {
-			return publish.NewDaemon(namer, []string{}), nil
+			return publish.NewDaemon(namer, ta.Tags), nil
 		}
 		_, err := name.NewRepository(repoName, name.WeakValidation)
 		if err != nil {
@@ -96,7 +96,8 @@ func makePublisher(no *NameOptions, lo *LocalOptions) (publish.Interface, error)
 
 		return publish.NewDefault(repoName,
 			publish.WithAuthFromKeychain(authn.DefaultKeychain),
-			publish.WithNamer(namer))
+			publish.WithNamer(namer),
+			publish.WithTags(ta.Tags))
 	}()
 	if err != nil {
 		return nil, err
@@ -109,7 +110,7 @@ func makePublisher(no *NameOptions, lo *LocalOptions) (publish.Interface, error)
 // resolvedFuture represents a "future" for the bytes of a resolved file.
 type resolvedFuture chan []byte
 
-func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions, out io.WriteCloser) {
+func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions, ta *TagsOptions, out io.WriteCloser) {
 	defer out.Close()
 	builder, err := makeBuilder()
 	if err != nil {
@@ -117,7 +118,7 @@ func resolveFilesToWriter(fo *FilenameOptions, no *NameOptions, lo *LocalOptions
 	}
 
 	// Wrap publisher in a memoizing publisher implementation.
-	publisher, err := makePublisher(no, lo)
+	publisher, err := makePublisher(no, lo, ta)
 	if err != nil {
 		log.Fatalf("error creating publisher: %v", err)
 	}

--- a/cmd/ko/tags.go
+++ b/cmd/ko/tags.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type TagsOptions struct {
+	Tags []string
+}
+
+func addTagsArg(cmd *cobra.Command, ta *TagsOptions) {
+	cmd.Flags().StringSliceVar(&ta.Tags, "tags", ta.Tags,
+		"Which tags to use for the produced image instead of the default 'latest' tag.")
+}

--- a/cmd/ko/tags.go
+++ b/cmd/ko/tags.go
@@ -18,11 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TagsOptions holds the list of tags to tag the built image
 type TagsOptions struct {
 	Tags []string
 }
 
 func addTagsArg(cmd *cobra.Command, ta *TagsOptions) {
-	cmd.Flags().StringSliceVar(&ta.Tags, "tags", ta.Tags,
+	cmd.Flags().StringSliceVarP(&ta.Tags, "tags", "t", []string{"latest"},
 		"Which tags to use for the produced image instead of the default 'latest' tag.")
 }

--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -49,13 +49,16 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 		return nil, err
 	}
 
-	for _, tagName := range d.tags {
+	tagsAndDigest := append(d.tags, h.Hex)
+
+	for _, tagName := range tagsAndDigest {
 		tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", LocalDomain, d.namer(s), tagName), name.WeakValidation)
 		if err != nil {
 			return nil, err
 		}
 		log.Printf("Loading %v", tag)
-		// TODO: This is slow because we have to load the image multiple times. We should use client.ImageTag instead
+		// TODO: This is slow because we have to load the image multiple times.
+		// We should use client.ImageTag instead
 		if _, err := daemon.Write(tag, img); err != nil {
 			return nil, err
 		}

--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -55,6 +55,7 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 			return nil, err
 		}
 		log.Printf("Loading %v", tag)
+		// TODO: This is slow because we have to load the image multiple times. We should use client.ImageTag instead
 		if _, err := daemon.Write(tag, img); err != nil {
 			return nil, err
 		}

--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -49,10 +49,6 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 		return nil, err
 	}
 
-	if len(d.tags) == 0 {
-		d.tags = []string{"latest"}
-	}
-
 	for _, tagName := range d.tags {
 		tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", LocalDomain, d.namer(s), tagName), name.WeakValidation)
 		if err != nil {

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
@@ -47,7 +48,21 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def := NewDaemon(md5Hash)
+	def := NewDaemon(md5Hash, []string{})
+	if d, err := def.Publish(img, importpath); err != nil {
+		t.Errorf("Publish() = %v", err)
+	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {
+		t.Errorf("Publish() = %v, wanted prefix %v", got, want)
+	}
+}
+func TestDaemonAdditionalTags(t *testing.T) {
+	importpath := "github.com/google/go-containerregistry/cmd/ko"
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+
+	def := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"})
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -55,6 +55,7 @@ func TestDaemon(t *testing.T) {
 		t.Errorf("Publish() = %v, wanted prefix %v", got, want)
 	}
 }
+
 func TestDaemonAdditionalTags(t *testing.T) {
 	importpath := "github.com/google/go-containerregistry/cmd/ko"
 	img, err := random.Image(1024, 1)
@@ -62,7 +63,7 @@ func TestDaemonAdditionalTags(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"})
+	def := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", " production"})
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -56,7 +56,7 @@ func TestDaemon(t *testing.T) {
 	}
 }
 
-func TestDaemonAdditionalTags(t *testing.T) {
+func TestDaemonTags(t *testing.T) {
 	importpath := "github.com/google/go-containerregistry/cmd/ko"
 	img, err := random.Image(1024, 1)
 	if err != nil {

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -63,7 +63,7 @@ func TestDaemonTags(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", " production"})
+	def := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"})
 	if d, err := def.Publish(img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {

--- a/pkg/ko/publish/default.go
+++ b/pkg/ko/publish/default.go
@@ -55,7 +55,7 @@ type Namer func(string) string
 //   ^--base--^ ^-------import path-------^
 func identity(in string) string { return in }
 
-// As some registries do not support push an image by digest, the default tag for pushing
+// As some registries do not support pushing an image by digest, the default tag for pushing
 // is the 'latest' tag.
 var defaultTags = []string{"latest"}
 

--- a/pkg/ko/publish/default.go
+++ b/pkg/ko/publish/default.go
@@ -100,6 +100,8 @@ func (d *defalt) Publish(img v1.Image, s string) (name.Reference, error) {
 		}
 
 		log.Printf("Publishing %v", tag)
+		// TODO: This is slow because we have to load the image multiple times.
+		// Figure out some way to publish the manifest with another tag.
 		if err := remote.Write(tag, img, d.auth, d.t); err != nil {
 			return nil, err
 		}

--- a/pkg/ko/publish/default_test.go
+++ b/pkg/ko/publish/default_test.go
@@ -18,7 +18,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -221,7 +220,4 @@ func TestDefaultWithTags(t *testing.T) {
 	if _, ok := createdTags["v1.2.3"]; !ok {
 		t.Errorf("Tag v1.2.3 was not created.")
 	}
-
-	log.Println(createdTags)
-
 }

--- a/pkg/ko/publish/default_test.go
+++ b/pkg/ko/publish/default_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -148,4 +149,79 @@ func TestDefaultWithCustomNamer(t *testing.T) {
 	} else if !strings.HasSuffix(d.Context().String(), md5Hash(strings.ToLower(importpath))) {
 		t.Errorf("Publish() = %v, wanted suffix %v", d.Context(), md5Hash(importpath))
 	}
+}
+
+func TestDefaultWithTags(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	base := "blah"
+	importpath := "github.com/Google/go-containerregistry/cmd/crane"
+	expectedRepo := fmt.Sprintf("%s/%s", base, strings.ToLower(importpath))
+	headPathPrefix := fmt.Sprintf("/v2/%s/blobs/", expectedRepo)
+	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/", expectedRepo)
+
+	createdTags := make(map[string]struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.HasPrefix(r.URL.Path, headPathPrefix) && r.URL.Path != initiatePath {
+			http.Error(w, "NotFound", http.StatusNotFound)
+			return
+		}
+		switch {
+		case r.URL.Path == "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == initiatePath:
+			if r.Method != http.MethodPost {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
+			}
+			http.Error(w, "Mounted", http.StatusCreated)
+		case strings.HasPrefix(r.URL.Path, manifestPath):
+			if r.Method != http.MethodPut {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPut)
+			}
+
+			createdTags[strings.TrimPrefix(r.URL.Path, manifestPath)] = struct{}{}
+
+			http.Error(w, "Created", http.StatusCreated)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+	tag, err := name.NewTag(fmt.Sprintf("%s/%s:notLatest", u.Host, expectedRepo), name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	repoName := fmt.Sprintf("%s/%s", u.Host, base)
+
+	def, err := NewDefault(repoName, WithTags([]string{"notLatest", "v1.2.3"}))
+	if err != nil {
+		t.Errorf("NewDefault() = %v", err)
+	}
+	if d, err := def.Publish(img, importpath); err != nil {
+		t.Errorf("Publish() = %v", err)
+	} else if !strings.HasPrefix(d.String(), repoName) {
+		t.Errorf("Publish() = %v, wanted prefix %v", d, tag.Repository)
+	} else if !strings.HasSuffix(d.Context().String(), strings.ToLower(importpath)) {
+		t.Errorf("Publish() = %v, wanted suffix %v", d.Context(), md5Hash(importpath))
+	}
+
+	if _, ok := createdTags["notLatest"]; !ok {
+		t.Errorf("Tag notLatest was not created.")
+	}
+
+	if _, ok := createdTags["v1.2.3"]; !ok {
+		t.Errorf("Tag v1.2.3 was not created.")
+	}
+
+	log.Println(createdTags)
+
 }

--- a/pkg/ko/publish/options.go
+++ b/pkg/ko/publish/options.go
@@ -72,3 +72,11 @@ func WithNamer(n Namer) Option {
 		return nil
 	}
 }
+
+// WithTags is a functional option for overriding the image tags
+func WithTags(tags []string) Option {
+	return func(i *defaultOpener) error {
+		i.tags = tags
+		return nil
+	}
+}


### PR DESCRIPTION
Sequence from #277. 

I have changed a little the context of the PR. The previous implementation only let you define additional tags, but when pushing an Image, you should have total control over the tags will be pushed.

There are moments when you don't want to publish a `latest` tag, for example when you need to generate a image from a hotfix from a old version of an application.

So with this in mind, when you pass a `--tag=` flag you override the `latest` default tag.

This closes #181 

Note: this requires some more testing. 