### PR TITLE
golang format tools

### DIFF
--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // Image validates that img does not violate any invariants of the image format.

--- a/pkg/v1/validate/index.go
+++ b/pkg/v1/validate/index.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
