### PR TITLE
Add "type":"layers" to config RootFS in random

### DIFF
--- a/pkg/v1/empty/image_test.go
+++ b/pkg/v1/empty/image_test.go
@@ -34,4 +34,7 @@ func TestManifestAndConfig(t *testing.T) {
 	if got, want := len(config.RootFS.DiffIDs), 0; got != want {
 		t.Fatalf("num diff ids; got %v, want %v", got, want)
 	}
+	if got, want := config.RootFS.Type, "layers"; got != want {
+		t.Fatalf("rootfs type; got %v, want %v", got, want)
+	}
 }

--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -76,6 +76,9 @@ func Image(byteSize, layers int64) (v1.Image, error) {
 
 	cfg := &v1.ConfigFile{}
 
+	// Some clients check this.
+	cfg.RootFS.Type = "layers"
+
 	// It is ok that iteration order is random in Go, because this is the random image anyways.
 	for k := range layerz {
 		cfg.RootFS.DiffIDs = append(cfg.RootFS.DiffIDs, k)


### PR DESCRIPTION
This is checked by some clients, and using empty.Image fails these
checks because it uses random.Image.