### PR TITLE
Add crane export

### DIFF
--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -23,6 +23,7 @@ crane [flags]
 * [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst
 * [crane delete](crane_delete.md)	 - Delete an image reference from its registry
 * [crane digest](crane_digest.md)	 - Get the digest of an image
+* [crane export](crane_export.md)	 - Export contents of a remote image as a tarball
 * [crane ls](crane_ls.md)	 - List the tags in a repo
 * [crane manifest](crane_manifest.md)	 - Get the manifest of an image
 * [crane pull](crane_pull.md)	 - Pull a remote image by reference and store its contents in a tarball

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -1,0 +1,32 @@
+## crane export
+
+Export contents of a remote image as a tarball
+
+### Synopsis
+
+Export contents of a remote image as a tarball
+
+```
+crane export IMAGE OUTPUT [flags]
+```
+
+### Examples
+
+```
+  # Write tarball to stdout
+  crane export ubuntu -
+
+  # Write tarball to file
+  crane export ubuntu ubuntu.tar
+```
+
+### Options
+
+```
+  -h, --help   help for export
+```
+
+### SEE ALSO
+
+* [crane](crane.md)	 - Crane is a tool for managing container images
+

--- a/pkg/crane/export.go
+++ b/pkg/crane/export.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crane
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdExport()) }
+
+// NewCmdExport creates a new cobra.Command for the export subcommand.
+func NewCmdExport() *cobra.Command {
+	exportCmd := &cobra.Command{
+		Use:   "export IMAGE OUTPUT",
+		Short: "Export contents of a remote image as a tarball",
+		Example: `  # Write tarball to stdout
+  crane export ubuntu -
+
+  # Write tarball to file
+  crane export ubuntu ubuntu.tar`,
+		Args: cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			doExport(args[0], args[1])
+		},
+	}
+
+	return exportCmd
+}
+
+func openFile(s string) (*os.File, error) {
+	if s == "-" {
+		return os.Stdout, nil
+	} else {
+		return os.Create(s)
+	}
+}
+
+func doExport(src, dst string) {
+	srcRef, err := name.ParseReference(src)
+	if err != nil {
+		log.Fatalf("parsing reference %q: %v", src, err)
+	}
+	img, err := remote.Image(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		log.Fatalf("reading image %q: %v", srcRef, err)
+	}
+
+	fs := mutate.Extract(img)
+
+	out, err := openFile(dst)
+	if err != nil {
+		log.Fatalf("failed to open %s: %v", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, fs); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is useful for viewing the filesystem of a remote image without having to fiddle with assembling the layers after a `crane pull`.

For example, if you wanted to see the files in the "ubuntu" image:

```
$ crane export ubuntu - | tar tv
```