### PR TITLE
Implement remote.Index

### DIFF
--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -171,9 +171,9 @@ func TestRawManifestDigests(t *testing.T) {
 			}
 
 			rmt := remoteImage{
-				fetch: fetcher{
-					ref:    ref,
-					client: http.DefaultClient,
+				fetcher: fetcher{
+					Ref:    ref,
+					Client: http.DefaultClient,
 				},
 			}
 
@@ -205,9 +205,9 @@ func TestRawManifestNotFound(t *testing.T) {
 	}
 
 	img := remoteImage{
-		fetch: fetcher{
-			ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
-			client: http.DefaultClient,
+		fetcher: fetcher{
+			Ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+			Client: http.DefaultClient,
 		},
 	}
 
@@ -244,9 +244,9 @@ func TestRawConfigFileNotFound(t *testing.T) {
 	}
 
 	rmt := remoteImage{
-		fetch: fetcher{
-			ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
-			client: http.DefaultClient,
+		fetcher: fetcher{
+			Ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+			Client: http.DefaultClient,
 		},
 	}
 
@@ -281,9 +281,9 @@ func TestAcceptHeaders(t *testing.T) {
 	}
 
 	rmt := &remoteImage{
-		fetch: fetcher{
-			ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
-			client: http.DefaultClient,
+		fetcher: fetcher{
+			Ref:    mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo)),
+			Client: http.DefaultClient,
 		},
 	}
 	manifest, err := rmt.RawManifest()

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -31,7 +31,15 @@ import (
 
 const bogusDigest = "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-func mustDigest(t *testing.T, img v1.Image) v1.Hash {
+// TODO: Rename this and move to write.go. Needed to treat Image and ImageIndex
+// the same for content-addressability reasons and code reuse.
+type Manifest interface {
+	Digest() (v1.Hash, error)
+	RawManifest() ([]byte, error)
+	MediaType() (types.MediaType, error)
+}
+
+func mustDigest(t *testing.T, img Manifest) v1.Hash {
 	h, err := img.Digest()
 	if err != nil {
 		t.Fatalf("Digest() = %v", err)
@@ -47,7 +55,7 @@ func mustManifest(t *testing.T, img v1.Image) *v1.Manifest {
 	return m
 }
 
-func mustRawManifest(t *testing.T, img v1.Image) []byte {
+func mustRawManifest(t *testing.T, img Manifest) []byte {
 	m, err := img.RawManifest()
 	if err != nil {
 		t.Fatalf("RawManifest() = %v", err)

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -1,0 +1,169 @@
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// remoteIndex accesses an index from a remote registry
+type remoteIndex struct {
+	ref          name.Reference
+	client       *http.Client
+	manifestLock sync.Mutex // Protects manifest
+	manifest     []byte
+	mediaType    types.MediaType
+}
+
+// Index provides access to a remote index reference, applying functional options
+// to the underlying imageOpener before resolving the reference into a v1.ImageIndex.
+func Index(ref name.Reference, options ...ImageOption) (v1.ImageIndex, error) {
+	i := &imageOpener{
+		auth:      authn.Anonymous,
+		transport: http.DefaultTransport,
+		ref:       ref,
+	}
+
+	for _, option := range options {
+		if err := option(i); err != nil {
+			return nil, err
+		}
+	}
+	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, err
+	}
+	return &remoteIndex{
+		ref:    i.ref,
+		client: &http.Client{Transport: tr},
+	}, nil
+}
+
+func (r *remoteIndex) url(resource, identifier string) url.URL {
+	return url.URL{
+		Scheme: r.ref.Context().Registry.Scheme(),
+		Host:   r.ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", r.ref.Context().RepositoryStr(), resource, identifier),
+	}
+}
+
+func (r *remoteIndex) MediaType() (types.MediaType, error) {
+	if string(r.mediaType) != "" {
+		return r.mediaType, nil
+	}
+	return types.DockerManifestList, nil
+}
+
+func (r *remoteIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(r)
+}
+
+func (r *remoteIndex) RawManifest() ([]byte, error) {
+	r.manifestLock.Lock()
+	defer r.manifestLock.Unlock()
+	if r.manifest != nil {
+		return r.manifest, nil
+	}
+
+	u := r.url("manifests", r.ref.Identifier())
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", strings.Join([]string{
+		string(types.DockerManifestList),
+		string(types.OCIImageIndex),
+	}, ","))
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	manifest, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, _, err := v1.SHA256(bytes.NewReader(manifest))
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the digest matches what we asked for, if pulling by digest.
+	if dgst, ok := r.ref.(name.Digest); ok {
+		if digest.String() != dgst.DigestStr() {
+			return nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), r.ref)
+		}
+	} else {
+		// Do nothing for tags; I give up.
+		//
+		// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
+		// but so many registries implement this incorrectly that it's not worth checking.
+		//
+		// For reference:
+		// https://github.com/docker/distribution/issues/2395
+		// https://github.com/GoogleContainerTools/kaniko/issues/298
+	}
+
+	r.mediaType = types.MediaType(resp.Header.Get("Content-Type"))
+	r.manifest = manifest
+	return r.manifest, nil
+}
+
+func (r *remoteIndex) IndexManifest() (*v1.IndexManifest, error) {
+	b, err := r.RawManifest()
+	if err != nil {
+		return nil, err
+	}
+	return v1.ParseIndexManifest(bytes.NewReader(b))
+}
+
+func (r *remoteIndex) Image(h v1.Hash) (v1.Image, error) {
+	imgRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.ref.Context(), h), name.StrictValidation)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: pull this out for reuse
+	ri := &remoteImage{
+		ref:    imgRef,
+		client: r.client,
+	}
+	imgCore, err := partial.CompressedToImage(ri)
+	if err != nil {
+		return imgCore, err
+	}
+	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
+	// remote.Write calls to facilitate cross-repo "mounting".
+	return &mountableImage{
+		Image:     imgCore,
+		Reference: r.ref,
+	}, nil
+}
+
+func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	idxRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.ref.Context(), h), name.StrictValidation)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: pull this out for reuse
+	return &remoteIndex{
+		ref:    idxRef,
+		client: r.client,
+	}, nil
+}

