### PR TITLE
Resolve manifest lists to manifests in remote.Image

### DIFF
--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -34,6 +34,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/v1util"
 )
 
+var defaultPlatform = v1.Platform{
+	Architecture: "amd64",
+	OS:           "linux",
+}
+
 // remoteImage accesses an image from a remote registry
 type remoteImage struct {
 	fetcher
@@ -89,10 +94,7 @@ func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
 		auth:      authn.Anonymous,
 		transport: http.DefaultTransport,
 		ref:       ref,
-		platform: v1.Platform{
-			Architecture: runtime.GOARCH,
-			OS:           runtime.GOOS,
-		},
+		platform:  defaultPlatform,
 	}
 
 	for _, option := range options {
@@ -316,10 +318,7 @@ func (r *remoteImage) matchImage(rawIndex []byte) ([]byte, *v1.Descriptor, error
 	}
 	for _, childDesc := range index.Manifests {
 		// If platform is missing from child descriptor, assume it's amd64/linux.
-		p := v1.Platform{
-			Architecture: "amd64",
-			OS:           "linux",
-		}
+		p := defaultPlatform
 		if childDesc.Platform != nil {
 			p = *childDesc.Platform
 		}

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -16,10 +16,12 @@ package remote
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -257,7 +259,12 @@ func TestAcceptHeaders(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
-			wantAccept := strings.Join([]string{string(types.DockerManifestSchema2), string(types.OCIManifestSchema1)}, ",")
+			wantAccept := strings.Join([]string{
+				string(types.DockerManifestSchema2),
+				string(types.OCIManifestSchema1),
+				string(types.DockerManifestList),
+				string(types.OCIImageIndex),
+			}, ",")
 			if got, want := r.Header.Get("Accept"), wantAccept; got != want {
 				t.Errorf("Accept header; got %v, want %v", got, want)
 			}
@@ -352,5 +359,150 @@ func TestImage(t *testing.T) {
 	}
 	if got, want := size, layerSize; want != got {
 		t.Errorf("BlobSize() = %v want %v", got, want)
+	}
+}
+
+func TestPullingManifestList(t *testing.T) {
+	idx := randomIndex(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	childDigest := mustIndexManifest(t, idx).Manifests[1].Digest
+	child := mustChild(t, idx, childDigest)
+	childPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, childDigest)
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, child))
+
+	// Rewrite the index to make sure the current runtime matches the second child.
+	manifest, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure the first manifest doesn't match.
+	manifest.Manifests[0].Platform = &v1.Platform{
+		Architecture: "not-real-arch",
+		OS:           "not-real-os",
+	}
+	// Make sure the second manifest does.
+	manifest.Manifests[1].Platform = &v1.Platform{
+		Architecture: runtime.GOARCH,
+		OS:           runtime.GOOS,
+	}
+	rawManifest, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(rawManifest))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(mustMediaType(t, idx)))
+			w.Write(rawManifest)
+		case childPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawManifest(t, child))
+		case configPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawConfigFile(t, child))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	rmtChild, err := Image(tag)
+	if err != nil {
+		t.Errorf("Image() = %v", err)
+	}
+
+	// Test that child works as expected.
+	if got, want := mustRawManifest(t, rmtChild), mustRawManifest(t, child); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawManifest() = %v, want %v", got, want)
+	}
+	if got, want := mustRawConfigFile(t, rmtChild), mustRawConfigFile(t, child); bytes.Compare(got, want) != 0 {
+		t.Errorf("RawConfigFile() = %v, want %v", got, want)
+	}
+}
+
+func TestPullingManifestListNoMatch(t *testing.T) {
+	idx := randomIndex(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	childDigest := mustIndexManifest(t, idx).Manifests[1].Digest
+	child := mustChild(t, idx, childDigest)
+	childPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, childDigest)
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, child))
+
+	// Rewrite the index to make sure the current runtime matches the second child.
+	manifest, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure none match.
+	for i := range manifest.Manifests {
+		manifest.Manifests[i].Platform = &v1.Platform{
+			Architecture: "not-real-arch",
+			OS:           "not-real-os",
+		}
+	}
+	rawManifest, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(rawManifest))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(mustMediaType(t, idx)))
+			w.Write(rawManifest)
+		case childPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawManifest(t, child))
+		case configPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(mustRawConfigFile(t, child))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	rmtChild, err := Image(tag)
+	if err != nil {
+		t.Errorf("Image() = %v", err)
+	}
+
+	// Test that child works as expected.
+	if b, err := rmtChild.RawManifest(); err == nil {
+		t.Errorf("RawManifest() = %v, wanted err", b)
 	}
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // WithTransport is a functional option for overriding the default transport
@@ -51,6 +52,13 @@ func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
 			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		i.auth = auth
+		return nil
+	}
+}
+
+func WithPlatform(p v1.Platform) ImageOption {
+	return func(i *imageOpener) error {
+		i.platform = p
 		return nil
 	}
 }


### PR DESCRIPTION
We currently rely on the registry to do fallback for us, but this is
unreliable:
* Some registries won't do it.
* This only works for amd64/linux