### PR TITLE
Turn crane into a library

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdAppend()) }
+
+// NewCmdAppend creates a new cobra.Command for the append subcommand.
+func NewCmdAppend() *cobra.Command {
+	var baseRef, newTag, newLayer, outFile string
+	appendCmd := &cobra.Command{
+		Use:   "append",
+		Short: "Append contents of a tarball to a remote image",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, args []string) {
+			base, err := crane.Pull(baseRef)
+			if err != nil {
+				log.Fatalf("pulling %s: %v", baseRef, err)
+			}
+
+			img, err := crane.Append(base, newLayer)
+			if err != nil {
+				log.Fatalf("appending %s: %v", newLayer, err)
+			}
+
+			if outFile != "" {
+				if err := crane.Save(img, newTag, outFile); err != nil {
+					log.Fatalf("writing output %q: %v", outFile, err)
+				}
+			} else {
+				if err := crane.Push(img, newTag); err != nil {
+					log.Fatalf("pushing image %s: %v", newTag, err)
+				}
+			}
+		},
+	}
+	appendCmd.Flags().StringVarP(&baseRef, "base", "b", "", "Name of base image to append to")
+	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
+	appendCmd.Flags().StringVarP(&newLayer, "new_layer", "f", "", "Path to tarball to append to image")
+	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
+
+	appendCmd.MarkFlagRequired("base")
+	appendCmd.MarkFlagRequired("new_tag")
+	appendCmd.MarkFlagRequired("new_layer")
+	return appendCmd
+}

--- a/cmd/crane/cmd/config.go
+++ b/cmd/crane/cmd/config.go
@@ -12,13 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
-// Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
-	if err != nil {
-		return nil, err
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdConfig()) }
+
+// NewCmdConfig creates a new cobra.Command for the config subcommand.
+func NewCmdConfig() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Get the config of an image",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := crane.Config(args[0])
+			if err != nil {
+				log.Fatalf("fetching config: %v", err)
+			}
+			fmt.Print(string(cfg))
+		},
 	}
-	return desc.Manifest, nil
 }

--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -12,13 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
-// Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
-	if err != nil {
-		return nil, err
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdCopy()) }
+
+// NewCmdCopy creates a new cobra.Command for the copy subcommand.
+func NewCmdCopy() *cobra.Command {
+	return &cobra.Command{
+		Use:     "copy",
+		Aliases: []string{"cp"},
+		Short:   "Efficiently copy a remote image from src to dst",
+		Args:    cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			src, dst := args[0], args[1]
+			if err := crane.Copy(src, dst); err != nil {
+				log.Fatal(err)
+			}
+		},
 	}
-	return desc.Manifest, nil
 }

--- a/cmd/crane/cmd/delete.go
+++ b/cmd/crane/cmd/delete.go
@@ -12,13 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
-// Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
-	if err != nil {
-		return nil, err
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdDelete()) }
+
+// NewCmdDelete creates a new cobra.Command for the delete subcommand.
+func NewCmdDelete() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an image reference from its registry",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			ref := args[0]
+			if err := crane.Delete(ref); err != nil {
+				log.Fatalf("deleting %s: %v", ref, err)
+			}
+		},
 	}
-	return desc.Manifest, nil
 }

--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -12,13 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
-// Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
-	if err != nil {
-		return nil, err
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdDigest()) }
+
+// NewCmdDigest creates a new cobra.Command for the digest subcommand.
+func NewCmdDigest() *cobra.Command {
+	return &cobra.Command{
+		Use:   "digest",
+		Short: "Get the digest of an image",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			digest, err := crane.Digest(args[0])
+			if err != nil {
+				log.Fatalf("computing digest: %v", err)
+			}
+			fmt.Println(digest)
+		},
 	}
-	return desc.Manifest, nil
 }

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdExport()) }
+
+// NewCmdExport creates a new cobra.Command for the export subcommand.
+func NewCmdExport() *cobra.Command {
+	return &cobra.Command{
+		Use:   "export IMAGE OUTPUT",
+		Short: "Export contents of a remote image as a tarball",
+		Example: `  # Write tarball to stdout
+  crane export ubuntu -
+
+  # Write tarball to file
+  crane export ubuntu ubuntu.tar`,
+		Args: cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			src, dst := args[0], args[1]
+
+			f, err := openFile(dst)
+			if err != nil {
+				log.Fatalf("failed to open %s: %v", dst, err)
+			}
+			defer f.Close()
+
+			img, err := crane.Pull(src)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if err := crane.Export(img, f); err != nil {
+				log.Fatalf("exporting %s: %v", src, err)
+			}
+		},
+	}
+}
+
+func openFile(s string) (*os.File, error) {
+	if s == "-" {
+		return os.Stdout, nil
+	}
+	return os.Create(s)
+}

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -12,13 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
-// Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
-	if err != nil {
-		return nil, err
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdList()) }
+
+// NewCmdList creates a new cobra.Command for the ls subcommand.
+func NewCmdList() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ls",
+		Short: "List the tags in a repo",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			repo := args[0]
+			tags, err := crane.ListTags(repo)
+			if err != nil {
+				log.Fatalf("reading tags for %s: %v", repo, err)
+			}
+
+			for _, tag := range tags {
+				fmt.Println(tag)
+			}
+		},
 	}
