### PR TITLE
golang format tools

### DIFF
--- a/pkg/v1/v1util/zip_test.go
+++ b/pkg/v1/v1util/zip_test.go
@@ -62,4 +62,3 @@ func TestIsGzipped(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
