### PR TITLE
Random index

### DIFF
--- a/pkg/v1/index.go
+++ b/pkg/v1/index.go
@@ -29,6 +29,12 @@ type ImageIndex interface {
 	// IndexManifest returns this image index's manifest object.
 	IndexManifest() (*IndexManifest, error)
 
-	// RawIndexManifest returns the serialized bytes of IndexManifest().
-	RawIndexManifest() ([]byte, error)
+	// RawManifest returns the serialized bytes of IndexManifest().
+	RawManifest() ([]byte, error)
+
+	// Image returns a v1.Image that this ImageIndex references.
+	Image(Hash) (Image, error)
+
+	// ImageIndex returns a v1.ImageIndex that this ImageIndex references.
+	ImageIndex(Hash) (ImageIndex, error)
 }

--- a/pkg/v1/random/index.go
+++ b/pkg/v1/random/index.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type randomIndex struct {
+	images   map[v1.Hash]v1.Image
+	manifest *v1.IndexManifest
+}
+
+func Index(byteSize, layers, count int64) (v1.ImageIndex, error) {
+	manifest := v1.IndexManifest{
+		SchemaVersion: 2,
+		Manifests:     []v1.Descriptor{},
+	}
+
+	images := make(map[v1.Hash]v1.Image)
+	for i := int64(0); i < count; i++ {
+		img, err := Image(byteSize, layers)
+		if err != nil {
+			return nil, err
+		}
+
+		rawManifest, err := img.RawManifest()
+		if err != nil {
+			return nil, err
+		}
+		digest, size, err := v1.SHA256(bytes.NewReader(rawManifest))
+		if err != nil {
+			return nil, err
+		}
+		mediaType, err := img.MediaType()
+		if err != nil {
+			return nil, err
+		}
+
+		manifest.Manifests = append(manifest.Manifests, v1.Descriptor{
+			Digest:    digest,
+			Size:      size,
+			MediaType: mediaType,
+		})
+
+		images[digest] = img
+	}
+
+	return &randomIndex{
+		images:   images,
+		manifest: &manifest,
+	}, nil
+}
+
+func (i *randomIndex) MediaType() (types.MediaType, error) {
+	return types.OCIImageIndex, nil
+}
+
+func (i *randomIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(i)
+}
+
+func (i *randomIndex) IndexManifest() (*v1.IndexManifest, error) {
+	return i.manifest, nil
+}
+
+func (i *randomIndex) RawManifest() ([]byte, error) {
+	m, err := i.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(m)
+}
+
+func (i *randomIndex) Image(h v1.Hash) (v1.Image, error) {
+	if img, ok := i.images[h]; ok {
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("image not found: %v", h)
+}
+
+func (i *randomIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	// This is a single level index (for now?).
+	return nil, fmt.Errorf("image not found: %v", h)
+}

--- a/pkg/v1/random/index_test.go
+++ b/pkg/v1/random/index_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestRandomIndex(t *testing.T) {
+	ii, err := Index(1024, 5, 3)
+	if err != nil {
+		t.Fatalf("Error loading index: %v", err)
+	}
+
+	manifest, err := ii.IndexManifest()
+	if err != nil {
+		t.Fatalf("Error reading manifest: %v", err)
+	}
+
+	for _, desc := range manifest.Manifests {
+		img, err := ii.Image(desc.Digest)
+		if err != nil {
+			t.Fatalf("Image(%s): unexpected err: %v", desc.Digest, err)
+		}
+
+		digest, err := img.Digest()
+		if err != nil {
+			t.Fatalf("Image(%s).Digest(): unexpected err: %v", desc.Digest, err)
+		}
+
+		if got, want := digest.String(), desc.Digest.String(); got != want {
+			t.Errorf("Image(%s).Digest(): wrong value, got: %s, want: %s", desc.Digest, got, want)
+		}
+	}
+
+	digest, err := ii.Digest()
+	if err != nil {
+		t.Fatalf("Digest(): unexpected err: %v", err)
+	}
+
+	if _, err := ii.Image(digest); err == nil {
+		t.Errorf("Image(%s): expected err, got nil", digest)
+	}
+
+	if _, err := ii.ImageIndex(digest); err == nil {
+		t.Errorf("ImageIndex(%s): expected err, got nil", digest)
+	}
+
+	mt, err := ii.MediaType()
+	if err != nil {
+		t.Errorf("MediaType(): unexpected err: %v", err)
+	}
+
+	if got, want := mt, types.OCIImageIndex; got != want {
+		t.Errorf("MediaType(): got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Update the `v1.ImageIndex` definition to be more usable and more similar to the `v1.Image` definition.

Also adds a `random.Index` as a starting point so we can test other implementations.