### PR TITLE
Add http fallback

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -63,9 +63,6 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		}
 		in.Header.Set("User-Agent", transportName)
 
-		if bt.scheme == "" {
-			bt.scheme = "https"
-		}
 		in.URL.Scheme = bt.scheme
 		return bt.inner.RoundTrip(in)
 	}

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -76,6 +76,7 @@ func TestBearerRefresh(t *testing.T) {
 				realm:    server.URL,
 				scopes:   []string{expectedScope},
 				service:  expectedService,
+				scheme:   "http",
 			}
 
 			if err := bt.refresh(); (err != nil) != tc.wantErr {
@@ -129,6 +130,7 @@ func TestBearerTransport(t *testing.T) {
 		inner:    &http.Transport{},
 		bearer:   bearer,
 		registry: registry,
+		scheme:   "http",
 	}}
 
 	_, err = client.Get(fmt.Sprintf("http://%s/v2/auth", u.Host))
@@ -175,6 +177,7 @@ func TestBearerTransportTokenRefresh(t *testing.T) {
 		basic:    &authn.Basic{},
 		registry: registry,
 		realm:    server.URL,
+		scheme:   "http",
 	}
 	client := http.Client{Transport: transport}
 
@@ -187,54 +190,5 @@ func TestBearerTransportTokenRefresh(t *testing.T) {
 	}
 	if transport.bearer.Token != refreshedToken {
 		t.Errorf("Expected Bearer token to be refreshed, got %v, want %v", bearer.Token, refreshedToken)
-	}
-}
-
-func TestHttpFallback(t *testing.T) {
-	tests := []struct {
-		reg     name.Registry
-		wantErr bool
-	}{{
-		// Should never make it to our test server because https fails and our server is http only.
-		reg:     mustRegistry("gcr.io"),
-		wantErr: true,
-	}, {
-		reg: mustRegistry("ko.local"),
-	}, {
-		reg: mustInsecureRegistry("us.gcr.io"),
-	}}
-
-	server := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-		}))
-	defer server.Close()
-
-	u, err := url.Parse(server.URL)
-	if err != nil {
-		t.Errorf("Unexpected error during url.Parse: %v", err)
-	}
-
-	bearer := &authn.Bearer{Token: "inital-token"}
-	for _, test := range tests {
-		transport := &bearerTransport{
-			inner:    http.DefaultTransport,
-			bearer:   bearer,
-			basic:    &authn.Basic{},
-			registry: test.reg,
-			realm:    server.URL,
-		}
-		client := http.Client{Transport: transport}
-		resp, err := client.Get(fmt.Sprintf("http://%s/v2/foo/bar/blobs/blah", u.Host))
-		if test.wantErr && err == nil {
-			t.Errorf("%s: wanted err but got nil", test.reg.String())
-		} else if !test.wantErr && err != nil {
-			t.Errorf("%s: unexpected err: %v", test.reg.String(), err)
-		}
-
-		// Check that we get the expected response back if it's supposed to work.
-		if !test.wantErr && resp.StatusCode != http.StatusNotFound {
-			t.Errorf("%s: unexpected response: %v", test.reg.String(), resp)
-		}
 	}
 }

--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -66,7 +66,9 @@ func parseChallenge(suffix string) map[string]string {
 func ping(reg name.Registry, t http.RoundTripper) (*pingResp, error) {
 	client := http.Client{Transport: t}
 
-	// Always try https first, falling back to http if we can.
+	// This first attempts to use "https" for every request, falling back to http
+	// if the registry matches our localhost heuristic or if it is intentionally
+	// set to insecure via name.NewInsecureRegistry.
 	schemes := []string{"https"}
 	if reg.Scheme() == "http" {
 		schemes = append(schemes, "http")

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -90,6 +90,9 @@ func TestPingNoChallenge(t *testing.T) {
 	if pr.challenge != anonymous {
 		t.Errorf("ping(); got %v, want %v", pr.challenge, anonymous)
 	}
+	if pr.scheme != "http" {
+		t.Errorf("ping(); got %v, want %v", pr.scheme, "http")
+	}
 }
 
 func TestPingBasicChallengeNoParams(t *testing.T) {

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -73,6 +73,7 @@ func New(reg name.Registry, auth authn.Authenticator, t http.RoundTripper, scope
 			registry: reg,
 			service:  service,
 			scopes:   scopes,
+			scheme:   pr.scheme,
 		}
 		if err := bt.refresh(); err != nil {
 			return nil, err

--- a/pkg/v1/remote/transport/transport_test.go
+++ b/pkg/v1/remote/transport/transport_test.go
@@ -84,9 +84,12 @@ func TestTransportSelectionBearer(t *testing.T) {
 			request = request + 1
 			switch request {
 			case 1:
+				// This is an https request that fails, causing us to fall back to http.
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			case 2:
 				w.Header().Set("WWW-Authenticate", `Bearer realm="http://foo.io"`)
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			case 2:
+			case 3:
 				hdr := r.Header.Get("Authorization")
 				if !strings.HasPrefix(hdr, "Basic ") {
 					t.Errorf("Header.Get(Authorization); got %v, want Basic prefix", hdr)


### PR DESCRIPTION
This first attempts to use "https" for every request, falling back to
"http" if the registry matches our localhost heuristic or if it is
intentionally set to insecure via name.NewInsecureRegistry.

Fixes #279