### PR TITLE
Create a tls version of the registry.New()

### DIFF
--- a/pkg/registry/blobs.go
+++ b/pkg/registry/blobs.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry
 
 import (

--- a/pkg/registry/compatibility_test.go
+++ b/pkg/registry/compatibility_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package registry_test
 
 import (

--- a/pkg/registry/error.go
+++ b/pkg/registry/error.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry
 
 import (

--- a/pkg/registry/example_test.go
+++ b/pkg/registry/example_test.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry_test
 
 import (

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry
 
 import (

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Package registry implements a docker V2 registry and the OCI distribution specification.
 //
 // It is designed to be used anywhere a low dependency container registry is needed, with an

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry_test
 
 import (

--- a/pkg/registry/tls.go
+++ b/pkg/registry/tls.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// TLS returns a httptest server, as well as a transport that has been modified to
+// send all requests to the given server. The TLS certs are generated for the given domain
+// which should correspond to the domain the container is stored in.
+func TLS(domain string) (*httptest.Server, *http.Transport, error) {
+
+	s := httptest.NewUnstartedServer(New())
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, t, nil
+
+}

--- a/pkg/registry/tls.go
+++ b/pkg/registry/tls.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry
 
 import (
@@ -16,12 +29,11 @@ import (
 	"time"
 )
 
-// TLS returns a httptest server, with a http client that has been configured to
-// send all requests to the given server. The TLS certs are generated for the given domain
-// which should correspond to the domain the container is stored in.
+// TLS returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain
+// which should correspond to the domain the image is stored in.
 // If you need a transport, Client().Transport is correctly configured.
 func TLS(domain string) (*httptest.Server, error) {
-
 	s := httptest.NewUnstartedServer(New())
 
 	template := x509.Certificate{
@@ -88,5 +100,4 @@ func TLS(domain string) (*httptest.Server, error) {
 	s.Client().Transport = t
 
 	return s, nil
-
 }

--- a/pkg/registry/tls_test.go
+++ b/pkg/registry/tls_test.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry_test
 
 import (
@@ -10,7 +23,7 @@ import (
 )
 
 func TestTLS(t *testing.T) {
-	s, err := registry.TLS("test.com")
+	s, err := registry.TLS("registry.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,11 +38,11 @@ func TestTLS(t *testing.T) {
 		t.Fatalf("Unable to get image digest: %v", err)
 	}
 
-	d, err := name.NewDigest("test.com/foo@" + rd.String())
+	d, err := name.NewDigest("registry.example.com/foo@" + rd.String())
 	if err != nil {
 		t.Fatalf("Unable to parse digest: %v", err)
 	}
 	if err := remote.Write(d, i, remote.WithTransport(s.Client().Transport)); err != nil {
-		t.Fatalf("Unable to write image to remove: %s", err)
+		t.Fatalf("Unable to write image to remote: %s", err)
 	}
 }

--- a/pkg/registry/tls_test.go
+++ b/pkg/registry/tls_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTLS(t *testing.T) {
-	s, tp, err := registry.TLS("test.com")
+	s, err := registry.TLS("test.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse digest: %v", err)
 	}
-	if err := remote.Write(d, i, remote.WithTransport(tp)); err != nil {
+	if err := remote.Write(d, i, remote.WithTransport(s.Client().Transport)); err != nil {
 		t.Fatalf("Unable to write image to remove: %s", err)
 	}
 }

--- a/pkg/registry/tls_test.go
+++ b/pkg/registry/tls_test.go
@@ -1,15 +1,16 @@
-package registry
+package registry_test
 
 import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 func TestTLS(t *testing.T) {
-	s, tp, err := TLS("test.com")
+	s, tp, err := registry.TLS("test.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/tls_test.go
+++ b/pkg/registry/tls_test.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestTLS(t *testing.T) {
+	s, tp, err := TLS("test.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	i, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("Unable to make image: %v", err)
+	}
+	rd, err := i.Digest()
+	if err != nil {
+		t.Fatalf("Unable to get image digest: %v", err)
+	}
+
+	d, err := name.NewDigest("test.com/foo@" + rd.String())
+	if err != nil {
+		t.Fatalf("Unable to parse digest: %v", err)
+	}
+	if err := remote.Write(d, i, remote.WithTransport(tp)); err != nil {
+		t.Fatalf("Unable to write image to remove: %s", err)
+	}
+}


### PR DESCRIPTION
This handles the complexity of generating certs and forcing transports
to the server with the correct root ca. This should be usable for
replacing any given container registry in a test.