### PR TITLE
registry: Full implementation

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+)
+
+var port = flag.Int("port", 1338, "port to run registry on")
+
+func main() {
+	flag.Parse()
+	s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", *port),
+		Handler: registry.New(),
+	}
+	log.Fatal(s.ListenAndServe())
+}

--- a/pkg/registry/blobs.go
+++ b/pkg/registry/blobs.go
@@ -49,7 +49,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 		return &regError{
 			Status:  http.StatusBadRequest,
 			Code:    "NAME_INVALID",
-			Message: "blobs must be attached to a container",
+			Message: "blobs must be attached to a repo",
 		}
 	}
 	target := elem[len(elem)-1]

--- a/pkg/registry/error.go
+++ b/pkg/registry/error.go
@@ -1,0 +1,32 @@
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type regError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (r *regError) Write(resp http.ResponseWriter) error {
+	resp.WriteHeader(r.Status)
+
+	type err struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type wrap struct {
+		Errors []err `json:"errors"`
+	}
+	return json.NewEncoder(resp).Encode(wrap{
+		Errors: []err{
+			{
+				Code:    r.Code,
+				Message: r.Message,
+			},
+		},
+	})
+}

--- a/pkg/registry/example_test.go
+++ b/pkg/registry/example_test.go
@@ -1,0 +1,16 @@
+package registry_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+)
+
+func ExampleSetup() {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	resp, _ := s.Client().Get(s.URL + "/v2/bar/blobs/sha256:...")
+	fmt.Println(resp.StatusCode)
+	// Output: 404
+}

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -51,6 +53,8 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 				Message: "Unknown manifest",
 			}
 		}
+		d := "sha256:" + hex.EncodeToString(m)
+		resp.Header().Set("Docker-Content-Digest", d)
 		resp.Header().Set("Content-Length", fmt.Sprint(len(m)))
 		resp.WriteHeader(http.StatusOK)
 		io.Copy(resp, bytes.NewReader(m))
@@ -75,6 +79,8 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 				Message: "Unknown manifest",
 			}
 		}
+		d := "sha256:" + hex.EncodeToString(m)
+		resp.Header().Set("Docker-Content-Digest", d)
 		resp.Header().Set("Content-Length", fmt.Sprint(len(m)))
 		resp.WriteHeader(http.StatusOK)
 		return nil
@@ -88,7 +94,10 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 		}
 		b := &bytes.Buffer{}
 		io.Copy(b, req.Body)
+		rd := sha256.Sum256(b.Bytes())
+		d := "sha256:" + hex.EncodeToString(rd[:])
 		m.manifests[repo][target] = b.Bytes()
