### PR TITLE
Add logs package

### DIFF
--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -20,7 +20,13 @@ import (
 
 	crane "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/google/go-containerregistry/pkg/logs"
 )
+
+func init() {
+	logs.Warn.SetOutput(os.Stderr)
+	logs.Progress.SetOutput(os.Stderr)
+}
 
 func main() {
 	// Maintain a map of google-specific commands that we "override".

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -100,19 +100,19 @@ var (
 func (dk *defaultKeychain) Resolve(reg name.Registry) (Authenticator, error) {
 	dir, err := configDir()
 	if err != nil {
-		log.Printf("Unable to determine config dir: %v", err)
+		logs.Warn.Printf("Unable to determine config dir: %v", err)
 		return Anonymous, nil
 	}
 	file := filepath.Join(dir, "config.json")
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Printf("Unable to read %q: %v", file, err)
+		logs.Warn.Printf("Unable to read %q: %v", file, err)
 		return Anonymous, nil
 	}
 
 	var cf cfg
 	if err := json.Unmarshal(content, &cf); err != nil {
-		log.Printf("Unable to parse %q: %v", file, err)
+		logs.Warn.Printf("Unable to parse %q: %v", file, err)
 		return Anonymous, nil
 	}
 

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -30,7 +31,7 @@ func Copy(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %v", src, err)
 	}
-	log.Printf("Pulling %v", srcRef)
+	logs.Progress.Printf("Pulling %v", srcRef)
 
 	desc, err := remote.Get(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
@@ -42,7 +43,7 @@ func Copy(src, dst string) error {
 		return fmt.Errorf("getting creds for %q: %v", srcRef, err)
 	}
 
-	log.Printf("Pushing %v", dstRef)
+	logs.Progress.Printf("Pushing %v", dstRef)
 
 	switch desc.MediaType {
 	case types.OCIImageIndex, types.DockerManifestList:

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -225,7 +226,7 @@ func (c *copier) copyRepo(ctx context.Context, oldRepo name.Repository, tags *go
 		// we just need to copy everything.
 		//
 		// TODO: refactor remote.Error to expose response code?
-		log.Printf("failed to list %s: %v", newRepo, err)
+		logs.Warn.Printf("failed to list %s: %v", newRepo, err)
 	} else {
 		have = haveTags.Manifests
 	}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -12,24 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+// Package logs exposes the loggers used by this library.
+package logs
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/google/go-containerregistry/cmd/crane/cmd"
-	"github.com/google/go-containerregistry/pkg/logs"
+	"io/ioutil"
+	"log"
 )
 
-func init() {
-	logs.Warn.SetOutput(os.Stderr)
-	logs.Progress.SetOutput(os.Stderr)
-}
+var (
+	// Warn is used to log non-fatal errors.
+	Warn = log.New(ioutil.Discard, "", log.LstdFlags)
 
-func main() {
-	if err := cmd.Root.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
+	// Progress is used to log notable, successful events.
+	Progress = log.New(ioutil.Discard, "", log.LstdFlags)
+)

--- a/pkg/v1/cache/cache.go
+++ b/pkg/v1/cache/cache.go
@@ -3,8 +3,8 @@ package cache
 
 import (
 	"errors"
-	"log"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -63,7 +63,7 @@ func (i *image) Layers() ([]v1.Layer, error) {
 		}
 		if cl, err := i.c.Get(digest); err == nil {
 			// Layer found in the cache.
-			log.Printf("Layer %s found (compressed) in cache", digest)
+			logs.Progress.Printf("Layer %s found (compressed) in cache", digest)
 			out = append(out, cl)
 			continue
 		} else if err != nil && err != ErrNotFound {
@@ -78,7 +78,7 @@ func (i *image) Layers() ([]v1.Layer, error) {
 		}
 		if cl, err := i.c.Get(diffID); err == nil {
 			// Layer found in the cache.
-			log.Printf("Layer %s found (uncompressed) in cache", diffID)
+			logs.Progress.Printf("Layer %s found (uncompressed) in cache", diffID)
 			out = append(out, cl)
 		} else if err != nil && err != ErrNotFound {
 			return nil, err

--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"golang.org/x/oauth2"
 	googauth "golang.org/x/oauth2/google"
 )
@@ -62,7 +62,7 @@ func NewGcloudAuthenticator() (authn.Authenticator, error) {
 	if _, err := exec.LookPath("gcloud"); err != nil {
 		// TODO(#390): Use better logger.
 		// gcloud is not available, fall back to anonymous
-		log.Println("gcloud binary not found")
+		logs.Warn.Println("gcloud binary not found")
 		return authn.Anonymous, nil
 	}
 

--- a/pkg/v1/google/options.go
+++ b/pkg/v1/google/options.go
@@ -15,10 +15,10 @@
 package google
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 )
 
 // WithTransport is a functional option for overriding the default transport
@@ -48,7 +48,7 @@ func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
 			return err
 		}
 		if auth == authn.Anonymous {
-			log.Println("No matching credentials were found, falling back on anonymous")
+			logs.Warn.Println("No matching credentials were found, falling back on anonymous")
 		}
 		l.auth = auth
 		return nil

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -15,10 +15,10 @@
 package remote
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -53,7 +53,7 @@ func makeOptions(reg name.Registry, opts ...Option) (*options, error) {
 			return nil, err
 		}
 		if auth == authn.Anonymous {
-			log.Println("No matching credentials were found, falling back on anonymous")
+			logs.Warn.Println("No matching credentials were found, falling back on anonymous")
 		}
 		o.auth = auth
 	}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -19,12 +19,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/internal/retry"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -298,7 +298,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 			return err
 		}
 		if existing {
-			log.Printf("existing blob: %v", h)
+			logs.Progress.Printf("existing blob: %v", h)
 			return nil
 		}
 
@@ -319,7 +319,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 			if err != nil {
 				return err
 			}
-			log.Printf("mounted blob: %s", h.String())
+			logs.Progress.Printf("mounted blob: %s", h.String())
 			return nil
 		}
 
@@ -341,7 +341,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		if err := w.commitBlob(location, digest); err != nil {
 			return err
 		}
-		log.Printf("pushed blob: %s", digest)
+		logs.Progress.Printf("pushed blob: %s", digest)
 		return nil
 	}
 
@@ -392,7 +392,7 @@ func (w *writer) commitImage(man manifest) error {
 	}
 
 	// The image was successfully pushed!
-	log.Printf("%v: digest: %v size: %d", w.ref, digest, len(raw))
+	logs.Progress.Printf("%v: digest: %v size: %d", w.ref, digest, len(raw))
 	return nil
 }
 
@@ -453,7 +453,7 @@ func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
 			return err
 		}
 		if exists {
-			log.Printf("existing manifest: %v", desc.Digest)
+			logs.Progress.Printf("existing manifest: %v", desc.Digest)
 			continue
 		}
 


### PR DESCRIPTION
Fixes #480

We log for two reasons:
1. Warning for something that might have gone wrong.
2. Progress for things that are going right.

This introduces logs.Warn and logs.Progress which just expose two
package level log.Loggers, which will allow consumers of this library to
override them.

cc @dgageot this will make our library not log anything by default, see `cmd/crane/main.go` for enabling progress and/or warning logs. We'll want to do the same for `ko` to keep the same behavior.