### PR TITLE
Remove msg-s about using anonymous authenticator

### DIFF
--- a/pkg/ko/publish/options.go
+++ b/pkg/ko/publish/options.go
@@ -15,7 +15,6 @@
 package publish
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -55,9 +54,6 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 		auth, err := keys.Resolve(repo.Registry)
 		if err != nil {
 			return err
-		}
-		if auth == authn.Anonymous {
-			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		i.auth = auth
 		return nil

--- a/pkg/v1/google/options.go
+++ b/pkg/v1/google/options.go
@@ -15,7 +15,6 @@
 package google
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -46,9 +45,6 @@ func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
 		auth, err := keys.Resolve(l.repo.Registry)
 		if err != nil {
 			return err
-		}
-		if auth == authn.Anonymous {
-			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		l.auth = auth
 		return nil

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -15,7 +15,6 @@
 package remote
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -46,9 +45,6 @@ func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
 		auth, err := keys.Resolve(i.ref.Context().Registry)
 		if err != nil {
 			return err
-		}
-		if auth == authn.Anonymous {
-			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		i.auth = auth
 		return nil


### PR DESCRIPTION
These messages may mess up output of some program, that uses go-containerregistry as a library:

```
No matching credentials were found, falling back on anonymous
```

Maybe it should be optional? In this PR I've removed these messages, but it is not a good solution I guess. Don't know how to do it right way.