### PR TITLE
authn/k8schain : fallthrough in case of `gcloud` command not available

### DIFF
--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"time"
@@ -58,6 +59,13 @@ func NewEnvAuthenticator() (authn.Authenticator, error) {
 // NewGcloudAuthenticator returns an oauth2.TokenSource that generates access
 // tokens by shelling out to the gcloud sdk.
 func NewGcloudAuthenticator() (authn.Authenticator, error) {
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		// TODO(#390): Use better logger.
+		// gcloud is not available, fall back to anonymous
+		log.Println("gcloud binary not found")
+		return authn.Anonymous, nil
+	}
+
 	ts := gcloudSource{GetGcloudCmd()}
 
 	// Attempt to fetch a token to ensure gcloud is installed and we can run it.


### PR DESCRIPTION
It's not the prettiest change ever, but it keeps the error in the general case, but allows to fallthrough in a `multikeychain`. This type of errors could be used for other chains too :angel: 

It fixes cases where using `google.Keychain` with `authn.NewMultiKeychain` where `gcloud` command is not available (see https://gist.github.com/vdemeester/c397ffb3fd19b4cc2ba3243dc4db9f83). It should use `Anonymous` instead of failing hard in that case.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>