### PR TITLE
Add retries for temporary network issues

### DIFF
--- a/pkg/internal/retry/retry.go
+++ b/pkg/internal/retry/retry.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package retry provides methods for retrying operations. It is a thin wrapper
+// around k8s.io/apimachinery/pkg/util/wait to make certain operations easier.
+package retry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// This is implemented by several errors in the net package as well as our
+// transport.Error.
+type temporary interface {
+	Temporary() bool
+}
+
+// IsTemporary returns true if err implements Temporary() and it returns true.
+func IsTemporary(err error) bool {
+	if te, ok := err.(temporary); ok && te.Temporary() {
+		return true
+	}
+	return false
+}
+
+// IsNotNil returns true if err is not nil.
+func IsNotNil(err error) bool {
+	return err != nil
+}
+
+// Predicate determines whether an error should be retried.
+type Predicate func(error) (retry bool)
+
+// Retry retries a given function, f, until a predicate is satisfied, using
+// exponential backoff. If the predicate is never satisfied, it will return the
+// last error returned by f.
+func Retry(f func() error, p Predicate, backoff wait.Backoff) (err error) {
+	if f == nil {
+		return fmt.Errorf("nil f passed to retry")
+	}
+	if p == nil {
+		return fmt.Errorf("nil p passed to retry")
+	}
+
+	condition := func() (bool, error) {
+		err = f()
+		if p(err) {
+			return false, nil
+		}
+		return true, err
+	}
+
+	wait.ExponentialBackoff(backoff, condition)
+	return
+}

--- a/pkg/internal/retry/retry_test.go
+++ b/pkg/internal/retry/retry_test.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type temp struct{}
+
+func (e temp) Error() string {
+	return "temporary error"
+}
+
+func (e temp) Temporary() bool {
+	return true
+}
+
+func TestRetry(t *testing.T) {
+	for i, test := range []struct {
+		predicate   Predicate
+		err         error
+		shouldRetry bool
+	}{{
+		predicate:   IsTemporary,
+		err:         nil,
+		shouldRetry: false,
+	}, {
+		predicate:   IsTemporary,
+		err:         fmt.Errorf("not temporary"),
+		shouldRetry: false,
+	}, {
+		predicate:   IsNotNil,
+		err:         fmt.Errorf("not temporary"),
+		shouldRetry: true,
+	}, {
+		predicate:   IsTemporary,
+		err:         temp{},
+		shouldRetry: true,
+	}} {
+		// Make sure we retry 5 times if we shouldRetry.
+		steps := 5
+		backoff := wait.Backoff{
+			Steps: steps,
+		}
+
+		// Count how many times this function is invoked.
+		count := 0
+		f := func() error {
+			count++
+			return test.err
+		}
+
+		Retry(f, test.predicate, backoff)
+
+		if test.shouldRetry && count != steps {
+			t.Errorf("expected %d to retry %v, did not", i, test.err)
+		} else if !test.shouldRetry && count == steps {
+			t.Errorf("expected %d not to retry %v, but did", i, test.err)
+		}
+	}
+}
+
+// Make sure we don't panic.
+func TestNil(t *testing.T) {
+	if err := Retry(nil, nil, wait.Backoff{}); err == nil {
+		t.Errorf("got nil when passing in nil f")
+	}
+	if err := Retry(func() error { return nil }, nil, wait.Backoff{}); err == nil {
+		t.Errorf("got nil when passing in nil p")
+	}
+}

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -51,6 +51,9 @@ func newLister(repo name.Repository, options ...ListerOption) (*lister, error) {
 		}
 	}
 
+	// Wrap the transport in something that can retry network flakes.
+	l.transport = transport.NewRetry(l.transport)
+
 	scopes := []string{repo.Scope(transport.PullScope)}
 	tr, err := transport.New(repo.Registry, l.auth, l.transport, scopes)
 	if err != nil {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
 // Option is a functional option for remote operations.
@@ -56,6 +57,9 @@ func makeOptions(reg name.Registry, opts ...Option) (*options, error) {
 		}
 		o.auth = auth
 	}
