### PR TITLE
registry: Fix comment form and example name.

### DIFF
--- a/pkg/registry/example_test.go
+++ b/pkg/registry/example_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 )
 
-func ExampleSetup() {
+func Example() {
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
 	resp, _ := s.Client().Get(s.URL + "/v2/bar/blobs/sha256:...")

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,7 +4,6 @@
 // initial focus on tests.
 //
 // Its goal is to be standards compliant and its strictness will increase over time.
-
 package registry
 
 import (


### PR DESCRIPTION
This allows the package comment to correctly show up in go doc.