+		resp.Header().Set("Docker-Content-Digest", d)
 		resp.WriteHeader(http.StatusCreated)
 		return nil
 	}

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -1,0 +1,75 @@
+package registry
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type manifests struct {
+	// maps container -> manifest tag/ digest -> manifest
+	manifests map[string]map[string][]byte
+}
+
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-an-image-manifest
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-an-image
+func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	container := strings.Join(elem[1:len(elem)-2], "/")
+
+	if req.Method == "GET" {
+		if _, ok := m.manifests[container]; !ok {
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+		m, ok := m.manifests[container][target]
+		if !ok {
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader(m))
+		return
+	}
+
+	if req.Method == "HEAD" {
+		if _, ok := m.manifests[container]; !ok {
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+		m, ok := m.manifests[container][target]
+		if !ok {
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m)))
+		resp.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if req.Method == "PUT" {
+		if _, ok := m.manifests[container]; !ok {
+			m.manifests[container] = map[string][]byte{}
+		}
+		b := &bytes.Buffer{}
+		io.Copy(b, req.Body)
+		m.manifests[container][target] = b.Bytes()
+		resp.WriteHeader(http.StatusCreated)
+		return
+	}
+	resp.WriteHeader(http.StatusBadRequest)
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -41,9 +41,7 @@ func (v *v) v2(resp http.ResponseWriter, req *http.Request) *regError {
 func (v *v) root(resp http.ResponseWriter, req *http.Request) {
 	if rerr := v.v2(resp, req); rerr != nil {
 		log.Printf("%s %s %d %s %s", req.Method, req.URL, rerr.Status, rerr.Code, rerr.Message)
-		if err := rerr.Write(resp); err != nil {
-			log.Print(err)
-		}
+		rerr.Write(resp)
 		return
 	}
 	log.Printf("%s %s", req.Method, req.URL)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -6,7 +6,8 @@ import (
 )
 
 type v struct {
-	blobs blobs
+	blobs     blobs
+	manifests manifests
 }
 
 // https://docs.docker.com/registry/spec/api/#api-version-check
@@ -14,6 +15,10 @@ type v struct {
 func (v *v) v2(resp http.ResponseWriter, req *http.Request) {
 	if isBlob(req) {
 		v.blobs.handle(resp, req)
+		return
+	}
+	if isManifest(req) {
+		v.manifests.handle(resp, req)
 		return
 	}
 	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
@@ -31,6 +36,9 @@ func New() http.Handler {
 		blobs: blobs{
 			contents: map[string][]byte{},
 			uploads:  map[string][]byte{},
+		},
+		manifests: manifests{
+			manifests: map[string]map[string][]byte{},
 		},
 	}
 	m.HandleFunc("/v2/", v.v2)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,7 +27,7 @@ func (v *v) v2(resp http.ResponseWriter, req *http.Request) *regError {
 		return v.manifests.handle(resp, req)
 	}
 	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
-	if req.URL.Path != "/v2/" {
+	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
 		return &regError{
 			Status:  http.StatusNotFound,
 			Code:    "METHOD_UNKNOWN",
@@ -49,7 +49,6 @@ func (v *v) root(resp http.ResponseWriter, req *http.Request) {
 
 // New returns a handler which implements the docker registry protocol. It should be registered at the site root.
 func New() http.Handler {
-	m := http.NewServeMux()
 	v := v{
 		blobs: blobs{
 			contents: map[string][]byte{},
@@ -59,6 +58,5 @@ func New() http.Handler {
 			manifests: map[string]map[string]manifest{},
 		},
 	}
-	m.HandleFunc("/v2/", v.root)
-	return m
+	return http.HandlerFunc(v.root)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,4 +1,10 @@
-// Package registry implements a docker V2 registry.
+// Package registry implements a docker V2 registry and the OCI distribution specification.
+//
+// It is designed to be used anywhere a low dependency container registry is needed, with an
+// initial focus on tests.
+//
+// Its goal is to be standards compliant and its strictness will increase over time.
+
 package registry
 
 import (

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -56,7 +56,7 @@ func New() http.Handler {
 			uploads:  map[string][]byte{},
 		},
 		manifests: manifests{
-			manifests: map[string]map[string][]byte{},
+			manifests: map[string]map[string]manifest{},
 		},
 	}
 	m.HandleFunc("/v2/", v.root)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -108,6 +108,20 @@ func TestCalls(t *testing.T) {
 			Code:        http.StatusBadRequest,
 		},
 		{
+			Description: "monolithic upload good digest",
+			Method:      "POST",
+			URL:         "/v2/foo/blobs/uploads?digest=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			Code:        http.StatusCreated,
+			Body:        "foo",
+		},
+		{
+			Description: "monolithic upload bad digest",
+			Method:      "POST",
+			URL:         "/v2/foo/blobs/uploads?digest=sha256:fake",
+			Code:        http.StatusBadRequest,
+			Body:        "foo",
+		},
+		{
 			Description: "upload good digest",
 			Method:      "PUT",
 			URL:         "/v2/foo/blobs/uploads/1?digest=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -17,8 +17,9 @@ func TestCalls(t *testing.T) {
 		Description string
 
 		// Request / setup
-		URL     string
-		Digests map[string]string
+		URL       string
+		Digests   map[string]string
+		Manifests map[string]string
 
 		// Response
 		Code   int
@@ -58,6 +59,19 @@ func TestCalls(t *testing.T) {
 			Method:      "HEAD",
 			URL:         "/v2/foo/blobs/sha256:asd",
 			Code:        http.StatusNotFound,
+		},
+		{
+			Description: "bad blob verb",
+			Method:      "FOO",
+			URL:         "/v2/foo/blobs/sha256:asd",
+			Code:        http.StatusBadRequest,
+		},
+		{
+			Description: "GET containerless blob",
+			Digests:     map[string]string{"sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae": "foo"},
+			Method:      "GET",
+			URL:         "/v2/foo/blobs/sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			Code:        http.StatusOK,
 		},
 		{
 			Description: "GET blob",
@@ -108,6 +122,59 @@ func TestCalls(t *testing.T) {
 			Code:        http.StatusBadRequest,
 			Body:        "foo",
 		},
+		{
+			Description: "get missing manifest",
+			Method:      "GET",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusNotFound,
+		},
+		{
+			Description: "head missing manifest",
+			Method:      "HEAD",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusNotFound,
+		},
+		{
+			Description: "get missing manifest good container",
+			Manifests:   map[string]string{"foo/manifests/latest": "foo"},
+			Method:      "GET",
+			URL:         "/v2/foo/manifests/bar",
+			Code:        http.StatusNotFound,
+		},
+		{
+			Description: "head missing manifest good container",
+			Manifests:   map[string]string{"foo/manifests/latest": "foo"},
+			Method:      "HEAD",
+			URL:         "/v2/foo/manifests/bar",
+			Code:        http.StatusNotFound,
+		},
+		{
+			Description: "get manifest",
+			Manifests:   map[string]string{"foo/manifests/latest": "foo"},
+			Method:      "GET",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusOK,
+		},
+		{
+			Description: "head manifest",
+			Manifests:   map[string]string{"foo/manifests/latest": "foo"},
+			Method:      "HEAD",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusOK,
+		},
+		{
+			Description: "create manifest",
+			Method:      "PUT",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusCreated,
+			Body:        "foo",
+		},
+		{
+			Description: "bad manifest method",
+			Method:      "BAR",
+			URL:         "/v2/foo/manifests/latest",
+			Code:        http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -115,6 +182,24 @@ func TestCalls(t *testing.T) {
 			s := httptest.NewServer(registry.New())
 			defer s.Close()
 
+			for manifest, contents := range tc.Manifests {
+				u, err := url.Parse(s.URL + "/v2/" + manifest)
+				if err != nil {
+					t.Fatalf("Error parsing %q: %v", s.URL+"/v2", err)
+				}
+				req := &http.Request{
+					Method: "PUT",
+					URL:    u,
+					Body:   ioutil.NopCloser(strings.NewReader(contents)),
+				}
+				resp, err := s.Client().Do(req)
+				if err != nil {
+					t.Fatalf("Error uploading manifest: %v", err)
+				}
+				if resp.StatusCode != http.StatusCreated {
+					t.Fatalf("Error uploading manifest got status: %d", resp.StatusCode)
+				}
+			}
 			for digest, contents := range tc.Digests {
 				u, err := url.Parse(fmt.Sprintf("%s/v2/foo/blobs/uploads/1?digest=%s", s.URL, digest))
 				if err != nil {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -229,7 +229,7 @@ func TestCalls(t *testing.T) {
 			Method:        "PATCH",
 			URL:           "/v2/foo/blobs/uploads/1",
 			RequestHeader: map[string]string{"Content-Range": "0-bar"},
-			Code:          http.StatusBadRequest,
+			Code:          http.StatusRequestedRangeNotSatisfiable,
 			Body:          "foo",
 		},
 		{
@@ -238,7 +238,7 @@ func TestCalls(t *testing.T) {
 			URL:           "/v2/foo/blobs/uploads/1",
 			BlobStream:    map[string]string{"1": "foo"},
 			RequestHeader: map[string]string{"Content-Range": "2-5"},
-			Code:          http.StatusBadRequest,
+			Code:          http.StatusRequestedRangeNotSatisfiable,
 			Body:          "bar",
 		},
 		{

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -104,6 +104,13 @@ func TestCalls(t *testing.T) {
 			Header:      map[string]string{"Range": "0-0"},
 		},
 		{
+			Description: "uploadurl",
+			Method:      "POST",
+			URL:         "/v2/foo/blobs/uploads/",
+			Code:        http.StatusAccepted,
+			Header:      map[string]string{"Range": "0-0"},
+		},
+		{
 			Description: "upload put missing digest",
 			Method:      "PUT",
 			URL:         "/v2/foo/blobs/uploads/1",


### PR DESCRIPTION
- Add manifest support
- Increase Coverage
- Support monolithic, stream and chunked uploads.
- Add locks for concurrency.
- Add headers and path changes to get docker + crane working.
- Store manifest content type to get docker working with crane pushed container.
- Return spec compatible error codes everywhere.
- Log all requests (and failures).