### PR TITLE
Retry layer upload on BLOB_UPLOAD_INVALID error

### DIFF
--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -48,6 +48,20 @@ func (e *Error) Error() string {
 	}
 }
 
+// ShouldRetry returns whether the request that preceded the error should be retried.
+func (e *Error) ShouldRetry() bool {
+	if len(e.Errors) == 0 {
+		return false
+	}
+	for _, d := range e.Errors {
+		// TODO: Include other error types.
+		if d.Code != BlobUploadInvalidErrorCode {
+			return false
+		}
+	}
+	return true
+}
+
 // Diagnostic represents a single error returned by a Docker registry interaction.
 type Diagnostic struct {
 	Code    ErrorCode   `json:"code"`

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -24,6 +24,40 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestShouldRetry(t *testing.T) {
+	tests := []struct {
+		error *Error
+		retry bool
+	}{{
+		error: &Error{},
+		retry: false,
+	}, {
+		error: &Error{
+			Errors: []Diagnostic{{
+				Code: BlobUploadInvalidErrorCode,
+			}},
+		},
+		retry: true,
+	}, {
+		error: &Error{
+			Errors: []Diagnostic{{
+				Code: BlobUploadInvalidErrorCode,
+			}, {
+				Code: DeniedErrorCode,
+			}},
+		},
+		retry: false,
+	}}
+
+	for _, test := range tests {
+		retry := test.error.ShouldRetry()
+
+		if test.retry != retry {
+			t.Errorf("ShouldRetry(%s) = %t, wanted %t", test.error, retry, test.retry)
+		}
+	}
+}
+
 func TestCheckErrorNil(t *testing.T) {
 	tests := []int{
 		http.StatusOK,

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -36,6 +38,9 @@ type manifest interface {
 	MediaType() (types.MediaType, error)
 	Digest() (v1.Hash, error)
 }
+
+const maxRetries = 2
+const backoffFactor = 0.5
 
 // Write pushes the provided img to the specified image reference.
 func Write(ref name.Reference, img v1.Image, options ...Option) error {
@@ -307,38 +312,54 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		}
 	}
 
-	location, mounted, err := w.initiateUpload(from, mount)
-	if err != nil {
-		return err
-	} else if mounted {
+	tryUpload := func() error {
+		location, mounted, err := w.initiateUpload(from, mount)
+		if err != nil {
+			return err
+		} else if mounted {
+			h, err := l.Digest()
+			if err != nil {
+				return err
+			}
+			log.Printf("mounted blob: %s", h.String())
+			return nil
+		}
+
+		blob, err := l.Compressed()
+		if err != nil {
+			return err
+		}
+		location, err = w.streamBlob(blob, location)
+		if err != nil {
+			return err
+		}
+
 		h, err := l.Digest()
 		if err != nil {
 			return err
 		}
-		log.Printf("mounted blob: %s", h.String())
+		digest := h.String()
+
+		if err := w.commitBlob(location, digest); err != nil {
+			return err
+		}
+		log.Printf("pushed blob: %s", digest)
 		return nil
 	}
-
-	blob, err := l.Compressed()
-	if err != nil {
-		return err
+	retries := 0
+	for {
+		err := tryUpload()
+		if err == nil {
+			return nil
+		}
+		if te, ok := err.(*transport.Error); !(ok && te.ShouldRetry()) || retries >= maxRetries {
+			return err
+		}
+		log.Printf("retrying after error: %s", err)
+		retries++
+		duration := time.Duration(backoffFactor*math.Pow(2, float64(retries))) * time.Second
+		time.Sleep(duration)
 	}
-	location, err = w.streamBlob(blob, location)
-	if err != nil {
-		return err
-	}
-
-	h, err := l.Digest()
-	if err != nil {
-		return err
-	}
-	digest := h.String()
-
-	if err := w.commitBlob(location, digest); err != nil {
-		return err
-	}
-	log.Printf("pushed blob: %s", digest)
-	return nil
 }
 
 // commitImage does a PUT of the image's manifest.

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -39,9 +39,6 @@ type manifest interface {
 	Digest() (v1.Hash, error)
 }
 
-const maxRetries = 2
-const backoffFactor = 0.5
-
 // Write pushes the provided img to the specified image reference.
 func Write(ref name.Reference, img v1.Image, options ...Option) error {
 	ls, err := img.Layers()
@@ -346,6 +343,8 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		log.Printf("pushed blob: %s", digest)
 		return nil
 	}
+	const maxRetries = 2
+	const backoffFactor = 0.5
 	retries := 0
 	for {
 		err := tryUpload()


### PR DESCRIPTION
To close https://github.com/google/go-containerregistry/issues/431

I'm still new to Go so am especially receptive to changes. It seems like there should be tests for the retry, but I wasn't sure if there's a most idiomatic way