### PR TITLE
Load image to daemon only once when writing multiples tags

### DIFF
--- a/pkg/ko/publish/daemon.go
+++ b/pkg/ko/publish/daemon.go
@@ -72,7 +72,7 @@ func (d *demon) Publish(img v1.Image, s string) (name.Reference, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Printf("Added tagged %v", tagName)
+		log.Printf("Added tag %v", tagName)
 	}
 
 	return &digestTag, nil

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -29,6 +29,8 @@ import (
 
 type MockImageLoader struct{}
 
+var Tags []string
+
 func (m *MockImageLoader) ImageLoad(_ context.Context, _ io.Reader, _ bool) (types.ImageLoadResponse, error) {
 	return types.ImageLoadResponse{
 		Body: ioutil.NopCloser(strings.NewReader("Loaded")),
@@ -36,6 +38,7 @@ func (m *MockImageLoader) ImageLoad(_ context.Context, _ io.Reader, _ bool) (typ
 }
 
 func (m *MockImageLoader) ImageTag(ctx context.Context, source, target string) error {
+	Tags = append(Tags, target)
 	return nil
 }
 
@@ -61,6 +64,8 @@ func TestDaemon(t *testing.T) {
 }
 
 func TestDaemonTags(t *testing.T) {
+	Tags = nil
+
 	importpath := "github.com/google/go-containerregistry/cmd/ko"
 	img, err := random.Image(1024, 1)
 	if err != nil {
@@ -72,5 +77,13 @@ func TestDaemonTags(t *testing.T) {
 		t.Errorf("Publish() = %v", err)
 	} else if got, want := d.String(), "ko.local/"+md5Hash(importpath); !strings.HasPrefix(got, want) {
 		t.Errorf("Publish() = %v, wanted prefix %v", got, want)
+	}
+
+	expected := []string{"ko.local/d502d3a1d9858acbab6106d78a0e05f0:v2.0.0", "ko.local/d502d3a1d9858acbab6106d78a0e05f0:v1.2.3", "ko.local/d502d3a1d9858acbab6106d78a0e05f0:production"}
+
+	for i, v := range expected {
+		if Tags[i] != v {
+			t.Errorf("Expected tag %v got %v", v, Tags[i])
+		}
 	}
 }

--- a/pkg/ko/publish/daemon_test.go
+++ b/pkg/ko/publish/daemon_test.go
@@ -35,6 +35,10 @@ func (m *MockImageLoader) ImageLoad(_ context.Context, _ io.Reader, _ bool) (typ
 	}, nil
 }
 
+func (m *MockImageLoader) ImageTag(ctx context.Context, source, target string) error {
+	return nil
+}
+
 func init() {
 	daemon.GetImageLoader = func() (daemon.ImageLoader, error) {
 		return &MockImageLoader{}, nil

--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -47,7 +47,6 @@ var GetImageLoader = func() (ImageLoader, error) {
 // Tag adds a tag to an already existent image.
 func Tag(src, dest name.Tag) error {
 	cli, err := GetImageLoader()
-
 	if err != nil {
 		return err
 	}

--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -44,34 +44,15 @@ var GetImageLoader = func() (ImageLoader, error) {
 	return cli, nil
 }
 
-// WriteAndTag writes the image with the first tag and add the others tags with the
-// client.ImageTag function in order to save unnecesary subsequents Writes
-func WriteAndTag(tags []name.Tag, img v1.Image) (string, error) {
-	firstTag := tags[0]
-
-	r, err := Write(firstTag, img)
-
-	if len(tags) <= 1 {
-		return r, err
-	} else if err != nil {
-		return "", err
-	}
-
+// Tag adds a tag to an already existent image.
+func Tag(src, dest name.Tag) error {
 	cli, err := GetImageLoader()
 
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	for _, tag := range tags[1:] {
-		err := cli.ImageTag(context.Background(), firstTag.String(), tag.String())
-
-		if err != nil {
-			return r, nil
-		}
-	}
-
-	return r, nil
+	return cli.ImageTag(context.Background(), src.String(), dest.String())
 }
 
 // Write saves the image into the daemon as the given tag.

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -16,7 +16,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -31,8 +30,6 @@ import (
 type MockImageLoader struct {
 }
 
-var Tags []string
-
 func (m *MockImageLoader) ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error) {
 	return types.ImageLoadResponse{
 		Body: ioutil.NopCloser(strings.NewReader("Loaded")),
@@ -40,8 +37,6 @@ func (m *MockImageLoader) ImageLoad(context.Context, io.Reader, bool) (types.Ima
 }
 
 func (m *MockImageLoader) ImageTag(ctx context.Context, source, target string) error {
-	Tags = append(Tags, target)
-	fmt.Println("tagging", source, target)
 	return nil
 }
 
@@ -66,36 +61,5 @@ func TestWriteImage(t *testing.T) {
 	}
 	if !strings.Contains(response, "Loaded") {
 		t.Errorf("Error loading image. Response: %s", response)
-	}
-}
-func TestWriteAndTagImages(t *testing.T) {
-	image, err := tarball.ImageFromPath("../tarball/testdata/test_image_1.tar", nil)
-	if err != nil {
-		t.Errorf("Error loading image: %v", err.Error())
-	}
-	tag, err := name.NewTag("test_image_2:latest", name.WeakValidation)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	tagNotLatest, err := name.NewTag("test_image_2:notlatest", name.WeakValidation)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	response, err := WriteAndTag([]name.Tag{tag, tagNotLatest}, image)
-	if err != nil {
-		t.Errorf("Error writing image tar: %s", err.Error())
-	}
-	if !strings.Contains(response, "Loaded") {
-		t.Errorf("Error loading image. Response: %s", response)
-	}
-
-	if len(Tags) != 1 {
-		t.Error("Image should be tagged exactly once after push")
-	}
-
-	if Tags[0] != tagNotLatest.String() {
-		t.Errorf("Image was tagged with tag %s but was expected to be %s.", Tags[0], tagNotLatest.String())
 	}
 }

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -27,8 +27,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-type MockImageLoader struct {
-}
+type MockImageLoader struct{}
 
 func (m *MockImageLoader) ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error) {
 	return types.ImageLoadResponse{


### PR DESCRIPTION
follow up from #345 

With this, the image is written to the docker daemon only once with the first tag and the other tags are added via the `client.ImageTag`.