-	return desc.Manifest, nil
 }

--- a/cmd/crane/cmd/manifest.go
+++ b/cmd/crane/cmd/manifest.go
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
 import (
 	"fmt"
+	"log"
 
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
 )
 
-// ListTags returns the tags in repository src.
-func ListTags(src string) ([]string, error) {
-	repo, err := name.NewRepository(src)
-	if err != nil {
-		return nil, fmt.Errorf("parsing repo %q: %v", src, err)
-	}
+func init() { Root.AddCommand(NewCmdManifest()) }
 
-	return remote.List(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+// NewCmdManifest creates a new cobra.Command for the manifest subcommand.
+func NewCmdManifest() *cobra.Command {
+	return &cobra.Command{
+		Use:   "manifest",
+		Short: "Get the manifest of an image",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			src := args[0]
+			manifest, err := crane.Manifest(src)
+			if err != nil {
+				log.Fatalf("fetching manifest %s: %v", src, err)
+			}
+			fmt.Print(string(manifest))
+		},
+	}
 }

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdPull()) }
+
+// NewCmdPull creates a new cobra.Command for the pull subcommand.
+func NewCmdPull() *cobra.Command {
+	var cachePath string
+	pull := &cobra.Command{
+		Use:   "pull",
+		Short: "Pull a remote image by reference and store its contents in a tarball",
+		Args:  cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			src, path := args[0], args[1]
+			img, err := crane.Pull(src)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if cachePath != "" {
+				img = cache.Image(img, cache.NewFilesystemCache(cachePath))
+			}
+			if err := crane.Save(img, src, path); err != nil {
+				log.Fatalf("saving tarball %s: %v", path, err)
+			}
+		},
+	}
+	pull.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
+	return pull
+}

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdPush()) }
+
+// NewCmdPush creates a new cobra.Command for the push subcommand.
+func NewCmdPush() *cobra.Command {
+	return &cobra.Command{
+		Use:   "push",
+		Short: "Push image contents as a tarball to a remote registry",
+		Args:  cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			path, tag := args[0], args[1]
+			img, err := crane.Load(path)
+			if err != nil {
+				log.Fatalf("loading %s as tarball: %v", path, err)
+			}
+
+			if err := crane.Push(img, tag); err != nil {
+				log.Fatalf("pushing %s: %v", tag, err)
+			}
+		},
+	}
+}

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
 import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +33,35 @@ func NewCmdRebase() *cobra.Command {
 		Short: "Rebase an image onto a new base image",
 		Args:  cobra.NoArgs,
 		Run: func(*cobra.Command, []string) {
-			rebase(orig, oldBase, newBase, rebased)
+			origImg, err := crane.Pull(orig)
+			if err != nil {
+				log.Fatalf("pulling %s: %v", orig, err)
+			}
+
+			oldBaseImg, err := crane.Pull(oldBase)
+			if err != nil {
+				log.Fatalf("pulling %s: %v", oldBase, err)
+			}
+
+			newBaseImg, err := crane.Pull(newBase)
+			if err != nil {
+				log.Fatalf("pulling %s: %v", newBase, err)
+			}
+
+			img, err := mutate.Rebase(origImg, oldBaseImg, newBaseImg)
+			if err != nil {
+				log.Fatalf("rebasing: %v", err)
+			}
+
+			if err := crane.Push(img, rebased); err != nil {
+				log.Fatalf("pushing %s: %v", rebased, err)
+			}
+
+			digest, err := img.Digest()
+			if err != nil {
+				log.Fatalf("digesting rebased: %v", err)
+			}
+			fmt.Println(digest.String())
 		},
 	}
 	rebaseCmd.Flags().StringVarP(&orig, "original", "", "", "Original image to rebase")
