### PR TITLE
Use gcr.io/distroless/static:latest by default

### DIFF
--- a/cmd/ko/config.go
+++ b/cmd/ko/config.go
@@ -58,7 +58,7 @@ func getCreationTime() (*v1.Time, error) {
 
 func init() {
 	// If omitted, use this base image.
-	viper.SetDefault("defaultBaseImage", "gcr.io/distroless/base:latest")
+	viper.SetDefault("defaultBaseImage", "gcr.io/distroless/static:latest")
 	viper.SetConfigName(".ko") // .yaml is implicit
 
 	if override := os.Getenv("KO_CONFIG_PATH"); override != "" {


### PR DESCRIPTION
Fixes #339 

[`gcr.io/distroless/static:latest`](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md) is an even smaller and more minimal base image designed to be used with statically-compiled binaries (i.e., Go binaries). This base image doesn't include glibc, libssl or openssl.