### PR TITLE
Add Blob to ImageIndex interface

### DIFF
--- a/pkg/v1/empty/index.go
+++ b/pkg/v1/empty/index.go
@@ -17,6 +17,7 @@ package empty
 import (
 	"encoding/json"
 	"errors"
+	"io"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -55,5 +56,9 @@ func (i emptyIndex) Image(v1.Hash) (v1.Image, error) {
 }
 
 func (i emptyIndex) ImageIndex(v1.Hash) (v1.ImageIndex, error) {
+	return nil, errors.New("empty index")
+}
+
+func (i emptyIndex) Blob(v1.Hash) (io.ReadCloser, error) {
 	return nil, errors.New("empty index")
 }

--- a/pkg/v1/index.go
+++ b/pkg/v1/index.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"io"
+
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -37,4 +39,7 @@ type ImageIndex interface {
 
 	// ImageIndex returns a v1.ImageIndex that this ImageIndex references.
 	ImageIndex(Hash) (ImageIndex, error)
+
+	// Blob returns an io.Readcloser that this ImageIndex references.
+	Blob(Hash) (io.ReadCloser, error)
 }

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -178,6 +178,21 @@ func (f *fetcher) fetchManifest(acceptable []types.MediaType) ([]byte, *v1.Descr
 	return manifest, &desc, nil
 }
 
+func (f *fetcher) fetchBlob(h v1.Hash) (io.ReadCloser, error) {
+	u := f.url("blobs", h.String())
+	resp, err := f.Client.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+
+	return v1util.VerifyReadCloser(resp.Body, h)
+}
+
 func (r *remoteImage) MediaType() (types.MediaType, error) {
 	if string(r.mediaType) != "" {
 		return r.mediaType, nil
@@ -260,18 +275,7 @@ func (rl *remoteLayer) Digest() (v1.Hash, error) {
 
 // Compressed implements partial.CompressedLayer
 func (rl *remoteLayer) Compressed() (io.ReadCloser, error) {
-	u := rl.ri.url("blobs", rl.digest.String())
-	resp, err := rl.ri.Client.Get(u.String())
-	if err != nil {
-		return nil, err
-	}
-
-	if err := transport.CheckError(resp, http.StatusOK); err != nil {
-		resp.Body.Close()
-		return nil, err
-	}
-
-	return v1util.VerifyReadCloser(resp.Body, rl.digest)
+	return rl.ri.fetchBlob(rl.digest)
 }
 
 // Manifest implements partial.WithManifest so that we can use partial.BlobSize below.

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -17,6 +17,7 @@ package remote
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 
@@ -136,4 +137,8 @@ func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
 			Client: r.Client,
 		},
 	}, nil
+}
+
+func (r *remoteIndex) Blob(h v1.Hash) (io.ReadCloser, error) {
+	return r.fetchBlob(h)
 }


### PR DESCRIPTION
Most ImageIndex implementations will only reference other images or other indexes, but it's possible for them to reference blobs. See the [image layout example](https://github.com/opencontainers/image-spec/blob/master/image-layout.md#index-example). 

The [image-spec](https://github.com/opencontainers/image-spec/pull/759) clarifies that if we encounter something we don't understand, we can just ignore it, but ideally there would be some way to access them.

This PR is a suggestion of how to tackle that.