### PR TITLE
Refactor pkg/name to use options

### DIFF
--- a/pkg/name/check.go
+++ b/pkg/name/check.go
@@ -19,15 +19,6 @@ import (
 	"unicode/utf8"
 )
 
-// Strictness defines the level of strictness for name validation.
-type Strictness int
-
-// Enums for CRUD operations.
-const (
-	StrictValidation Strictness = iota
-	WeakValidation
-)
-
 // stripRunesFn returns a function which returns -1 (i.e. a value which
 // signals deletion in strings.Map) for runes in 'runes', and the rune otherwise.
 func stripRunesFn(runes string) func(rune) rune {

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -63,8 +63,8 @@ func checkDigest(name string) error {
 	return checkElement("digest", name, digestChars, 7+64, 7+64)
 }
 
-// NewDigest returns a new Digest representing the given name, according to the given strictness.
-func NewDigest(name string, strict Strictness) (Digest, error) {
+// NewDigest returns a new Digest representing the given name.
+func NewDigest(name string, opts ...Option) (Digest, error) {
 	// Split on "@"
 	parts := strings.Split(name, digestDelim)
 	if len(parts) != 2 {
@@ -78,12 +78,12 @@ func NewDigest(name string, strict Strictness) (Digest, error) {
 		return Digest{}, err
 	}
 
-	tag, err := NewTag(base, strict)
+	tag, err := NewTag(base, opts...)
 	if err == nil {
 		base = tag.Repository.Name()
 	}
 
-	repo, err := NewRepository(base, strict)
+	repo, err := NewRepository(base, opts...)
 	if err != nil {
 		return Digest{}, err
 	}

--- a/pkg/name/options.go
+++ b/pkg/name/options.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+type options struct {
+	strict   bool // weak by default
+	insecure bool // secure by default
+}
+
+func makeOptions(opts ...Option) options {
+	opt := options{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// Option is a functional option for name parsing.
+type Option func(*options)
+
+// StrictValidation is an Option that requires image references to be fully
+// specified; i.e. no defaulting for registry (dockerhub), repo (library),
+// or tag (latest).
+func StrictValidation(opts *options) {
+	opts.strict = true
+}
+
+// WeakValidation is an Option that sets defaults when parsing names, see
+// StrictValidation.
+func WeakValidation(opts *options) {
+	opts.strict = false
+}
+
+// Insecure is an Option that allows image references to be fetched without TLS.
+func Insecure(opts *options) {
+	opts.insecure = true
+}

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -38,11 +38,11 @@ type Reference interface {
 }
 
 // ParseReference parses the string as a reference, either by tag or digest.
-func ParseReference(s string, strict Strictness) (Reference, error) {
-	if t, err := NewTag(s, strict); err == nil {
+func ParseReference(s string, opts ...Option) (Reference, error) {
+	if t, err := NewTag(s, opts...); err == nil {
 		return t, nil
 	}
-	if d, err := NewDigest(s, strict); err == nil {
+	if d, err := NewDigest(s, opts...); err == nil {
 		return d, nil
 	}
 	// TODO: Combine above errors into something more useful?

--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -114,8 +114,9 @@ func checkRegistry(name string) error {
 
 // NewRegistry returns a Registry based on the given name.
 // Strict validation requires explicit, valid RFC 3986 URI authorities to be given.
-func NewRegistry(name string, strict Strictness) (Registry, error) {
-	if strict == StrictValidation && len(name) == 0 {
+func NewRegistry(name string, opts ...Option) (Registry, error) {
+	opt := makeOptions(opts...)
+	if opt.strict && len(name) == 0 {
 		return Registry{}, NewErrBadName("strict validation requires the registry to be explicitly defined")
 	}
 
@@ -129,16 +130,12 @@ func NewRegistry(name string, strict Strictness) (Registry, error) {
 		name = DefaultRegistry
 	}
 
-	return Registry{registry: name}, nil
+	return Registry{registry: name, insecure: opt.insecure}, nil
 }
 
 // NewInsecureRegistry returns an Insecure Registry based on the given name.
 // Strict validation requires explicit, valid RFC 3986 URI authorities to be given.
-func NewInsecureRegistry(name string, strict Strictness) (Registry, error) {
-	reg, err := NewRegistry(name, strict)
-	if err != nil {
-		return Registry{}, err
-	}
-	reg.insecure = true
-	return reg, nil
+func NewInsecureRegistry(name string, opts ...Option) (Registry, error) {
+	opts = append(opts, Insecure)
+	return NewRegistry(name, opts...)
 }

--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -134,7 +134,8 @@ func NewRegistry(name string, opts ...Option) (Registry, error) {
 }
 
 // NewInsecureRegistry returns an Insecure Registry based on the given name.
-// Strict validation requires explicit, valid RFC 3986 URI authorities to be given.
+//
+// Deprecated: Use the Insecure Option with NewRegistry instead.
 func NewInsecureRegistry(name string, opts ...Option) (Registry, error) {
 	opts = append(opts, Insecure)
 	return NewRegistry(name, opts...)

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -68,7 +68,8 @@ func checkRepository(repository string) error {
 }
 
 // NewRepository returns a new Repository representing the given name, according to the given strictness.
-func NewRepository(name string, strict Strictness) (Repository, error) {
+func NewRepository(name string, opts ...Option) (Repository, error) {
+	opt := makeOptions(opts...)
 	if len(name) == 0 {
 		return Repository{}, NewErrBadName("a repository name must be specified")
 	}
@@ -88,11 +89,11 @@ func NewRepository(name string, strict Strictness) (Repository, error) {
 		return Repository{}, err
 	}
 
-	reg, err := NewRegistry(registry, strict)
+	reg, err := NewRegistry(registry, opts...)
 	if err != nil {
 		return Repository{}, err
 	}
-	if hasImplicitNamespace(repo, reg) && strict == StrictValidation {
+	if hasImplicitNamespace(repo, reg) && opt.strict {
 		return Repository{}, NewErrBadName("strict validation requires the full repository path (missing 'library')")
 	}
 	return Repository{reg, repo}, nil

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -71,7 +71,8 @@ func checkTag(name string) error {
 }
 
 // NewTag returns a new Tag representing the given name, according to the given strictness.
-func NewTag(name string, strict Strictness) (Tag, error) {
+func NewTag(name string, opts ...Option) (Tag, error) {
+	opt := makeOptions(opts...)
 	base := name
 	tag := ""
 
@@ -87,13 +88,13 @@ func NewTag(name string, strict Strictness) (Tag, error) {
 	// even when not being strict.
 	// If we are being strict, we want to validate the tag regardless in case
 	// it's empty.
-	if tag != "" || strict == StrictValidation {
+	if tag != "" || opt.strict {
 		if err := checkTag(tag); err != nil {
 			return Tag{}, err
 		}
 	}
 
-	repo, err := NewRepository(base, strict)
+	repo, err := NewRepository(base, opts...)
 	if err != nil {
 		return Tag{}, err
 	}


### PR DESCRIPTION
This changes the Strictness parameter to be a more general Option so
that we can also pass in name.Insecure for insecure registries.

Note that by changing the name.StrictValidation and name.WeakValidation
enums to be Options, this change avoids breaking callers or introducing
new methods.

Fixes https://github.com/google/go-containerregistry/issues/416