### PR TITLE
Add remote.Descriptor

### DIFF
--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -15,13 +15,13 @@
 package crane
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/spf13/cobra"
 )
 
@@ -52,50 +52,42 @@ func doCopy(_ *cobra.Command, args []string) {
 	}
 	log.Printf("Pushing %v", dstRef)
 
-	srcAuth, err := authn.DefaultKeychain.Resolve(srcRef.Context().Registry)
-	if err != nil {
-		log.Fatalf("getting creds for %q: %v", srcRef, err)
-	}
-
 	dstAuth, err := authn.DefaultKeychain.Resolve(dstRef.Context().Registry)
 	if err != nil {
 		log.Fatalf("getting creds for %q: %v", dstRef, err)
 	}
 
-	// First, try to copy as an index.
-	// If that fails, try to copy as an image.
-	// We have to try this second because fallback logic exists in the registry
-	// to convert an index to an image.
-	// TODO(#388): Figure out which artifact is returned at runtime.
-	if err := copyIndex(srcRef, dstRef, srcAuth, dstAuth); err != nil {
-		if err := copyImage(srcRef, dstRef, srcAuth, dstAuth); err != nil {
+	desc, err := remote.Get(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		log.Fatalf("fetching image %q: %v", srcRef, err)
+	}
+
+	switch desc.MediaType {
+	case types.OCIImageIndex, types.DockerManifestList:
+		// Handle indexes separately.
+		if err := copyIndex(desc, dstRef, dstAuth); err != nil {
+			log.Fatalf("failed to copy index: %v", err)
+		}
+	default:
+		// Assume anything else is an image, since some registries don't set mediaTypes properly.
+		if err := copyImage(desc, dstRef, dstAuth); err != nil {
 			log.Fatalf("failed to copy image: %v", err)
 		}
 	}
 }
 
-func copyImage(srcRef, dstRef name.Reference, srcAuth, dstAuth authn.Authenticator) error {
-	img, err := remote.Image(srcRef, remote.WithAuth(srcAuth))
+func copyImage(desc *remote.Descriptor, dstRef name.Reference, dstAuth authn.Authenticator) error {
+	img, err := desc.Image()
 	if err != nil {
-		return fmt.Errorf("reading image %q: %v", srcRef, err)
+		return err
 	}
-
-	if err := remote.Write(dstRef, img, dstAuth, http.DefaultTransport); err != nil {
-		return fmt.Errorf("writing image %q: %v", dstRef, err)
-	}
-
-	return nil
+	return remote.Write(dstRef, img, dstAuth, http.DefaultTransport)
 }
 
-func copyIndex(srcRef, dstRef name.Reference, srcAuth, dstAuth authn.Authenticator) error {
-	idx, err := remote.Index(srcRef, remote.WithAuth(srcAuth))
+func copyIndex(desc *remote.Descriptor, dstRef name.Reference, dstAuth authn.Authenticator) error {
+	idx, err := desc.ImageIndex()
 	if err != nil {
-		return fmt.Errorf("reading index %q: %v", srcRef, err)
+		return err
 	}
-
-	if err := remote.WriteIndex(dstRef, idx, dstAuth, http.DefaultTransport); err != nil {
-		return fmt.Errorf("writing index %q: %v", dstRef, err)
-	}
-
-	return nil
+	return remote.WriteIndex(dstRef, idx, dstAuth, http.DefaultTransport)
 }

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -35,13 +35,9 @@ func NewCmdDigest() *cobra.Command {
 
 func digest(_ *cobra.Command, args []string) {
 	ref := args[0]
-	i, _, err := getImage(ref)
+	desc, err := getManifest(ref)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatal(err)
 	}
-	digest, err := i.Digest()
-	if err != nil {
-		log.Fatalln(err)
-	}
-	fmt.Println(digest.String())
+	fmt.Println(desc.Digest)
 }

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -34,3 +34,11 @@ func getImage(r string) (v1.Image, name.Reference, error) {
 	}
 	return img, ref, nil
 }
+
+func getManifest(r string) (*remote.Descriptor, error) {
+	ref, err := name.ParseReference(r, name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("parsing reference %q: %v", r, err)
+	}
+	return remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+}

--- a/pkg/crane/manifest.go
+++ b/pkg/crane/manifest.go
@@ -35,13 +35,9 @@ func NewCmdManifest() *cobra.Command {
 
 func manifest(_ *cobra.Command, args []string) {
 	ref := args[0]
-	i, _, err := getImage(ref)
+	desc, err := getManifest(ref)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatal(err)
 	}
-	manifest, err := i.RawManifest()
-	if err != nil {
-		log.Fatalln(err)
-	}
-	fmt.Print(string(manifest))
+	fmt.Print(string(desc.Manifest))
 }

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -67,7 +67,9 @@ func doCopy(args []string, recursive bool) {
 		// If that fails, try to copy as an image.
 		// We have to try this second because fallback logic exists in the registry
 		// to convert an index to an image.
-		// TODO(#388): Figure out which artifact is returned at runtime.
+		//
+		// TODO(#407): Refactor crane so we can just call into that logic in the
+		// single-image case.
 		if err := copyIndex(src, dst, srcAuth, dstAuth); err != nil {
 			if err := copyImage(src, dst, srcAuth, dstAuth); err != nil {
 				log.Fatalf("failed to copy image: %v", err)

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -15,8 +15,13 @@
 package remote
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -155,4 +160,77 @@ func (d *Descriptor) remoteIndex() *remoteIndex {
 		manifest:  d.Manifest,
 		mediaType: d.MediaType,
 	}
+}
+
+// fetcher implements methods for reading from a registry.
+type fetcher struct {
+	Ref    name.Reference
+	Client *http.Client
+}
+
+// url returns a url.Url for the specified path in the context of this remote image reference.
+func (f *fetcher) url(resource, identifier string) url.URL {
+	return url.URL{
+		Scheme: f.Ref.Context().Registry.Scheme(),
+		Host:   f.Ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
+	}
+}
+
+func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType) ([]byte, *v1.Descriptor, error) {
+	u := f.url("manifests", ref.Identifier())
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	accept := []string{}
+	for _, mt := range acceptable {
+		accept = append(accept, string(mt))
+	}
+	req.Header.Set("Accept", strings.Join(accept, ","))
+
+	resp, err := f.Client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, nil, err
+	}
+
+	manifest, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Validate the digest matches what we asked for, if pulling by digest.
+	if dgst, ok := ref.(name.Digest); ok {
+		if digest.String() != dgst.DigestStr() {
+			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
+		}
+	} else {
+		// Do nothing for tags; I give up.
+		//
+		// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
+		// but so many registries implement this incorrectly that it's not worth checking.
+		//
+		// For reference:
+		// https://github.com/docker/distribution/issues/2395
+		// https://github.com/GoogleContainerTools/kaniko/issues/298
+	}
+
+	// Return all this info since we have to calculate it anyway.
+	desc := v1.Descriptor{
+		Digest:    digest,
+		Size:      size,
+		MediaType: types.MediaType(resp.Header.Get("Content-Type")),
+	}
+
+	return manifest, &desc, nil
 }

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -1,0 +1,158 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var defaultPlatform = v1.Platform{
+	Architecture: "amd64",
+	OS:           "linux",
+}
+
+var Schema1Error = errors.New("unsupported MediaType: https://github.com/google/go-containerregistry/issues/377")
+
+// Descriptor TODO
+type Descriptor struct {
+	fetcher
+	v1.Descriptor
+	Manifest []byte
+
+	// So we can share this implementation with Image..
+	platform v1.Platform
+}
+
+type imageOpener struct {
+	auth      authn.Authenticator
+	transport http.RoundTripper
+	ref       name.Reference
+	client    *http.Client
+	platform  v1.Platform
+}
+
+func Get(ref name.Reference, options ...ImageOption) (*Descriptor, error) {
+	acceptable := []types.MediaType{
+		types.DockerManifestSchema2,
+		types.OCIManifestSchema1,
+		types.DockerManifestList,
+		types.OCIImageIndex,
+		// Just to look at them.
+		types.DockerManifestSchema1,
+		types.DockerManifestSchema1Signed,
+	}
+	return get(ref, acceptable, options...)
+}
+
+func get(ref name.Reference, acceptable []types.MediaType, options ...ImageOption) (*Descriptor, error) {
+	i := &imageOpener{
+		auth:      authn.Anonymous,
+		transport: http.DefaultTransport,
+		ref:       ref,
+		platform:  defaultPlatform,
+	}
+
+	for _, option := range options {
+		if err := option(i); err != nil {
+			return nil, err
+		}
+	}
+	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, err
+	}
+
+	f := fetcher{
+		Ref:    i.ref,
+		Client: &http.Client{Transport: tr},
+	}
+
+	b, desc, err := f.fetchManifest(ref, acceptable)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Descriptor{
+		fetcher:    f,
+		Manifest:   b,
+		Descriptor: *desc,
+		platform:   i.platform,
+	}, nil
+}
+
+func (d *Descriptor) Image() (v1.Image, error) {
+	switch d.MediaType {
+	case types.OCIImageIndex, types.DockerManifestList:
+		// We want an image but the registry has an index, resolve it to an image.
+		return d.remoteIndex().ImageByPlatform(d.platform)
+	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
+		// We don't care to support schema 1 images:
+		// https://github.com/google/go-containerregistry/issues/377
+		return nil, Schema1Error
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		// These are expected. Enumerated here to allow a default case.
+	default:
+		// We could just return an error here, but some registries (e.g. static
+		// registries) don't set the Content-Type headers correctly, so instead...
+		// TODO(#390): Log a warning.
+	}
+
+	ri := d.remoteImage()
+	imgCore, err := partial.CompressedToImage(ri)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
+	// remote.Write calls to facilitate cross-repo "mounting".
+	return &mountableImage{
+		Image:     imgCore,
+		Reference: d.Ref,
+	}, nil
+}
+
+func (d *Descriptor) ImageIndex() (v1.ImageIndex, error) {
+	return d.remoteIndex(), nil
+}
+
+func (d *Descriptor) remoteImage() *remoteImage {
+	return &remoteImage{
+		fetcher: fetcher{
+			Ref:    d.Ref,
+			Client: d.Client,
+		},
+		manifest:  d.Manifest,
+		mediaType: d.MediaType,
+	}
+}
+
+func (d *Descriptor) remoteIndex() *remoteIndex {
+	return &remoteIndex{
+		fetcher: fetcher{
+			Ref:    d.Ref,
+			Client: d.Client,
+		},
+		manifest:  d.Manifest,
+		mediaType: d.MediaType,
+	}
+}

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -36,9 +36,13 @@ var defaultPlatform = v1.Platform{
 	OS:           "linux",
 }
 
-var Schema1Error = errors.New("unsupported MediaType: https://github.com/google/go-containerregistry/issues/377")
+// ErrSchema1 indicates that we received a schema1 manifest from the registry.
+// This library doesn't have plans to support this legacy image format:
+// https://github.com/google/go-containerregistry/issues/377
+var ErrSchema1 = errors.New("unsupported MediaType: https://github.com/google/go-containerregistry/issues/377")
 
-// Descriptor TODO
+// Descriptor provides access to metadata about remote artifact and accessors
+// for efficiently converting it into a v1.Image or v1.ImageIndex.
 type Descriptor struct {
 	fetcher
 	v1.Descriptor
@@ -56,6 +60,9 @@ type imageOpener struct {
 	platform  v1.Platform
 }
 
+// Get returns a remote.Descriptor for the given reference. The response from
+// the registry is left un-interpreted, for the most part. This is useful for
+// querying what kind of artifact a reference represents.
 func Get(ref name.Reference, options ...ImageOption) (*Descriptor, error) {
 	acceptable := []types.MediaType{
 		types.DockerManifestSchema2,
@@ -69,6 +76,8 @@ func Get(ref name.Reference, options ...ImageOption) (*Descriptor, error) {
 	return get(ref, acceptable, options...)
 }
 
+// Handle options and fetch the manifest with the acceptable MediaTypes in the
+// Accept header.
 func get(ref name.Reference, acceptable []types.MediaType, options ...ImageOption) (*Descriptor, error) {
 	i := &imageOpener{
 		auth:      authn.Anonymous,
@@ -105,15 +114,23 @@ func get(ref name.Reference, acceptable []types.MediaType, options ...ImageOptio
 	}, nil
 }
 
+// Image converts the Descriptor into a v1.Image.
+//
+// If the fetched artifact is already an image, it will just return it.
+//
+// If the fetched artifact is an index, it will attempt to resolve the index to
+// a child image with the appropriate platform.
+//
+// See WithPlatform to set the desired platform.
 func (d *Descriptor) Image() (v1.Image, error) {
 	switch d.MediaType {
-	case types.OCIImageIndex, types.DockerManifestList:
-		// We want an image but the registry has an index, resolve it to an image.
-		return d.remoteIndex().ImageByPlatform(d.platform)
 	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
 		// We don't care to support schema 1 images:
 		// https://github.com/google/go-containerregistry/issues/377
-		return nil, Schema1Error
+		return nil, ErrSchema1
+	case types.OCIImageIndex, types.DockerManifestList:
+		// We want an image but the registry has an index, resolve it to an image.
+		return d.remoteIndex().imageByPlatform(d.platform)
 	case types.OCIManifestSchema1, types.DockerManifestSchema2:
 		// These are expected. Enumerated here to allow a default case.
 	default:
@@ -122,21 +139,35 @@ func (d *Descriptor) Image() (v1.Image, error) {
 		// TODO(#390): Log a warning.
 	}
 
-	ri := d.remoteImage()
-	imgCore, err := partial.CompressedToImage(ri)
+	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
+	// remote.Write calls to facilitate cross-repo "mounting".
+	imgCore, err := partial.CompressedToImage(d.remoteImage())
 	if err != nil {
 		return nil, err
 	}
-
-	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
-	// remote.Write calls to facilitate cross-repo "mounting".
 	return &mountableImage{
 		Image:     imgCore,
 		Reference: d.Ref,
 	}, nil
 }
 
+// ImageIndex converts the Descriptor into a v1.ImageIndex.
 func (d *Descriptor) ImageIndex() (v1.ImageIndex, error) {
+	switch d.MediaType {
+	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
+		// We don't care to support schema 1 images:
+		// https://github.com/google/go-containerregistry/issues/377
+		return nil, ErrSchema1
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		// We want an index but the registry has an image, nothing we can do.
+		return nil, fmt.Errorf("unexpected media type for ImageIndex(): %s; call Image() instead", d.MediaType)
+	case types.OCIImageIndex, types.DockerManifestList:
+		// These are expected.
+	default:
+		// We could just return an error here, but some registries (e.g. static
+		// registries) don't set the Content-Type headers correctly, so instead...
+		// TODO(#390): Log a warning.
+	}
 	return d.remoteIndex(), nil
 }
 
@@ -209,9 +240,13 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 		return nil, nil, err
 	}
 
+	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
+
 	// Validate the digest matches what we asked for, if pulling by digest.
 	if dgst, ok := ref.(name.Digest); ok {
-		if digest.String() != dgst.DigestStr() {
+		if mediaType == types.DockerManifestSchema1Signed {
+			// Digests for this are stupid to calculate, ignore it.
+		} else if digest.String() != dgst.DigestStr() {
 			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
 		}
 	} else {
@@ -229,7 +264,7 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 	desc := v1.Descriptor{
 		Digest:    digest,
 		Size:      size,
-		MediaType: types.MediaType(resp.Header.Get("Content-Type")),
+		MediaType: mediaType,
 	}
 
 	return manifest, &desc, nil

--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -1,0 +1,106 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestGetSchema1(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema1))
+			w.Write([]byte("doesn't matter"))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+
+	// Get should succeed even for invalid json. We don't parse the response.
+	desc, err := Get(tag)
+	if err != nil {
+		t.Fatalf("Get(%s) = %v", tag, err)
+	}
+
+	// Should fail based on media type.
+	if _, err := desc.Image(); err != ErrSchema1 {
+		t.Errorf("Image() = %v, expected remote.ErrSchema1", err)
+	}
+
+	// Should fail based on media type.
+	if _, err := desc.ImageIndex(); err != ErrSchema1 {
+		t.Errorf("ImageIndex() = %v, expected remote.ErrSchema1", err)
+	}
+}
+
+func TestGetImageAsIndex(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema2))
+			w.Write([]byte("doesn't matter"))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+
+	// Get should succeed even for invalid json. We don't parse the response.
+	desc, err := Get(tag)
+	if err != nil {
+		t.Fatalf("Get(%s) = %v", tag, err)
+	}
+
+	// Should fail based on media type.
+	if _, err := desc.ImageIndex(); err == nil {
+		t.Errorf("ImageIndex() = %v, expected err", err)
+	}
+}

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -73,9 +73,9 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		return r.manifest, nil
 	}
 
-	// We should never get here because the public entrypoints do type-checking
-	// via remote.Descriptor. Just in case, but I've left this here for tests that
-	// directly instantiate a remoteImage.
+	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
+	// do type-checking via remote.Descriptor. Just in case, but I've left this
+	// here for tests that directly instantiate a remoteImage.
 	acceptable := []types.MediaType{
 		types.DockerManifestSchema2,
 		types.OCIManifestSchema1,

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -74,8 +74,8 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	}
 
 	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
-	// do type-checking via remote.Descriptor. Just in case, but I've left this
-	// here for tests that directly instantiate a remoteImage.
+	// do type-checking via remote.Descriptor. I've left this here for tests that
+	// directly instantiate a remoteImage.
 	acceptable := []types.MediaType{
 		types.DockerManifestSchema2,
 		types.OCIManifestSchema1,

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -262,8 +262,6 @@ func TestAcceptHeaders(t *testing.T) {
 			wantAccept := strings.Join([]string{
 				string(types.DockerManifestSchema2),
 				string(types.OCIManifestSchema1),
-				string(types.DockerManifestList),
-				string(types.OCIImageIndex),
 			}, ",")
 			if got, want := r.Header.Get("Accept"), wantAccept; got != want {
 				t.Errorf("Accept header; got %v, want %v", got, want)
@@ -390,7 +388,6 @@ func TestPullingManifestList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(string(rawManifest))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -430,7 +427,7 @@ func TestPullingManifestList(t *testing.T) {
 
 	// Test that child works as expected.
 	if got, want := mustRawManifest(t, rmtChild), mustRawManifest(t, child); bytes.Compare(got, want) != 0 {
-		t.Errorf("RawManifest() = %v, want %v", got, want)
+		t.Errorf("RawManifest() = %v, want %v", string(got), string(want))
 	}
 	if got, want := mustRawConfigFile(t, rmtChild), mustRawConfigFile(t, child); bytes.Compare(got, want) != 0 {
 		t.Errorf("RawConfigFile() = %v, want %v", got, want)
@@ -480,13 +477,7 @@ func TestPullingManifestListNoMatch(t *testing.T) {
 		OS:           "not-real-os",
 	}
 	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
-	rmtChild, err := Image(tag, WithPlatform(platform))
-	if err != nil {
-		t.Errorf("Image() = %v", err)
-	}
-
-	// Test that child works as expected.
-	if b, err := rmtChild.RawManifest(); err == nil {
-		t.Errorf("RawManifest() = %v, wanted err", b)
+	if _, err := Image(tag, WithPlatform(platform)); err == nil {
+		t.Errorf("Image succeeded, wanted err")
 	}
 }

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -67,6 +67,9 @@ func (r *remoteIndex) RawManifest() ([]byte, error) {
 		return r.manifest, nil
 	}
 
+	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
+	// do type-checking via remote.Descriptor. Just in case, but I've left this
+	// here for tests that directly instantiate a remoteIndex.
 	acceptable := []types.MediaType{
 		types.DockerManifestList,
 		types.OCIImageIndex,
@@ -90,39 +93,31 @@ func (r *remoteIndex) IndexManifest() (*v1.IndexManifest, error) {
 }
 
 func (r *remoteIndex) Image(h v1.Hash) (v1.Image, error) {
-	imgRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	desc, err := r.childByHash(h)
 	if err != nil {
 		return nil, err
 	}
-	ri := &remoteImage{
-		fetcher: fetcher{
-			Ref:    imgRef,
-			Client: r.Client,
-		},
-	}
-	imgCore, err := partial.CompressedToImage(ri)
-	if err != nil {
-		return imgCore, err
-	}
-	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
-	// remote.Write calls to facilitate cross-repo "mounting".
-	return &mountableImage{
-		Image:     imgCore,
-		Reference: r.Ref,
-	}, nil
+
+	// Descriptor.Image will handle coercing nested indexes into an Image.
+	return desc.Image()
 }
 
 func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
-	idxRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	desc, err := r.childByHash(h)
 	if err != nil {
 		return nil, err
 	}
-	return &remoteIndex{
-		fetcher: fetcher{
-			Ref:    idxRef,
-			Client: r.Client,
-		},
-	}, nil
+	return desc.ImageIndex()
+}
+
+func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
+	desc, err := r.childByPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	// Descriptor.Image will handle coercing nested indexes into an Image.
+	return desc.Image()
 }
 
 // This naively matches the first manifest with matching Architecture and OS.
@@ -132,17 +127,7 @@ func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
 //
 // But first we'd need to migrate to:
 //   github.com/opencontainers/image-spec/specs-go/v1
-func (r *remoteIndex) ImageByPlatform(platform v1.Platform) (v1.Image, error) {
-	desc, err := r.DescriptorByPlatform(platform)
-	if err != nil {
-		return nil, err
-	}
-
-	// Descriptor.Image will call back into here if it's an index.
-	return desc.Image()
-}
-
-func (r *remoteIndex) DescriptorByPlatform(platform v1.Platform) (*Descriptor, error) {
+func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error) {
 	index, err := r.IndexManifest()
 	if err != nil {
 		return nil, err
@@ -153,30 +138,48 @@ func (r *remoteIndex) DescriptorByPlatform(platform v1.Platform) (*Descriptor, e
 		if childDesc.Platform != nil {
 			p = *childDesc.Platform
 		}
-		if platform.Architecture == p.Architecture && platform.OS == p.OS {
-			childRef, err := r.childRef(childDesc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			manifest, desc, err := r.fetchManifest(childRef, []types.MediaType{childDesc.MediaType})
-			if err != nil {
-				return nil, err
-			}
 
-			return &Descriptor{
-				fetcher: fetcher{
-					Ref:    childRef,
-					Client: r.Client,
-				},
-				Manifest:   manifest,
-				Descriptor: *desc,
-				platform:   platform,
-			}, nil
+		if platform.Architecture == p.Architecture && platform.OS == p.OS {
+			return r.childDescriptor(childDesc, platform)
 		}
 	}
-	return nil, fmt.Errorf("no matching image for %s/%s in %s", platform.Architecture, platform.OS, r.Ref)
+	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.Architecture, platform.OS, r.Ref)
+}
+
+func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {
+	index, err := r.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	for _, childDesc := range index.Manifests {
+		if h == childDesc.Digest {
+			return r.childDescriptor(childDesc, defaultPlatform)
+		}
+	}
+	return nil, fmt.Errorf("no child with digest %s in index %s", h, r.Ref)
 }
 
 func (r *remoteIndex) childRef(h v1.Hash) (name.Reference, error) {
 	return name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+}
+
+// Convert one of this index's child's v1.Descriptor into a remote.Descriptor, with the given platform option.
+func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform) (*Descriptor, error) {
+	ref, err := r.childRef(child.Digest)
+	if err != nil {
+		return nil, err
+	}
+	manifest, desc, err := r.fetchManifest(ref, []types.MediaType{child.MediaType})
+	if err != nil {
+		return nil, err
+	}
+	return &Descriptor{
+		fetcher: fetcher{
+			Ref:    ref,
+			Client: r.Client,
+		},
+		Manifest:   manifest,
+		Descriptor: *desc,
+		platform:   platform,
+	}, nil
 }

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -68,8 +68,8 @@ func (r *remoteIndex) RawManifest() ([]byte, error) {
 	}
 
 	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
-	// do type-checking via remote.Descriptor. Just in case, but I've left this
-	// here for tests that directly instantiate a remoteIndex.
+	// do type-checking via remote.Descriptor. I've left this here for tests that
+	// directly instantiate a remoteIndex.
 	acceptable := []types.MediaType{
 		types.DockerManifestList,
 		types.OCIImageIndex,

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -22,6 +22,9 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+// ImageOption is a functional option for Image, index, and Get.
+type ImageOption func(*imageOpener) error
+
 // WithTransport is a functional option for overriding the default transport
 // on a remote image
 func WithTransport(t http.RoundTripper) ImageOption {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -59,6 +59,9 @@ func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
 	}
 }
 
+// WithPlatform is a functional option for overriding the default platform
+// that Image and Descriptor.Image use for resolving an index to an image.
+// The default platform is amd64/linux.
 func WithPlatform(p v1.Platform) ImageOption {
 	return func(i *imageOpener) error {
 		i.platform = p


### PR DESCRIPTION
This resolves a mismatch between how registries actually work and our
Image/ImageIndex interfaces. Since we don't know what type of artifact a
registry stores, we need some kind of union type to represent either
of them. This allows clients to reason about what type of artifact they
got back from the registry, and efficiently "cast" it to the right
implementation. This removes the need to do fallback.

remote.Descriptor embeds a v1.Descriptor, so it contains MediaType,
Size, and Digest, but it also has a Manifest field so we can access
the raw response from the registry. This is useful for crane digest and
crane manifest, where we dont' want to interpret the response, just show
what's there.

The remote.Image and remote.Index functions have been rewritten to use
remote.Descriptor under the hood. One observable side-effect of this is
that these functions will fail earlier than before. Whereas we used to
just perform the token handshake in e.g. `remote.Image(ref)`, now we
fetch the manifest (potentially recursively). In my opinion, this is a
good thing. It's better to fail early than later. One thing this fixes
is that e.g. crane push will fail with a message about pulling instead
of pushing, since we'll fail before we try to call remote.Write. This is
better for debugging.

Doing this eager manifest fetching also allows us to return a better
error message in the case of schema 1 images.

There are downsides to this, e.g. passing around collection of v1.Image
(before calling (Image.RawManifest)) will take up more memory (the size
of the manifest, just a few KB). That really only affects
tarball.MultiWriteToFile, but the difference should be negligble.

Fixes #388
Closes #377

I tacked on changes to relevant consumers in crane and added some
schema 1 checks (since it's easier to do now). I can split those out into
separate PRs if needed.
