### PR TITLE
Dedupe layer uploads where possible

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -63,7 +63,11 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 	seen := map[v1.Hash]struct{}{}
 	for _, l := range ls {
 		l := l
-		if h, err := l.Digest(); err == nil {
+		if _, ok := l.(*stream.Layer); !ok {
+			h, err := l.Digest()
+			if err != nil {
+				return err
+			}
 			// If we can determine the layer's digest ahead of
 			// time, use it to dedupe uploads.
 			if _, found := seen[h]; found {

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -60,7 +60,7 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 	// If we can dedupe by the layer digest, try to do so. If the layer is
 	// a stream.Layer, we can't dedupe and might re-upload.
 	var g errgroup.Group
-	seen := map[v1.Hash]struct{}{}
+	uploaded := map[v1.Hash]bool{}
 	for _, l := range ls {
 		l := l
 		if _, ok := l.(*stream.Layer); !ok {
@@ -70,10 +70,10 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 			}
 			// If we can determine the layer's digest ahead of
 			// time, use it to dedupe uploads.
-			if _, found := seen[h]; found {
+			if uploaded[h] {
 				continue // Already uploading.
 			}
-			seen[h] = struct{}{}
+			uploaded[h] = true
 		}
 
 		g.Go(func() error {


### PR DESCRIPTION
Fixes issue in https://github.com/GoogleContainerTools/kaniko/pull/599

Prior to #301 we deduped layers using `BlobSet`, but that was dropped when some layers might not be digestable ahead of time.

~~TODO: tests, I wanted to get this out in case there were comments about the overall direction.~~