### PR TITLE
Skip sending Authorization header if it's empty

### DIFF
--- a/pkg/v1/remote/transport/basic.go
+++ b/pkg/v1/remote/transport/basic.go
@@ -40,7 +40,7 @@ func (bt *basicTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	// we are redirected, only set it when the authorization header matches
 	// the host with which we are interacting.
 	// In case of redirect http.Client can use an empty Host, check URL too.
-	if in.Host == bt.target || in.URL.Host == bt.target {
+	if hdr != "" && (in.Host == bt.target || in.URL.Host == bt.target) {
 		in.Header.Set("Authorization", hdr)
 	}
 	in.Header.Set("User-Agent", transportName)


### PR DESCRIPTION
To fix https://github.com/google/go-containerregistry/issues/468