### PR TITLE
Handle 0-byte layer.tar files

### DIFF
--- a/pkg/v1/v1util/zip.go
+++ b/pkg/v1/v1util/zip.go
@@ -73,7 +73,11 @@ func GunzipReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
 // IsGzipped detects whether the input stream is compressed.
 func IsGzipped(r io.Reader) (bool, error) {
 	magicHeader := make([]byte, 2)
-	if _, err := r.Read(magicHeader); err != nil {
+	n, err := r.Read(magicHeader)
+	if n == 0 && err == io.EOF {
+		return false, nil
+	}
+	if err != nil {
 		return false, err
 	}
 	return bytes.Equal(magicHeader, gzipMagicHeader), nil

--- a/pkg/v1/v1util/zip_test.go
+++ b/pkg/v1/v1util/zip_test.go
@@ -40,3 +40,26 @@ func TestReader(t *testing.T) {
 		t.Errorf("ReadAll(); got %q, want %q", got, want)
 	}
 }
+
+func TestIsGzipped(t *testing.T) {
+	tests := []struct {
+		in  []byte
+		out bool
+		err error
+	}{
+		{[]byte{}, false, nil},
+		{[]byte{'\x00', '\x00', '\x00'}, false, nil},
+		{[]byte{'\x1f', '\x8b', '\x1b'}, true, nil},
+	}
+	for _, test := range tests {
+		reader := bytes.NewReader(test.in)
+		got, err := IsGzipped(reader)
+		if got != test.out {
+			t.Errorf("IsGzipped; n: got %v, wanted %v\n", got, test.out)
+		}
+		if err != test.err {
+			t.Errorf("IsGzipped; err: got %v, wanted %v\n", err, test.err)
+		}
+	}
+}
+


### PR DESCRIPTION
Fix `IsGzipped` to handle 0-byte layer tar files.

Fixes #367 