### PR TITLE
Replace LayerFromOpener with LayerFromReader where it makes sense.

### DIFF
--- a/pkg/ko/build/gobuild.go
+++ b/pkg/ko/build/gobuild.go
@@ -285,10 +285,7 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	dataLayerBytes := dataLayerBuf.Bytes()
-	dataLayer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewBuffer(dataLayerBytes)), nil
-	})
+	dataLayer, err := tarball.LayerFromReader(dataLayerBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -301,10 +298,7 @@ func (gb *gobuild) Build(s string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	binaryLayerBytes := binaryLayerBuf.Bytes()
-	binaryLayer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewBuffer(binaryLayerBytes)), nil
-	})
+	binaryLayer, err := tarball.LayerFromReader(binaryLayerBuf)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -425,7 +425,8 @@ func TestInitiateUploadMountsWithMountFromTheSameRegistry(t *testing.T) {
 }
 
 func TestDedupeLayers(t *testing.T) {
-	newBlob := func() io.ReadCloser { return ioutil.NopCloser(bytes.NewReader(bytes.Repeat([]byte{'a'}, 10000))) }
+	blob := bytes.NewReader(bytes.Repeat([]byte{'a'}, 10000))
+        newBlob := func() io.ReadCloser { return ioutil.NopCloser(bytes.NewReader(bytes.Repeat([]byte{'a'}, 10000))) }
 
 	img, err := random.Image(1024, 3)
 	if err != nil {
@@ -435,9 +436,9 @@ func TestDedupeLayers(t *testing.T) {
 	// Append three identical tarball.Layers, which should be deduped
 	// because contents can be hashed before uploading.
 	for i := 0; i < 3; i++ {
-		tl, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) { return newBlob(), nil })
+		tl, err := tarball.LayerFromReader(blob)
 		if err != nil {
-			t.Fatalf("LayerFromOpener(#%d): %v", i, err)
+			t.Fatalf("LayerFromReader(#%d): %v", i, err)
 		}
 		img, err = mutate.AppendLayers(img, tl)
 		if err != nil {

--- a/pkg/v1/stream/layer_test.go
+++ b/pkg/v1/stream/layer_test.go
@@ -63,10 +63,10 @@ func TestStreamVsBuffer(t *testing.T) {
 	}
 
 	// Test that buffering the same contents and using
-	// tarball.LayerFromOpener results in the same digest/diffID/size.
-	tl, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) { return newBlob(), nil })
+	// tarball.LayerFromReader results in the same digest/diffID/size.
+	tl, err := tarball.LayerFromReader(newBlob())
 	if err != nil {
-		t.Fatalf("LayerFromOpener: %v", err)
+		t.Fatalf("LayerFromReader: %v", err)
 	}
 	if d, err := tl.Digest(); err != nil {
 		t.Errorf("Digest: %v", err)


### PR DESCRIPTION
This pretty much removes every reference to LayerFromOpener except for mutate.go