### PR TITLE
Speed up ko resolve test

### DIFF
--- a/pkg/ko/resolve/resolve_test.go
+++ b/pkg/ko/resolve/resolve_test.go
@@ -19,13 +19,12 @@ import (
 	"io"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -309,7 +308,7 @@ func TestMultiDocumentYAMLs(t *testing.T) {
 }
 
 func mustRandom() v1.Image {
-	img, err := random.Image(5, 1024)
+	img, err := random.Image(1024, 5)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This was testing an image with 1024 layers, each 5 bytes, instead of 5
layers, each 1024 bytes.