### PR TITLE
Always validate digests in NewDigest

### DIFF
--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -73,14 +73,9 @@ func NewDigest(name string, strict Strictness) (Digest, error) {
 	base := parts[0]
 	digest := parts[1]
 
-	// We don't require a digest, but if we get one check it's valid,
-	// even when not being strict.
-	// If we are being strict, we want to validate the digest regardless in case
-	// it's empty.
-	if digest != "" || strict == StrictValidation {
-		if err := checkDigest(digest); err != nil {
-			return Digest{}, err
-		}
+	// Always check that the digest is valid.
+	if err := checkDigest(digest); err != nil {
+		return Digest{}, err
 	}
 
 	tag, err := NewTag(base, strict)

--- a/pkg/name/digest_test.go
+++ b/pkg/name/digest_test.go
@@ -37,7 +37,6 @@ var goodStrictValidationTagDigestNames = []string{
 var goodWeakValidationDigestNames = []string{
 	"namespace/pathcomponent/image@" + validDigest,
 	"library/ubuntu@" + validDigest,
-	"gcr.io/project-id/missing-digest@",
 }
 
 var goodWeakValidationTagDigestNames = []string{
@@ -48,6 +47,7 @@ var goodWeakValidationTagDigestNames = []string{
 var badDigestNames = []string{
 	"gcr.io/project-id/unknown-alg@unknown:abc123",
 	"gcr.io/project-id/wrong-length@sha256:d34db33fd34db33f",
+	"gcr.io/project-id/missing-digest@",
 }
 
 func TestNewDigestStrictValidation(t *testing.T) {


### PR DESCRIPTION
This was allowing a missing digest after "@" for weak validation. That
doesn't make sense for digests because there's no way to have a default
digest.