### PR TITLE
Add remote.CheckPushPermission

### DIFF
--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -13,6 +13,8 @@ import (
 //
 // This can be useful to check whether the caller has permission to push an
 // image before doing work to construct the image.
+//
+// TODO(#412): Remove the need for this method.
 func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTripper) error {
 	auth, err := kc.Resolve(ref.Context().Registry)
 	if err != nil {

--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -24,6 +24,10 @@ func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTrip
 	if err != nil {
 		return err
 	}
+	// TODO(jasonhall): Against GCR, just doing the token handshake is
+	// enough, but this doesn't extend to Dockerhub, so we actually need
+	// to initiate an upload. Figure out how to return early here when we
+	// can.
 	w := writer{
 		ref:    ref,
 		client: &http.Client{Transport: tr},

--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -1,0 +1,33 @@
+package remote
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// CheckPushPermission returns an error if the given keychain cannot authorize
+// a push operation to the given ref.
+//
+// This can be useful to check whether the caller has permission to push an
+// image before doing work to construct the image.
+func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTripper) error {
+	auth, err := kc.Resolve(ref.Context().Registry)
+	if err != nil {
+		return err
+	}
+
+	scopes := []string{ref.Scope(transport.PushScope)}
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
+	if err != nil {
+		return err
+	}
+	w := writer{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	}
+	_, _, err = w.initiateUpload("", "")
+	return err
+}

--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -25,9 +25,11 @@ func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTrip
 		return err
 	}
 	// TODO(jasonhall): Against GCR, just doing the token handshake is
-	// enough, but this doesn't extend to Dockerhub, so we actually need
-	// to initiate an upload. Figure out how to return early here when we
-	// can.
+	// enough, but this doesn't extend to Dockerhub
+	// (https://github.com/docker/hub-feedback/issues/1771), so we actually
+	// need to initiate an upload to tell whether the credentials can
+	// authorize a push. Figure out how to return early here when we can,
+	// to avoid a roundtrip for spec-compliant registries.
 	w := writer{
 		ref:    ref,
 		client: &http.Client{Transport: tr},

--- a/pkg/v1/remote/check_test.go
+++ b/pkg/v1/remote/check_test.go
@@ -1,0 +1,55 @@
+package remote
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+func TestCheckPushPermission(t *testing.T) {
+	for _, c := range []struct {
+		status  int
+		wantErr bool
+	}{{
+		http.StatusCreated,
+		false,
+	}, {
+		http.StatusForbidden,
+		true,
+	}, {
+		http.StatusBadRequest,
+		true,
+	}} {
+
+		expectedRepo := "write/time"
+		initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case initiatePath:
+				if r.Method != http.MethodPost {
+					t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
+				}
+				w.Header().Set("Location", "somewhere/else")
+				http.Error(w, "", c.status)
+			default:
+				t.Fatalf("Unexpected path: %v", r.URL.Path)
+			}
+		}))
+		defer server.Close()
+		u, err := url.Parse(server.URL)
+		if err != nil {
+			t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+		}
+
+		ref := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+		if err := CheckPushPermission(ref, authn.DefaultKeychain, http.DefaultTransport); (err != nil) != c.wantErr {
+			t.Errorf("CheckPermission(%d): got error = %v, want err = %t", c.status, err, c.wantErr)
+		}
+	}
+}

--- a/pkg/v1/remote/check_test.go
+++ b/pkg/v1/remote/check_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 func TestCheckPushPermission(t *testing.T) {
@@ -50,6 +51,23 @@ func TestCheckPushPermission(t *testing.T) {
 		ref := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
 		if err := CheckPushPermission(ref, authn.DefaultKeychain, http.DefaultTransport); (err != nil) != c.wantErr {
 			t.Errorf("CheckPermission(%d): got error = %v, want err = %t", c.status, err, c.wantErr)
+		}
+	}
+}
+
+func TestCheckPushPermission_Real(t *testing.T) {
+	// Tests should not run in an environment where these registries can
+	// be pushed to.
+	for _, r := range []name.Reference{
+		mustNewTag(t, "ubuntu"),
+		mustNewTag(t, "google/cloud-sdk"),
+		mustNewTag(t, "microsoft/dotnet:sdk"),
+		mustNewTag(t, "gcr.io/non-existent-project/made-up"),
+		mustNewTag(t, "gcr.io/google-containers/foo"),
+		mustNewTag(t, "quay.io/username/reponame"),
+	} {
+		if err := CheckPushPermission(r, authn.DefaultKeychain, http.DefaultTransport); err == nil {
+			t.Errorf("CheckPushPermission(%s) returned nil", r)
 		}
 	}
 }


### PR DESCRIPTION
Ideas welcome on a better name. I didn't want to add a more generic "can I (push | pull)?" method since it's already pretty trivial to pull an image, and not costly since you'll fail to pull the manifest first.

The immediate use is in Kaniko, which takes a `--destination` flag and could fail fast if the current creds don't have permission to push to that destination. `ko` could likewise fail fast before `go build`ing if the current creds don't have permission on `KO_DOCKER_REPO`.

Callers that already have an image constructed and just want to push it (e.g., `crane push`) should call `remote.Write` to avoid unnecessary calls to `initiateUpload`.