### PR TITLE
golang format tools

### DIFF
--- a/pkg/v1/layout/blob.go
+++ b/pkg/v1/layout/blob.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // Blob returns a blob with the given hash from the Path.

--- a/pkg/v1/layout/image.go
+++ b/pkg/v1/layout/image.go
@@ -19,7 +19,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )

--- a/pkg/v1/layout/image_test.go
+++ b/pkg/v1/layout/image_test.go
@@ -17,7 +17,7 @@ package layout
 import (
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )

--- a/pkg/v1/layout/index.go
+++ b/pkg/v1/layout/index.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )

--- a/pkg/v1/layout/options.go
+++ b/pkg/v1/layout/options.go
@@ -1,6 +1,6 @@
 package layout
 
-import "github.com/google/go-containerregistry/pkg/v1"
+import v1 "github.com/google/go-containerregistry/pkg/v1"
 
 // Option is a functional option for Layout.
 //

--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
 )

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
