### PR TITLE
Resolve ports to well-known values when comparing Host values to decide whether or not to send Bearer Authorization header

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -174,7 +174,7 @@ func (bt *bearerTransport) canonicalAddress(host string) (address string, err er
 	// - [ipv6]:port
 	// As net.SplitHostPort returns an error if the host does not contain a port, we should only attempt
 	// to call it when we know that the address contains a port
-	if strings.Count(host, ":") == 1 || (strings.Count(host, ":") >= 2 && strings.Contains(host, "]")) {
+	if strings.Count(host, ":") == 1 || (strings.Count(host, ":") >= 2 && strings.Contains(host, "]:")) {
 		hostname, port, err := net.SplitHostPort(host)
 		if err != nil {
 			return "", err

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -65,18 +65,9 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		// we are redirected, only set it when the authorization header matches
 		// the registry with which we are interacting.
 		// In case of redirect http.Client can use an empty Host, check URL too.
-		canonicalHeaderHost, err := bt.canonicalAddress(in.Host)
-		if err != nil {
-			return nil, err
-		}
-		canonicalURLHost, err := bt.canonicalAddress(in.URL.Host)
-		if err != nil {
-			return nil, err
-		}
-		canonicalRegistryHost, err := bt.canonicalAddress(bt.registry.RegistryStr())
-		if err != nil {
-			return nil, err
-		}
+		canonicalHeaderHost := bt.canonicalAddress(in.Host)
+		canonicalURLHost := bt.canonicalAddress(in.URL.Host)
+		canonicalRegistryHost := bt.canonicalAddress(bt.registry.RegistryStr())
 		if canonicalHeaderHost == canonicalRegistryHost || canonicalURLHost == canonicalRegistryHost {
 			in.Header.Set("Authorization", hdr)
 
@@ -164,7 +155,7 @@ func (bt *bearerTransport) refresh() error {
 	return nil
 }
 
-func (bt *bearerTransport) canonicalAddress(host string) (address string, err error) {
+func (bt *bearerTransport) canonicalAddress(host string) (address string) {
 	// The host may be any one of:
 	// - hostname
 	// - hostname:port
@@ -177,14 +168,14 @@ func (bt *bearerTransport) canonicalAddress(host string) (address string, err er
 	if strings.Count(host, ":") == 1 || (strings.Count(host, ":") >= 2 && strings.Contains(host, "]:")) {
 		hostname, port, err := net.SplitHostPort(host)
 		if err != nil {
-			return "", err
+			return host
 		}
 		if port == "" {
 			port = portMap[bt.scheme]
 		}
 
-		return net.JoinHostPort(hostname, port), nil
+		return net.JoinHostPort(hostname, port)
 	}
 
-	return net.JoinHostPort(host, portMap[bt.scheme]), nil
+	return net.JoinHostPort(host, portMap[bt.scheme])
 }

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -18,8 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -45,6 +47,11 @@ type bearerTransport struct {
 
 var _ http.RoundTripper = (*bearerTransport)(nil)
 
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
 // RoundTrip implements http.RoundTripper
 func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	sendRequest := func() (*http.Response, error) {
@@ -58,7 +65,19 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		// we are redirected, only set it when the authorization header matches
 		// the registry with which we are interacting.
 		// In case of redirect http.Client can use an empty Host, check URL too.
-		if in.Host == bt.registry.RegistryStr() || in.URL.Host == bt.registry.RegistryStr() {
+		canonicalHeaderHost, err := bt.canonicalAddress(in.Host)
+		if err != nil {
+			return nil, err
+		}
+		canonicalURLHost, err := bt.canonicalAddress(in.URL.Host)
+		if err != nil {
+			return nil, err
+		}
+		canonicalRegistryHost, err := bt.canonicalAddress(bt.registry.RegistryStr())
+		if err != nil {
+			return nil, err
+		}
+		if canonicalHeaderHost == canonicalRegistryHost || canonicalURLHost == canonicalRegistryHost {
 			in.Header.Set("Authorization", hdr)
 
 			// When we ping() the registry, we determine whether to use http or https
@@ -143,4 +162,29 @@ func (bt *bearerTransport) refresh() error {
 	// Replace our old bearer authenticator (if we had one) with our newly refreshed authenticator.
 	bt.bearer = &bearer
 	return nil
+}
+
+func (bt *bearerTransport) canonicalAddress(host string) (address string, err error) {
+	// The host may be any one of:
+	// - hostname
+	// - hostname:port
+	// - ipv4
+	// - ipv4:port
+	// - ipv6
+	// - [ipv6]:port
+	// As net.SplitHostPort returns an error if the host does not contain a port, we should only attempt
+	// to call it when we know that the address contains a port
+	if strings.Count(host, ":") == 1 || (strings.Count(host, ":") >= 2 && strings.Contains(host, "]")) {
+		hostname, port, err := net.SplitHostPort(host)
+		if err != nil {
+			return "", err
+		}
+		if port == "" {
+			port = portMap[bt.scheme]
+		}
+
+		return net.JoinHostPort(hostname, port), nil
+	}
+
+	return net.JoinHostPort(host, portMap[bt.scheme]), nil
 }

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -317,6 +317,24 @@ func TestCanonicalAddressResolution(t *testing.T) {
 			registry: registry,
 			scheme:   "http",
 		},
+		address: "registry.example.com:",
+		want:    "registry.example.com:80",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "registry.example.com:",
+		want:    "registry.example.com:443",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
 		address: "2001:db8::1",
 		want:    "[2001:db8::1]:80",
 	}, {
@@ -346,6 +364,24 @@ func TestCanonicalAddressResolution(t *testing.T) {
 		},
 		address: "[2001:db8::1]:12345",
 		want:    "[2001:db8::1]:12345",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
+		address: "[2001:db8::1]:",
+		want:    "[2001:db8::1]:80",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "[2001:db8::1]:",
+		want:    "[2001:db8::1]:443",
 	}}
 
 	for _, tt := range tests {

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -385,10 +385,7 @@ func TestCanonicalAddressResolution(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		got, err := tt.bt.canonicalAddress(tt.address)
-		if err != nil {
-			t.Errorf("Unexpected error during bt.canonicalAddress: %v", err)
-		}
+		got := tt.bt.canonicalAddress(tt.address)
 		if got != tt.want {
 			t.Errorf("Wrong canonical host: wanted %v got %v", tt.want, got)
 		}

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -261,3 +261,100 @@ func TestSchemeOverride(t *testing.T) {
 		}
 	}
 }
+
+func TestCanonicalAddressResolution(t *testing.T) {
+	bearer := &authn.Bearer{Token: "does-not-matter"}
+
+	registry, err := name.NewRegistry("does-not-matter", name.WeakValidation)
+	if err != nil {
+		t.Errorf("Unexpected error during NewRegistry: %v", err)
+	}
+
+	tests := []struct {
+		bt      *bearerTransport
+		address string
+		want    string
+	}{{
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
+		address: "registry.example.com",
+		want:    "registry.example.com:80",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
+		address: "registry.example.com:12345",
+		want:    "registry.example.com:12345",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "registry.example.com",
+		want:    "registry.example.com:443",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "registry.example.com:12345",
+		want:    "registry.example.com:12345",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
+		address: "2001:db8::1",
+		want:    "[2001:db8::1]:80",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "2001:db8::1",
+		want:    "[2001:db8::1]:443",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "http",
+		},
+		address: "[2001:db8::1]:12345",
+		want:    "[2001:db8::1]:12345",
+	}, {
+		bt: &bearerTransport{
+			inner:    &http.Transport{},
+			bearer:   bearer,
+			registry: registry,
+			scheme:   "https",
+		},
+		address: "[2001:db8::1]:12345",
+		want:    "[2001:db8::1]:12345",
+	}}
+
+	for _, tt := range tests {
+		got, err := tt.bt.canonicalAddress(tt.address)
+		if err != nil {
+			t.Errorf("Unexpected error during bt.canonicalAddress: %v", err)
+		}
+		if got != tt.want {
+			t.Errorf("Wrong canonical host: wanted %v got %v", tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Previously the code considered 'https://registry.example.com/' functionally different to 'https://registry.example.com:443', and similarly for 'http' and port 80.  This change always resolves Host values (which in Go may or may not be a combination of host and port) to include the host and port based on the scheme being used such that these two examples are considered functionally equivalent.

This should resolve https://github.com/google/go-containerregistry/issues/472