### PR TITLE
Rewrite remote streaming layer handling

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -28,7 +28,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
 )
@@ -58,16 +57,16 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 
 	// Upload individual layers in goroutines and collect any errors.
 	// If we can dedupe by the layer digest, try to do so. If the layer is
-	// a stream.Layer, we can't dedupe and might re-upload.
+	// a streaming layer, we can't dedupe and might re-upload.
 	var g errgroup.Group
 	uploaded := map[v1.Hash]bool{}
 	for _, l := range ls {
 		l := l
-		if _, ok := l.(*stream.Layer); !ok {
-			h, err := l.Digest()
-			if err != nil {
-				return err
-			}
+
+		// Streaming layers calculate their digests while uploading them. Assume
+		// an error here indicates we need to upload the layer.
+		h, err := l.Digest()
+		if err == nil {
 			// If we can determine the layer's digest ahead of
 			// time, use it to dedupe uploads.
 			if uploaded[h] {
@@ -81,14 +80,15 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		})
 	}
 
-	if l, err := partial.ConfigLayer(img); err == stream.ErrNotComputed {
-		// We can't read the ConfigLayer, because of streaming layers, since the
-		// config hasn't been calculated yet.
+	if l, err := partial.ConfigLayer(img); err != nil {
+		// We can't read the ConfigLayer, possibly because of streaming layers,
+		// since the layer DiffIDs haven't been calculated yet. Attempt to wait
+		// for the other layers to be uploaded, then try the config again.
 		if err := g.Wait(); err != nil {
 			return err
 		}
 
-		// Now that all the layers are uploaded, upload the config file blob.
+		// Now that all the layers are uploaded, try to upload the config file blob.
 		l, err := partial.ConfigLayer(img)
 		if err != nil {
 			return err
@@ -96,9 +96,6 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 		if err := w.uploadOne(l); err != nil {
 			return err
 		}
-	} else if err != nil {
-		// This is an actual error, not a streaming error, just return it.
-		return err
 	} else {
 		// We *can* read the ConfigLayer, so upload it concurrently with the layers.
 		g.Go(func() error {
@@ -285,19 +282,10 @@ func (w *writer) commitBlob(location, digest string) error {
 
 // uploadOne performs a complete upload of a single layer.
 func (w *writer) uploadOne(l v1.Layer) error {
-	var from, mount, digest string
-	if _, ok := l.(*stream.Layer); !ok {
-		// Layer isn't streamable, we should take advantage of that to
-		// skip uploading if possible.
-		// By sending ?digest= in the request, we'll also check that
-		// our computed digest matches the one computed by the
-		// registry.
-		h, err := l.Digest()
-		if err != nil {
-			return err
-		}
-		digest = h.String()
-
+	var from, mount string
+	if h, err := l.Digest(); err == nil {
+		// If we know the digest, this isn't a streaming layer. Do an existence
+		// check so we can skip uploading the layer if possible.
 		existing, err := w.checkExistingBlob(h)
 		if err != nil {
 			return err
@@ -340,7 +328,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 	if err != nil {
 		return err
 	}
-	digest = h.String()
+	digest := h.String()
 
 	if err := w.commitBlob(location, digest); err != nil {
 		return err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -56,8 +56,8 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 	}
 
 	// Upload individual layers in goroutines and collect any errors.
-	// If we can dedupe by the layer digest, try to do so. If the layer is
-	// a streaming layer, we can't dedupe and might re-upload.
+	// If we can dedupe by the layer digest, try to do so. If we can't determine
+	// the digest for whatever reason, we can't dedupe and might re-upload.
 	var g errgroup.Group
 	uploaded := map[v1.Hash]bool{}
 	for _, l := range ls {


### PR DESCRIPTION
Assume errors in v1.Layer.Digest are related to streaming.

Retry any errors that could be related to streaming layers after we've
uploaded all layers.

Remove any references to stream.Layer from remote.