### PR TITLE
Close tar.Writer before using output

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -518,6 +518,10 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 		}
 	}
 
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+
 	b := w.Bytes()
 	// gzip the contents, then create the layer
 	opener := func() (io.ReadCloser, error) {

--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -63,6 +63,9 @@ func Image(byteSize, layers int64) (v1.Image, error) {
 		if _, err := io.CopyN(tw, rand.Reader, byteSize); err != nil {
 			return nil, err
 		}
+		if err := tw.Close(); err != nil {
+			return nil, err
+		}
 		bts := b.Bytes()
 		h, _, err := v1.SHA256(bytes.NewReader(bts))
 		if err != nil {

--- a/pkg/v1/stream/layer_test.go
+++ b/pkg/v1/stream/layer_test.go
@@ -137,6 +137,9 @@ func TestStreamableLayerFromTarball(t *testing.T) {
 					return err
 				}
 			}
+			if err := tw.Close(); err != nil {
+				return err
+			}
 			return nil
 		}())
 	}()
@@ -153,7 +156,7 @@ func TestStreamableLayerFromTarball(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	wantDigest := "sha256:f53d6a164ab476294212843f267740bd12f79e00abd8050c24ce8a9bceaa36b0"
+	wantDigest := "sha256:ed80efd7e7e884fb59db568f234332283b341b96155e872d638de42d55a34198"
 	if got, err := l.Digest(); err != nil {
 		t.Errorf("Digest: %v", err)
 	} else if got.String() != wantDigest {


### PR DESCRIPTION
kaniko's tar files produced error messages about truncated files when
expanding the layers.  This appears to be due to not correctly closing
the tar.Writer in all cases, before using the output.  Closing a
tar.Writer adds padding and a tar file trailer.