### PR TITLE
golang format tools

### DIFF
--- a/pkg/v1/cache/cache.go
+++ b/pkg/v1/cache/cache.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"log"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // Cache encapsulates methods to interact with cached layers.

--- a/pkg/v1/cache/cache_test.go
+++ b/pkg/v1/cache/cache_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 

--- a/pkg/v1/cache/fs.go
+++ b/pkg/v1/cache/fs.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 

--- a/pkg/v1/cache/fs_test.go
+++ b/pkg/v1/cache/fs_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 

--- a/pkg/v1/cache/ro.go
+++ b/pkg/v1/cache/ro.go
@@ -1,6 +1,6 @@
 package cache
 
-import "github.com/google/go-containerregistry/pkg/v1"
+import v1 "github.com/google/go-containerregistry/pkg/v1"
 
 // ReadOnly returns a read-only implementation of the given Cache.
 //

--- a/pkg/v1/cache/ro_test.go
+++ b/pkg/v1/cache/ro_test.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
