### PR TITLE
registry: Add a disclaimer and fix copyright headers.

### DIFF
--- a/pkg/registry/blobs.go
+++ b/pkg/registry/blobs.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry
 
 import (

--- a/pkg/registry/error.go
+++ b/pkg/registry/error.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry
 
 import (

--- a/pkg/registry/example_test.go
+++ b/pkg/registry/example_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry_test
 
 import (

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry
 
 import (

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -11,13 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 // Package registry implements a docker V2 registry and the OCI distribution specification.
 //
 // It is designed to be used anywhere a low dependency container registry is needed, with an
 // initial focus on tests.
 //
 // Its goal is to be standards compliant and its strictness will increase over time.
+//
+// This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it
+// in production, please let us know how and send us CL's for integration tests.
 package registry
 
 import (

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry_test
 
 import (

--- a/pkg/registry/tls.go
+++ b/pkg/registry/tls.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry
 
 import (

--- a/pkg/registry/tls_test.go
+++ b/pkg/registry/tls_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package registry_test
 
 import (


### PR DESCRIPTION
Hopefully this will make sure that people understand it's current production state and fix go doc.