### PR TITLE
Name the app using the base of the importpath

### DIFF
--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-const appPath = "/ko-app"
+const appDir = "/ko-app"
 
 // GetBase takes an importpath and returns a base v1.Image.
 type GetBase func(string) (v1.Image, error)
@@ -117,7 +117,7 @@ func build(ip string) (string, error) {
 	return file, nil
 }
 
-func tarBinary(binary string) (*bytes.Buffer, error) {
+func tarBinary(name, binary string) (*bytes.Buffer, error) {
 	buf := bytes.NewBuffer(nil)
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
@@ -132,7 +132,7 @@ func tarBinary(binary string) (*bytes.Buffer, error) {
 		return nil, err
 	}
 	header := &tar.Header{
-		Name:     appPath,
+		Name:     name,
 		Size:     stat.Size(),
 		Typeflag: tar.TypeReg,
 		// Use a fixed Mode, so that this isn't sensitive to the directory and umask
@@ -249,8 +249,10 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	}
 	layers = append(layers, dataLayer)
 
+	appPath := filepath.Join(appDir, filepath.Base(s))
+
 	// Construct a tarball with the binary and produce a layer.
-	binaryLayerBuf, err := tarBinary(file)
+	binaryLayerBuf, err := tarBinary(appPath, file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -119,7 +119,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "a688c9bc444d0a34cbc24abd62aa2fa263f61f2060963bb7a4fc3fa92075a2bf",
+			Hex:       "4b0bcce3acbfba36dbdb76d3c5d0dc43e268cf2666fcf58584fc714ccbb28bd7",
 		}
 		appLayer := ls[baseLayers+1]
 
@@ -141,7 +141,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 			t.Errorf("len(entrypoint) = %v, want %v", got, want)
 		}
 
-		if got, want := entrypoint[0], appPath; got != want {
+		if got, want := entrypoint[0], "/ko-app/crane"; got != want {
 			t.Errorf("entrypoint = %v, want %v", got, want)
 		}
 	})
@@ -196,7 +196,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "71912d718600c5a2b8db3a127a14073bba61dded0dac8e1a6ebdeb4a37f2ce8d",
+			Hex:       "c7502053d5bcf34f0b720cdea2d53ff0e38e803756108396e09f92ad36cc375e",
 		}
 		appLayer := ls[baseLayers+1]
 
@@ -277,7 +277,7 @@ func TestGoBuild(t *testing.T) {
 			t.Errorf("len(entrypoint) = %v, want %v", got, want)
 		}
 
-		if got, want := entrypoint[0], appPath; got != want {
+		if got, want := entrypoint[0], "/ko-app/test"; got != want {
 			t.Errorf("entrypoint = %v, want %v", got, want)
 		}
 	})

--- a/pkg/ko/build/gobuild_test.go
+++ b/pkg/ko/build/gobuild_test.go
@@ -119,7 +119,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "4b0bcce3acbfba36dbdb76d3c5d0dc43e268cf2666fcf58584fc714ccbb28bd7",
+			Hex:       "f9a8bbe82883cf49161202d6697d906319c5b418725d4256778e6958c786801f",
 		}
 		appLayer := ls[baseLayers+1]
 
@@ -196,7 +196,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "c7502053d5bcf34f0b720cdea2d53ff0e38e803756108396e09f92ad36cc375e",
+			Hex:       "d6538378e47da0d6780d9a7caa6bdeffa6428bc6d35b95e1802958d1eefb671c",
 		}
 		appLayer := ls[baseLayers+1]
 


### PR DESCRIPTION
Currently the entrypoint is always '/ko-app', which makes it difficult to tell which ko-built app is which from the host system.

This changes it so that a container built from the importpath
`github.com/knative/serving/cmd/autoscaler`

has an entrypoint of
`/ko-app/autoscaler`

Fixes #375