@@ -48,45 +74,4 @@ func NewCmdRebase() *cobra.Command {
 	rebaseCmd.MarkFlagRequired("new_base")
 	rebaseCmd.MarkFlagRequired("rebased")
 	return rebaseCmd
-}
-
-func rebase(orig, oldBase, newBase, rebased string) {
-	if orig == "" || oldBase == "" || newBase == "" || rebased == "" {
-		log.Fatalln("Must provide --original, --old_base, --new_base and --rebased")
-	}
-
-	origImg, _, err := getImage(orig)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	oldBaseImg, _, err := getImage(oldBase)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	newBaseImg, _, err := getImage(newBase)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	rebasedTag, err := name.NewTag(rebased)
-	if err != nil {
-		log.Fatalf("parsing tag %q: %v", rebased, err)
-	}
-
-	rebasedImg, err := mutate.Rebase(origImg, oldBaseImg, newBaseImg)
-	if err != nil {
-		log.Fatalf("rebasing: %v", err)
-	}
-
-	dig, err := rebasedImg.Digest()
-	if err != nil {
-		log.Fatalf("digesting rebased: %v", err)
-	}
-
-	if err := remote.Write(rebasedTag, rebasedImg, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-		log.Fatalf("writing image %q: %v", rebasedTag, err)
-	}
-	fmt.Print(dig.String())
 }

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package cmd
 
 import "github.com/spf13/cobra"
 

