### PR TITLE
Remove BlobSet from Image interface

### DIFF
--- a/pkg/v1/image.go
+++ b/pkg/v1/image.go
@@ -24,9 +24,6 @@ type Image interface {
 	// The order of the list is oldest/base layer first, and most-recent/top layer last.
 	Layers() ([]Layer, error)
 
-	// BlobSet returns an unordered collection of all the blobs in the image.
-	BlobSet() (map[Hash]struct{}, error)
-
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -237,14 +237,6 @@ func (i *image) Layers() ([]v1.Layer, error) {
 	return ls, nil
 }
 
-// BlobSet returns an unordered collection of all the blobs in the image.
-func (i *image) BlobSet() (map[v1.Hash]struct{}, error) {
-	if err := i.compute(); err != nil {
-		return nil, err
-	}
-	return partial.BlobSet(i)
-}
-
 // ConfigName returns the hash of the image's config file.
 func (i *image) ConfigName() (v1.Hash, error) {
 	if err := i.compute(); err != nil {

--- a/pkg/v1/partial/compressed.go
+++ b/pkg/v1/partial/compressed.go
@@ -91,11 +91,6 @@ type compressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*compressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *compressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *compressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/pkg/v1/partial/uncompressed.go
+++ b/pkg/v1/partial/uncompressed.go
@@ -112,11 +112,6 @@ type uncompressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*uncompressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *uncompressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *uncompressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -191,20 +191,6 @@ func FSLayers(i WithManifest) ([]v1.Hash, error) {
 	return fsl, nil
 }
 
-// BlobSet is a helper for implementing v1.Image
-func BlobSet(i WithManifest) (map[v1.Hash]struct{}, error) {
-	m, err := i.Manifest()
-	if err != nil {
-		return nil, err
-	}
-	bs := make(map[v1.Hash]struct{})
-	for _, l := range m.Layers {
-		bs[l.Digest] = struct{}{}
-	}
-	bs[m.Config.Digest] = struct{}{}
-	return bs, nil
-}
-
 // BlobSize is a helper for implementing v1.Image
 func BlobSize(i WithManifest, h v1.Hash) (int64, error) {
 	m, err := i.Manifest()


### PR DESCRIPTION
It doesn't appear to be used anywhere in go-containerregistry itself, and looking at some of the users of the library I couldn't find any usage there either (sorry if I missed one!)

With the introduction of `stream.Layer`, `BlobSet` could return `stream.ErrNotComputed` if any layer was a streaming layer, which isn't a great UX. As an alternative to removing it, we could make `BlobSet` only include blobs for which it knows the digest, but I'm not sure that's a great UX either. This made me realize I'm not really sure what the use case is for `BlobSet`...

This is a backward-incompatible change in cases where some project did call `img.BlobSet()` for whatever reason, but any implementations of the `Image` interface that happen to implement `BlobSet` won't be broken by the change at least.