--- a/pkg/v1/remote/index_test.go
+++ b/pkg/v1/remote/index_test.go
@@ -131,9 +131,9 @@ func TestIndexRawManifestDigests(t *testing.T) {
 			}
 
 			rmt := remoteIndex{
-				fetch: fetcher{
-					ref:    ref,
-					client: http.DefaultClient,
+				fetcher: fetcher{
+					Ref:    ref,
+					Client: http.DefaultClient,
 				},
 			}
 

--- a/pkg/v1/remote/index_test.go
+++ b/pkg/v1/remote/index_test.go
@@ -1,0 +1,229 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func randomIndex(t *testing.T) v1.ImageIndex {
+	rnd, err := random.Index(1024, 1, 3)
+	if err != nil {
+		t.Fatalf("random.Index() = %v", err)
+	}
+	return rnd
+}
+
+func mustIndexManifest(t *testing.T, idx v1.ImageIndex) *v1.IndexManifest {
+	m, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatalf("IndexManifest() = %v", err)
+	}
+	return m
+}
+
+func mustChild(t *testing.T, idx v1.ImageIndex, h v1.Hash) v1.Image {
+	img, err := idx.Image(h)
+	if err != nil {
+		t.Fatalf("Image(%s) = %v", h, err)
+	}
+	return img
+}
+
+func mustMediaType(t *testing.T, man Manifest) types.MediaType {
+	mt, err := man.MediaType()
+	if err != nil {
+		t.Fatalf("MediaType() = %v", err)
+	}
+	return mt
+}
+
+func TestIndexRawManifestDigests(t *testing.T) {
+	idx := randomIndex(t)
+	expectedRepo := "foo/bar"
+
+	cases := []struct {
+		name          string
+		ref           string
+		responseBody  []byte
+		contentDigest string
+		wantErr       bool
+	}{{
+		name:          "normal pull, by tag",
+		ref:           "latest",
+		responseBody:  mustRawManifest(t, idx),
+		contentDigest: mustDigest(t, idx).String(),
+		wantErr:       false,
+	}, {
+		name:          "normal pull, by digest",
+		ref:           mustDigest(t, idx).String(),
+		responseBody:  mustRawManifest(t, idx),
+		contentDigest: mustDigest(t, idx).String(),
+		wantErr:       false,
+	}, {
+		name:          "right content-digest, wrong body, by digest",
+		ref:           mustDigest(t, idx).String(),
+		responseBody:  []byte("not even json"),
+		contentDigest: mustDigest(t, idx).String(),
+		wantErr:       true,
+	}, {
+		name:          "right body, wrong content-digest, by tag",
+		ref:           "latest",
+		responseBody:  mustRawManifest(t, idx),
+		contentDigest: bogusDigest,
+		wantErr:       false,
+	}, {
+		// NB: This succeeds! We don't care what the registry thinks.
+		name:          "right body, wrong content-digest, by digest",
+		ref:           mustDigest(t, idx).String(),
+		responseBody:  mustRawManifest(t, idx),
+		contentDigest: bogusDigest,
+		wantErr:       false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, tc.ref)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case manifestPath:
+					if r.Method != http.MethodGet {
+						t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+					}
+
+					w.Header().Set("Docker-Content-Digest", tc.contentDigest)
+					w.Write(tc.responseBody)
+				default:
+					t.Fatalf("Unexpected path: %v", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+			u, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+			}
+
+			ref, err := newReference(u.Host, expectedRepo, tc.ref)
+			if err != nil {
+				t.Fatalf("url.Parse(%v, %v, %v) = %v", u.Host, expectedRepo, tc.ref, err)
+			}
+
+			rmt := remoteIndex{
+				fetch: fetcher{
+					ref:    ref,
+					client: http.DefaultClient,
+				},
+			}
+
+			if _, err := rmt.RawManifest(); (err != nil) != tc.wantErr {
+				t.Errorf("RawManifest() wrong error: %v, want %v: %v\n", (err != nil), tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestIndex(t *testing.T) {
+	idx := randomIndex(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	childDigest := mustIndexManifest(t, idx).Manifests[0].Digest
+	child := mustChild(t, idx, childDigest)
+	childPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, childDigest)
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, child))
+	manifestReqCount := 0
+	childReqCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			manifestReqCount++
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(mustMediaType(t, idx)))
+			w.Write(mustRawManifest(t, idx))
+		case childPath:
+			childReqCount++
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawManifest(t, child))
+		case configPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawConfigFile(t, child))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	rmt, err := Index(tag, WithTransport(http.DefaultTransport))
+	if err != nil {
+		t.Errorf("Image() = %v", err)
+	}
+	rmtChild, err := rmt.Image(childDigest)
+	if err != nil {
+		t.Errorf("Image() = %v", err)
+	}
+
+	// Test that index works as expected.
+	if got, want := mustRawManifest(t, rmt), mustRawManifest(t, idx); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawManifest() = %v, want %v", got, want)
+	}
+	if diff := cmp.Diff(mustIndexManifest(t, idx), mustIndexManifest(t, rmt)); diff != "" {
+		t.Errorf("IndexManifest() (-want +got) = %v", diff)
+	}
+	if got, want := mustMediaType(t, rmt), mustMediaType(t, idx); got != want {
+		t.Errorf("MediaType() = %v, want %v", got, want)
+	}
+	if got, want := mustDigest(t, rmt), mustDigest(t, idx); got != want {
+		t.Errorf("Digest() = %v, want %v", got, want)
+	}
+	// Make sure caching the manifest works for index.
+	if manifestReqCount != 1 {
+		t.Errorf("RawManifest made %v requests, expected 1", manifestReqCount)
+	}
+
+	// Test that child works as expected.
+	if got, want := mustRawManifest(t, rmtChild), mustRawManifest(t, child); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawManifest() = %v, want %v", got, want)
+	}
+	if got, want := mustRawConfigFile(t, rmtChild), mustRawConfigFile(t, child); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawConfigFile() = %v, want %v", got, want)
+	}
+	// Make sure caching the manifest works for child.
+	if childReqCount != 1 {
+		t.Errorf("RawManifest made %v requests, expected 1", childReqCount)
+	}
+}


### PR DESCRIPTION
This adds support for reading an ImageIndex from a remote repository.

I refactored some of the shared code between `Index` and `Image` to a separate "fetcher" struct. We should probably pull all of this out into a separate remote client that is shared between the read and write path, since it's very similar, but that's out of scope for this PR.

See #119 

Write support incoming once this lands.