--- a/cmd/crane/cmd/version.go
+++ b/cmd/crane/cmd/version.go
@@ -1,4 +1,4 @@
-package crane
+package cmd
 
 import (
 	"fmt"

--- a/cmd/crane/help/main.go
+++ b/cmd/crane/help/main.go
@@ -5,10 +5,9 @@ import (
 	"log"
 	"os"
 
+	"github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-
-	"github.com/google/go-containerregistry/pkg/crane"
 )
 
 var dir string
@@ -17,7 +16,7 @@ var root = &cobra.Command{
 	Short: "Generate crane's help docs",
 	Args:  cobra.NoArgs,
 	Run: func(*cobra.Command, []string) {
-		if err := doc.GenMarkdownTree(crane.Root, dir); err != nil {
+		if err := doc.GenMarkdownTree(cmd.Root, dir); err != nil {
 			log.Fatalln(err)
 		}
 	},

--- a/cmd/crane/main.go
+++ b/cmd/crane/main.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/cmd/crane/cmd"
 )
 
 func main() {
-	if err := crane.Root.Execute(); err != nil {
+	if err := cmd.Root.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/crane"
+	crane "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/google/go-containerregistry/pkg/gcrane"
 )
 

--- a/pkg/crane/config.go
+++ b/pkg/crane/config.go
@@ -14,34 +14,11 @@
 
 package crane
 
-import (
-	"fmt"
-	"log"
-
-	"github.com/spf13/cobra"
-)
-
-func init() { Root.AddCommand(NewCmdConfig()) }
-
-// NewCmdConfig creates a new cobra.Command for the config subcommand.
-func NewCmdConfig() *cobra.Command {
-	return &cobra.Command{
-		Use:   "config",
-		Short: "Get the config of an image",
-		Args:  cobra.ExactArgs(1),
-		Run:   config,
-	}
-}
-
-func config(_ *cobra.Command, args []string) {
-	ref := args[0]
+// Config returns the config file for the remote image ref.
+func Config(ref string) ([]byte, error) {
 	i, _, err := getImage(ref)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
-	config, err := i.RawConfigFile()
-	if err != nil {
-		log.Fatalln(err)
-	}
-	fmt.Print(string(config))
+	return i.RawConfigFile()
 }

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -15,45 +15,33 @@
 package crane
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/spf13/cobra"
 )
 
-func init() { Root.AddCommand(NewCmdCopy()) }
-
-// NewCmdCopy creates a new cobra.Command for the copy subcommand.
-func NewCmdCopy() *cobra.Command {
-	return &cobra.Command{
-		Use:     "copy",
-		Aliases: []string{"cp"},
-		Short:   "Efficiently copy a remote image from src to dst",
-		Args:    cobra.ExactArgs(2),
-		Run:     doCopy,
-	}
-}
-
-func doCopy(_ *cobra.Command, args []string) {
-	src, dst := args[0], args[1]
+// Copy copies a remote image or index from src to dst.
+func Copy(src, dst string) error {
 	srcRef, err := name.ParseReference(src)
 	if err != nil {
-		log.Fatalf("parsing reference %q: %v", src, err)
+		return fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 	log.Printf("Pulling %v", srcRef)
 
 	desc, err := remote.Get(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		log.Fatalf("fetching image %q: %v", srcRef, err)
+		return fmt.Errorf("parsing reference %q: %v", dst, err)
 	}
 
 	dstRef, err := name.ParseReference(dst)
 	if err != nil {
-		log.Fatalf("parsing reference %q: %v", dst, err)
+		return fmt.Errorf("getting creds for %q: %v", srcRef, err)
 	}
+
 	log.Printf("Pushing %v", dstRef)
 
 	switch desc.MediaType {
@@ -68,6 +56,8 @@ func doCopy(_ *cobra.Command, args []string) {
 			log.Fatalf("failed to copy image: %v", err)
 		}
 	}
+
+	return nil
 }
 
 func copyImage(desc *remote.Descriptor, dstRef name.Reference) error {

--- a/pkg/crane/delete.go
+++ b/pkg/crane/delete.go
@@ -15,34 +15,19 @@
 package crane
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/spf13/cobra"
 )
 
-func init() { Root.AddCommand(NewCmdDelete()) }
-
-// NewCmdDelete creates a new cobra.Command for the delete subcommand.
-func NewCmdDelete() *cobra.Command {
-	return &cobra.Command{
-		Use:   "delete",
-		Short: "Delete an image reference from its registry",
-		Args:  cobra.ExactArgs(1),
-		Run:   doDelete,
-	}
-}
-
-func doDelete(_ *cobra.Command, args []string) {
-	ref := args[0]
-	r, err := name.ParseReference(ref)
+// Delete deletes the remote reference at src.
+func Delete(src string) error {
+	ref, err := name.ParseReference(src)
 	if err != nil {
-		log.Fatalf("parsing reference %q: %v", ref, err)
+		return fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
-	if err := remote.Delete(r, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-		log.Fatalf("deleting image %q: %v", r, err)
-	}
+	return remote.Delete(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 }

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -14,30 +14,11 @@
 
 package crane
 
-import (
-	"fmt"
-	"log"
-
-	"github.com/spf13/cobra"
-)
-
-func init() { Root.AddCommand(NewCmdDigest()) }
-
-// NewCmdDigest creates a new cobra.Command for the digest subcommand.
-func NewCmdDigest() *cobra.Command {
-	return &cobra.Command{
-		Use:   "digest",
-		Short: "Get the digest of an image",
-		Args:  cobra.ExactArgs(1),
-		Run:   digest,
-	}
-}
-
-func digest(_ *cobra.Command, args []string) {
-	ref := args[0]
+// Digest returns the sha256 hash of the remote image at ref.
+func Digest(ref string) (string, error) {
 	desc, err := getManifest(ref)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
-	fmt.Println(desc.Digest)
+	return desc.Digest.String(), nil
 }

--- a/pkg/crane/export.go
+++ b/pkg/crane/export.go
@@ -16,63 +16,14 @@ package crane
 
 import (
 	"io"
-	"log"
-	"os"
 
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/spf13/cobra"
 )
 
-func init() { Root.AddCommand(NewCmdExport()) }
-
-// NewCmdExport creates a new cobra.Command for the export subcommand.
-func NewCmdExport() *cobra.Command {
-	exportCmd := &cobra.Command{
-		Use:   "export IMAGE OUTPUT",
-		Short: "Export contents of a remote image as a tarball",
-		Example: `  # Write tarball to stdout
-  crane export ubuntu -
-
-  # Write tarball to file
-  crane export ubuntu ubuntu.tar`,
-		Args: cobra.ExactArgs(2),
-		Run: func(_ *cobra.Command, args []string) {
-			doExport(args[0], args[1])
-		},
-	}
-
-	return exportCmd
-}
-
-func openFile(s string) (*os.File, error) {
-	if s == "-" {
-		return os.Stdout, nil
-	}
-	return os.Create(s)
-}
-
-func doExport(src, dst string) {
-	srcRef, err := name.ParseReference(src)
-	if err != nil {
-		log.Fatalf("parsing reference %q: %v", src, err)
-	}
-	img, err := remote.Image(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err != nil {
-		log.Fatalf("reading image %q: %v", srcRef, err)
-	}
-
+// Export writes the filesystem contents (as a tarball) of img to w.
+func Export(img v1.Image, w io.WriteCloser) error {
 	fs := mutate.Extract(img)
-
-	out, err := openFile(dst)
-	if err != nil {
-		log.Fatalf("failed to open %s: %v", dst, err)
-	}
-	defer out.Close()
-
-	if _, err := io.Copy(out, fs); err != nil {
-		log.Fatal(err)
-	}
+	_, err := io.Copy(w, fs)
+	return err
 }


### PR DESCRIPTION
Fixes #407

This change used to be a bit more compelling, before we started using functional options for everything, since it saves a bit of boilerplate. As is, it mostly just saves parsing strings via `name.ParseReference` and typing `remote.WithAuthFromKeychain(authn.DefaultKeychain)`.

I do think this strikes a nice balance for people who don't necessarily want to learn about our abstractions but do want to do something more sophisticated than what the `crane` CLI happens to expose.