+
+	// Wrap the transport in something that can retry network flakes.
+	o.transport = transport.NewRetry(o.transport)
 
 	return o, nil
 }

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -48,8 +48,8 @@ func (e *Error) Error() string {
 	}
 }
 
-// ShouldRetry returns whether the request that preceded the error should be retried.
-func (e *Error) ShouldRetry() bool {
+// Temporary returns whether the request that preceded the error is temporary.
+func (e *Error) Temporary() bool {
 	if len(e.Errors) == 0 {
 		return false
 	}

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestShouldRetry(t *testing.T) {
+func TestTemporary(t *testing.T) {
 	tests := []struct {
 		error *Error
 		retry bool
@@ -50,10 +50,10 @@ func TestShouldRetry(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		retry := test.error.ShouldRetry()
+		retry := test.error.Temporary()
 
 		if test.retry != retry {
-			t.Errorf("ShouldRetry(%s) = %t, wanted %t", test.error, retry, test.retry)
+			t.Errorf("Temporary(%s) = %t, wanted %t", test.error, retry, test.retry)
 		}
 	}
 }

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/internal/retry"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Sleep for 0.1, 0.3, 0.9, 2.7 seconds. This should cover networking blips.
+var defaultBackoff = wait.Backoff{
+	Duration: 100 * time.Millisecond,
+	Factor:   3.0,
+	Jitter:   0.1,
+	Steps:    5,
+}
+
+var _ http.RoundTripper = (*retryTransport)(nil)
+
+// retryTransport wraps a RoundTripper and retries temporary network errors.
+type retryTransport struct {
+	inner     http.RoundTripper
+	backoff   wait.Backoff
+	predicate retry.Predicate
+}
+
+// Option is a functional option for retryTransport.
+type Option func(*options)
+
+type options struct {
+	backoff   wait.Backoff
+	predicate retry.Predicate
+}
+
+// WithBackoff sets the backoff for retry operations.
+func WithBackoff(backoff wait.Backoff) Option {
+	return func(o *options) {
+		o.backoff = backoff
+	}
+}
+
+// WithPredicate sets the predicate for retry operations.
+func WithPredicate(predicate func(error) bool) Option {
+	return func(o *options) {
+		o.predicate = predicate
+	}
+}
+
+// NewRetry returns a transport that retries errors.
+func NewRetry(inner http.RoundTripper, opts ...Option) http.RoundTripper {
+	o := &options{
+		backoff:   defaultBackoff,
+		predicate: retry.IsTemporary,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return &retryTransport{
+		inner:     inner,
+		backoff:   o.backoff,
+		predicate: o.predicate,
+	}
+}
+
+func (t *retryTransport) RoundTrip(in *http.Request) (out *http.Response, err error) {
+	roundtrip := func() error {
+		out, err = t.inner.RoundTrip(in)
+		return err
+	}
+	retry.Retry(roundtrip, t.predicate, t.backoff)
+	return
+}

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -47,15 +47,15 @@ type options struct {
 	predicate retry.Predicate
 }
 
-// WithBackoff sets the backoff for retry operations.
-func WithBackoff(backoff wait.Backoff) Option {
+// WithRetryBackoff sets the backoff for retry operations.
+func WithRetryBackoff(backoff wait.Backoff) Option {
 	return func(o *options) {
 		o.backoff = backoff
 	}
 }
 
-// WithPredicate sets the predicate for retry operations.
-func WithPredicate(predicate func(error) bool) Option {
+// WithRetryPredicate sets the predicate for retry operations.
+func WithRetryPredicate(predicate func(error) bool) Option {
 	return func(o *options) {
 		o.predicate = predicate
 	}

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -69,7 +69,7 @@ func TestRetryTransport(t *testing.T) {
 			errs: test.errs,
 		}
 
-		tr := NewRetry(&mt, WithBackoff(wait.Backoff{Steps: 3}), WithPredicate(retry.IsTemporary))
+		tr := NewRetry(&mt, WithRetryBackoff(wait.Backoff{Steps: 3}), WithRetryPredicate(retry.IsTemporary))
 
 		tr.RoundTrip(nil)
 		if mt.count != test.count {

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -1,0 +1,95 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/internal/retry"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type mockTransport struct {
+	errs  []error
+	count int
+}
+
+func (t *mockTransport) RoundTrip(in *http.Request) (out *http.Response, err error) {
+	defer func() { t.count++ }()
+	return nil, t.errs[t.count]
+}
+
+type perm struct{}
+
+func (e perm) Error() string {
+	return "permanent error"
+}
+
+type temp struct{}
+
+func (e temp) Error() string {
+	return "temporary error"
+}
+
+func (e temp) Temporary() bool {
+	return true
+}
+
+func TestRetryTransport(t *testing.T) {
+	for _, test := range []struct {
+		errs  []error
+		count int
+	}{{
+		// Don't retry permanent.
+		errs:  []error{perm{}},
+		count: 1,
+	}, {
+		// Do retry temp.
+		errs:  []error{temp{}, perm{}},
+		count: 2,
+	}, {
+		// Stop at some max.
+		errs:  []error{temp{}, temp{}, temp{}, temp{}, temp{}},
+		count: 3,
+	}} {
+		mt := mockTransport{
+			errs: test.errs,
+		}
+
+		tr := NewRetry(&mt, WithBackoff(wait.Backoff{Steps: 3}), WithPredicate(retry.IsTemporary))
+
+		tr.RoundTrip(nil)
+		if mt.count != test.count {
+			t.Errorf("wrong count, wanted %d, got %d", test.count, mt.count)
+		}
+	}
+}
+
+func TestRetryDefaults(t *testing.T) {
+	tr := NewRetry(http.DefaultTransport)
+	rt, ok := tr.(*retryTransport)
+	if !ok {
+		t.Fatal("could not cast to retryTransport")
+	}
+
+	if rt.backoff != defaultBackoff {
+		t.Fatalf("default backoff wrong: %v", rt.backoff)
+	}
+
+	if rt.predicate == nil {
+		t.Fatal("default predicate not set")
+	}
+}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -20,17 +20,18 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/internal/retry"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type manifest interface {
@@ -343,22 +344,16 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		log.Printf("pushed blob: %s", digest)
 		return nil
 	}
-	const maxRetries = 2
-	const backoffFactor = 0.5
-	retries := 0
-	for {
-		err := tryUpload()
-		if err == nil {
-			return nil
-		}
-		if te, ok := err.(*transport.Error); !(ok && te.ShouldRetry()) || retries >= maxRetries {
-			return err
-		}
-		log.Printf("retrying after error: %s", err)
-		retries++
-		duration := time.Duration(backoffFactor*math.Pow(2, float64(retries))) * time.Second
-		time.Sleep(duration)
+
+	// Try this three times, waiting 1s after first failure, 3s after second.
+	backoff := wait.Backoff{
+		Duration: 1.0 * time.Second,
+		Factor:   3.0,
+		Jitter:   0.1,
+		Steps:    3,
 	}
+
+	return retry.Retry(tryUpload, retry.IsTemporary, backoff)
 }
 
 // commitImage does a PUT of the image's manifest.


### PR DESCRIPTION
We pretty commonly see this issue when communicating with a registry:
```
Get https://gcr.io/v2/: net/http: TLS handshake timeout
```

This causes a huge amount of pain if it's a failure within e.g. a large
CI job, since the entire thing would fail.

Fixes #77

This uses `k8s.io/apimachinery/pkg/util/wait` because we happen to already depend on it.