### PR TITLE
Add so much coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/zz_*_generated.go" # Ignore generated files.

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -1,0 +1,300 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crane_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// TODO(jonjohnsonjr): Test crane.Delete behavior.
+// TODO(jonjohnsonjr): Test crane.ListTags behavior.
+// TODO(jonjohnsonjr): Test crane.Copy failures.
+func TestCraneRegistry(t *testing.T) {
+	// Set up a fake registry.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := fmt.Sprintf("%s/test/crane", u.Host)
+	dst := fmt.Sprintf("%s/test/crane/copy", u.Host)
+
+	// Expected values.
+	img, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := img.RawManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := img.RawConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load up the registry.
+	if err := crane.Push(img, src); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that `crane.Foo` returns expected values.
+	d, err := crane.Digest(src)
+	if err != nil {
+		t.Error(err)
+	} else if d != digest.String() {
+		t.Errorf("Digest(): %v != %v", d, digest)
+	}
+
+	m, err := crane.Manifest(src)
+	if err != nil {
+		t.Error(err)
+	} else if string(m) != string(manifest) {
+		t.Errorf("Manifest(): %v != %v", m, manifest)
+	}
+
+	c, err := crane.Config(src)
+	if err != nil {
+		t.Error(err)
+	} else if string(c) != string(config) {
+		t.Errorf("Config(): %v != %v", c, config)
+	}
+
+	// Make sure we pull what we pushed.
+	pulled, err := crane.Pull(src)
+	if err != nil {
+		t.Error(err)
+	} else if m, err := pulled.RawManifest(); err != nil {
+		t.Fatal(err)
+	} else if string(m) != string(manifest) {
+		t.Errorf("crane.Pull().Manifest(): %v != %v", m, manifest)
+	}
+
+	// Test that the copied image is the same as the source.
+	if err := crane.Copy(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	pulled, err = crane.Pull(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err = crane.Digest(dst)
+	if err != nil {
+		t.Fatal(err)
+	} else if d != digest.String() {
+		t.Errorf("Copied Digest(): %v != %v", d, digest)
+	}
+}
+
+func TestCraneCopyIndex(t *testing.T) {
+	// Set up a fake registry.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := fmt.Sprintf("%s/test/crane", u.Host)
+	dst := fmt.Sprintf("%s/test/crane/copy", u.Host)
+
+	// Load up the registry.
+	idx, err := random.Index(1024, 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := name.ParseReference(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(ref, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that the copied index is the same as the source.
+	if err := crane.Copy(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := crane.Digest(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp, err := crane.Digest(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != cp {
+		t.Errorf("Copied Digest(): %v != %v", d, cp)
+	}
+}
+
+func TestCraneTarball(t *testing.T) {
+	t.Parallel()
+	// Write an image as a tarball.
+	tmp, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := fmt.Sprintf("test/crane@%s", digest)
+
+	if err := crane.Save(img, src, tmp.Name()); err != nil {
+		t.Errorf("Save: %v", err)
+	}
+
+	// Make sure the image we load has a matching digest.
+	img, err = crane.Load(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != digest {
+		t.Errorf("digest mismatch: %v != %v", d, digest)
+	}
+}
+
+func TestCraneFilesystem(t *testing.T) {
+	t.Parallel()
+	tmp, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := "/some/file"
+	content := []byte("sentinel")
+
+	tw := tar.NewWriter(tmp)
+	if err := tw.WriteHeader(&tar.Header{
+		Size: int64(len(content)),
+		Name: name,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Flush()
+	tw.Close()
+
+	img, err = crane.Append(img, tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := crane.Export(img, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(&buf)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			t.Fatalf("didn't find find")
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if header.Name == name {
+			b, err := ioutil.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != string(content) {
+				t.Fatalf("got back wrong content: %v != %v", string(b), string(content))
+			}
+			break
+		}
+	}
+}
+
+func TestBadInputs(t *testing.T) {
+	t.Parallel()
+	invalid := "@@@@@@"
+
+	// Create a valid image reference that will fail with not found.
+	s := httptest.NewServer(http.NotFoundHandler())
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := fmt.Sprintf("%s/some/image", u.Host)
+
+	for _, err := range []error{
+		crane.Push(nil, invalid),
+		crane.Delete(invalid),
+		crane.Delete(valid),
+		crane.Save(nil, invalid, ""),
+		crane.Copy(invalid, invalid),
+		crane.Copy(valid, invalid),
+		crane.Copy(valid, valid),
+		// These return multiple values, which are hard to use as expressions.
+		e(crane.Pull(invalid)),
+		e(crane.Digest(invalid)),
+		e(crane.Manifest(invalid)),
+		e(crane.Config(invalid)),
+		e(crane.Config(valid)),
+		e(crane.ListTags(invalid)),
+		e(crane.ListTags(valid)),
+		e(crane.Append(nil, invalid)),
+	} {
+		if err == nil {
+			t.Error("expected err, got nil")
+		}
+	}
+}
+
+// e drops the first parameter so we can use the result of a function
+// that returns two values as an expression above. This is a bit of a go quirk.
+func e(_ interface{}, err error) error {
+	return err
+}

--- a/pkg/name/digest_test.go
+++ b/pkg/name/digest_test.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"path"
 	"strings"
 	"testing"
 )
@@ -94,6 +95,7 @@ func TestDigestComponents(t *testing.T) {
 	t.Parallel()
 	testRegistry := "gcr.io"
 	testRepository := "project-id/image"
+	fullRepo := path.Join(testRegistry, testRepository)
 
 	digestNameStr := testRegistry + "/" + testRepository + "@" + validDigest
 	digest, err := NewDigest(digestNameStr, StrictValidation)
@@ -101,6 +103,12 @@ func TestDigestComponents(t *testing.T) {
 		t.Fatalf("`%s` should be a valid Digest name, got error: %v", digestNameStr, err)
 	}
 
+	if got := digest.String(); got != digestNameStr {
+		t.Errorf("String() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, digestNameStr, got)
+	}
+	if got := digest.Identifier(); got != validDigest {
+		t.Errorf("Identifier() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, validDigest, got)
+	}
 	actualRegistry := digest.RegistryStr()
 	if actualRegistry != testRegistry {
 		t.Errorf("RegistryStr() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, testRegistry, actualRegistry)
@@ -108,6 +116,10 @@ func TestDigestComponents(t *testing.T) {
 	actualRepository := digest.RepositoryStr()
 	if actualRepository != testRepository {
 		t.Errorf("RepositoryStr() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, testRepository, actualRepository)
+	}
+	contextRepo := digest.Context().String()
+	if contextRepo != fullRepo {
+		t.Errorf("Context().String() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, fullRepo, contextRepo)
 	}
 	actualDigest := digest.DigestStr()
 	if actualDigest != validDigest {

--- a/pkg/name/errors_test.go
+++ b/pkg/name/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2019 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package name
 
 import (
-	"io"
-
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"testing"
 )
 
-// Export writes the filesystem contents (as a tarball) of img to w.
-func Export(img v1.Image, w io.Writer) error {
-	fs := mutate.Extract(img)
-	_, err := io.Copy(w, fs)
-	return err
+func TestBadName(t *testing.T) {
+	_, err := ParseReference("@@")
+	if !IsErrBadName(err) {
+		t.Errorf("IsBadErrName == false: %v", err)
+	}
+	if err.Error() != "could not parse reference" {
+		t.Errorf("Unexpected string: %v", err)
+	}
 }

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -15,7 +15,6 @@
 package name
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -46,5 +45,5 @@ func ParseReference(s string, opts ...Option) (Reference, error) {
 		return d, nil
 	}
 	// TODO: Combine above errors into something more useful?
-	return nil, errors.New("could not parse reference")
+	return nil, NewErrBadName("could not parse reference")
 }

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -43,8 +43,13 @@ func TestNewRegistryStrictValidation(t *testing.T) {
 	for _, name := range goodStrictValidationRegistryNames {
 		if registry, err := NewRegistry(name, StrictValidation); err != nil {
 			t.Errorf("`%s` should be a valid Registry name, got error: %v", name, err)
-		} else if registry.Name() != name {
-			t.Errorf("`%v` .Name() should reproduce the original name. Wanted: %s Got: %s", registry, name, registry.Name())
+		} else {
+			if registry.Name() != name {
+				t.Errorf("`%v` .Name() should reproduce the original name. Wanted: %s Got: %s", registry, name, registry.Name())
+			}
+			if registry.String() != name {
+				t.Errorf("`%v` .String() should reproduce the original name. Wanted: %s Got: %s", registry, name, registry.String())
+			}
 		}
 	}
 

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -50,6 +50,7 @@ func (r Repository) Name() string {
 	if regName != "" {
 		return regName + regRepoDelimiter + r.RepositoryStr()
 	}
+	// TODO: As far as I can tell, this is unreachable.
 	return r.RepositoryStr()
 }
 

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -37,6 +37,7 @@ var goodWeakValidationRepositoryNames = []string{
 var badRepositoryNames = []string{
 	"white space",
 	"b@char/image",
+	"",
 }
 
 func TestNewRepositoryStrictValidation(t *testing.T) {
@@ -111,5 +112,11 @@ func TestRepositoryScopes(t *testing.T) {
 	actualScope := repository.Scope(testAction)
 	if actualScope != expectedScope {
 		t.Errorf("scope was incorrect for %v. Wanted: `%s` Got: `%s`", repository, expectedScope, actualScope)
+	}
+}
+
+func TestRepositoryBadDefaulting(t *testing.T) {
+	if _, err := NewRepository("index.docker.io/foo", StrictValidation); !IsErrBadName(err) {
+		t.Errorf("IsBadErrName == false: %v", err)
 	}
 }

--- a/pkg/name/tag_test.go
+++ b/pkg/name/tag_test.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"path"
 	"strings"
 	"testing"
 )
@@ -80,6 +81,7 @@ func TestTagComponents(t *testing.T) {
 	testRegistry := "gcr.io"
 	testRepository := "project-id/image"
 	testTag := "latest"
+	fullRepo := path.Join(testRegistry, testRepository)
 
 	tagNameStr := testRegistry + "/" + testRepository + ":" + testTag
 	tag, err := NewTag(tagNameStr, StrictValidation)
@@ -98,6 +100,15 @@ func TestTagComponents(t *testing.T) {
 	actualTag := tag.TagStr()
 	if actualTag != testTag {
 		t.Errorf("TagStr() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, testTag, actualTag)
+	}
+	if got, want := tag.Context().String(), fullRepo; got != want {
+		t.Errorf("Context.String() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, want, got)
+	}
+	if got, want := tag.Identifier(), testTag; got != want {
+		t.Errorf("Identifier() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, want, got)
+	}
+	if got, want := tag.String(), tagNameStr; got != want {
+		t.Errorf("String() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, want, got)
 	}
 }
 

--- a/pkg/v1/cache/cache_test.go
+++ b/pkg/v1/cache/cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 // TestCache tests that the cache is populated when LayerByDigest is called.
@@ -29,6 +30,23 @@ func TestCache(t *testing.T) {
 	}
 	if got, want := len(m.m), numLayers; got != want {
 		t.Errorf("Cache has %d entries, want %d", got, want)
+	}
+}
+
+func TestImage(t *testing.T) {
+	img, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	m := &memcache{map[v1.Hash]v1.Layer{}}
+	img = Image(img, m)
+
+	// Validate twice to hit the cache.
+	if err := validate.Image(img); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Errorf("Validate: %v", err)
 	}
 }
 

--- a/pkg/v1/config_test.go
+++ b/pkg/v1/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2019 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+package v1
 
 import (
-	"io"
+	"strings"
+	"testing"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-cmp/cmp"
 )
 
-// Export writes the filesystem contents (as a tarball) of img to w.
-func Export(img v1.Image, w io.Writer) error {
-	fs := mutate.Extract(img)
-	_, err := io.Copy(w, fs)
-	return err
+func TestParseConfig(t *testing.T) {
+	got, err := ParseConfigFile(strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ConfigFile{}
+
+	if diff := cmp.Diff(want, *got); diff != "" {
+		t.Errorf("ParseConfigFile({}); (-want +got) %s", diff)
+	}
+
+	if got, err := ParseConfigFile(strings.NewReader("{")); err == nil {
+		t.Errorf("expected error, got: %v", got)
+	}
 }

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -50,9 +50,9 @@ func TestWriteImage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error loading image: %v", err.Error())
 	}
-	tag, err := name.NewTag("test_image_2:latest", name.WeakValidation)
+	tag, err := name.NewTag("test_image_2:latest")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatal(err)
 	}
 	response, err := Write(tag, image)
 	if err != nil {
@@ -60,5 +60,13 @@ func TestWriteImage(t *testing.T) {
 	}
 	if !strings.Contains(response, "Loaded") {
 		t.Errorf("Error loading image. Response: %s", response)
+	}
+
+	dst, err := name.NewTag("hello:world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Tag(tag, dst); err != nil {
+		t.Errorf("Error tagging image: %v", err)
 	}
 }

--- a/pkg/v1/empty/image_test.go
+++ b/pkg/v1/empty/image_test.go
@@ -16,7 +16,15 @@ package empty
 
 import (
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
+
+func TestImage(t *testing.T) {
+	if err := validate.Image(Image); err != nil {
+		t.Fatalf("validate.Image(empty.Image) = %v", err)
+	}
+}
 
 func TestManifestAndConfig(t *testing.T) {
 	manifest, err := Image.Manifest()

--- a/pkg/v1/empty/index.go
+++ b/pkg/v1/empty/index.go
@@ -37,17 +37,11 @@ func (i emptyIndex) Digest() (v1.Hash, error) {
 }
 
 func (i emptyIndex) IndexManifest() (*v1.IndexManifest, error) {
-	return &v1.IndexManifest{
-		SchemaVersion: 2,
-	}, nil
+	return base(), nil
 }
 
 func (i emptyIndex) RawManifest() ([]byte, error) {
-	im, err := i.IndexManifest()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(im)
+	return json.Marshal(base())
 }
 
 func (i emptyIndex) Image(v1.Hash) (v1.Image, error) {
@@ -56,4 +50,10 @@ func (i emptyIndex) Image(v1.Hash) (v1.Image, error) {
 
 func (i emptyIndex) ImageIndex(v1.Hash) (v1.ImageIndex, error) {
 	return nil, errors.New("empty index")
+}
+
+func base() *v1.IndexManifest {
+	return &v1.IndexManifest{
+		SchemaVersion: 2,
+	}
 }

--- a/pkg/v1/empty/index_test.go
+++ b/pkg/v1/empty/index_test.go
@@ -17,11 +17,24 @@ package empty
 import (
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 func TestIndex(t *testing.T) {
 	if err := validate.Index(Index); err != nil {
 		t.Fatalf("validate.Index(empty.Index) = %v", err)
+	}
+
+	if mt, err := Index.MediaType(); err != nil || mt != types.OCIImageIndex {
+		t.Errorf("empty.Index.MediaType() = %v, %v", mt, err)
+	}
+
+	if _, err := Index.Image(v1.Hash{}); err == nil {
+		t.Errorf("empty.Index.Image() should always fail")
+	}
+	if _, err := Index.ImageIndex(v1.Hash{}); err == nil {
+		t.Errorf("empty.Index.ImageIndex() should always fail")
 	}
 }

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -105,7 +106,7 @@ func TestList(t *testing.T) {
 				t.Fatalf("name.NewRepository(%v) = %v", repoName, err)
 			}
 
-			tags, err := List(repo)
+			tags, err := List(repo, WithAuthFromKeychain(authn.DefaultKeychain), WithTransport(http.DefaultTransport))
 			if (err != nil) != tc.wantErr {
 				t.Errorf("List() wrong error: %v, want %v: %v\n", (err != nil), tc.wantErr, err)
 			}
@@ -203,7 +204,7 @@ func TestWalk(t *testing.T) {
 			}
 
 			r := recorder{}
-			err = Walk(repo, r.walk)
+			err = Walk(repo, r.walk, WithAuth(authn.Anonymous))
 
 			if diff := cmp.Diff(tc.wantResult, r); diff != "" {
 				t.Errorf("Walk() wrong tags (-want +got) = %s", diff)

--- a/pkg/v1/manifest_test.go
+++ b/pkg/v1/manifest_test.go
@@ -58,3 +58,19 @@ func TestManifestWithBadHash(t *testing.T) {
 		t.Errorf("Expected error parsing manifest, but got: %v", bad)
 	}
 }
+
+func TestParseIndexManifest(t *testing.T) {
+	got, err := ParseIndexManifest(strings.NewReader(`{}`))
+	if err != nil {
+		t.Errorf("Unexpected error parsing manifest: %v", err)
+	}
+
+	want := IndexManifest{}
+	if diff := cmp.Diff(want, *got); diff != "" {
+		t.Errorf("ParseIndexManifest({}); (-want +got) %s", diff)
+	}
+
+	if got, err := ParseIndexManifest(strings.NewReader("{")); err == nil {
+		t.Errorf("expected error, got: %v", got)
+	}
+}

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -439,7 +439,6 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 
 	layers, err := img.Layers()
 	if err != nil {
-
 		return nil, fmt.Errorf("Error getting image layers: %v", err)
 	}
 
@@ -522,12 +521,7 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 	b := w.Bytes()
 	// gzip the contents, then create the layer
 	opener := func() (io.ReadCloser, error) {
-		g, err := v1util.GzipReadCloser(ioutil.NopCloser(bytes.NewReader(b)))
-		if err != nil {
-			return nil, fmt.Errorf("Error compressing layer: %v", err)
-		}
-
-		return g, nil
+		return v1util.GzipReadCloser(ioutil.NopCloser(bytes.NewReader(b))), nil
 	}
 	layer, err = tarball.LayerFromOpener(opener)
 	if err != nil {

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -374,7 +374,35 @@ func TestAppendStreamableLayer(t *testing.T) {
 	if h.String() != wantDigest {
 		t.Errorf("Image digest got %q, want %q", h, wantDigest)
 	}
+}
 
+func TestCanonical(t *testing.T) {
+	source := sourceImage(t)
+	img, err := Canonical(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, s := range []string{
+		cf.Container,
+		cf.Config.Hostname,
+		cf.ContainerConfig.Hostname,
+		cf.DockerVersion,
+	} {
+		if s != "" {
+			t.Errorf("non-zeroed string: %v", s)
+		}
+	}
+
+	expectedLayerTime := time.Unix(0, 0)
+	layers := getLayers(t, img)
+	for _, layer := range layers {
+		assertMTime(t, layer, expectedLayerTime)
+	}
 }
 
 func assertMTime(t *testing.T, layer v1.Layer, expectedTime time.Time) {

--- a/pkg/v1/partial/compressed_test.go
+++ b/pkg/v1/partial/compressed_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partial_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
+)
+
+// Remote leverages a lot of compressed partials.
+func TestRemote(t *testing.T) {
+	rnd, err := random.Image(1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := registry.TLS("gcr.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := s.Client().Transport
+
+	src := "gcr.io/test/compressed"
+	ref, err := name.ParseReference(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(ref, rnd, remote.WithTransport(tr)); err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := remote.Image(ref, remote.WithTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Fatal(err)
+	}
+
+	cf, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := img.Manifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	layer, err := img.LayerByDiffID(cf.RootFS.DiffIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := layer.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(d, m.Layers[0].Digest); diff != "" {
+		t.Errorf("mismatched digest: %v", diff)
+	}
+}

--- a/pkg/v1/partial/configlayer_test.go
+++ b/pkg/v1/partial/configlayer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 type testUIC struct {
@@ -56,14 +57,22 @@ func TestConfigLayer(t *testing.T) {
 
 		layer, err := ConfigLayer(image)
 		if err != nil {
-			t.Errorf("ConfigLayer: %v", err)
+			t.Fatalf("ConfigLayer: %v", err)
 		}
 		lr, err := layer.Uncompressed()
 		if err != nil {
 			t.Fatalf("Error getting uncompressed layer: %v", err)
 		}
+		zr, err := layer.Compressed()
+		if err != nil {
+			t.Fatalf("Error getting compressed layer: %v", err)
+		}
 
 		cfgLayerBytes, err := ioutil.ReadAll(lr)
+		if err != nil {
+			t.Fatalf("Error reading config layer bytes: %v", err)
+		}
+		zcfgLayerBytes, err := ioutil.ReadAll(zr)
 		if err != nil {
 			t.Fatalf("Error reading config layer bytes: %v", err)
 		}
@@ -75,6 +84,42 @@ func TestConfigLayer(t *testing.T) {
 
 		if string(cfgFile) != string(cfgLayerBytes) {
 			t.Errorf("Config file layer doesn't match raw config file")
+		}
+		if string(cfgFile) != string(zcfgLayerBytes) {
+			t.Errorf("Config file layer doesn't match raw config file")
+		}
+
+		size, err := layer.Size()
+		if err != nil {
+			t.Fatalf("Error getting config layer size: %v", err)
+		}
+		if size != int64(len(cfgFile)) {
+			t.Errorf("Size() = %d, want %d", size, len(cfgFile))
+		}
+
+		digest, err := layer.Digest()
+		if err != nil {
+			t.Fatalf("Digest() = %v", err)
+		}
+		if digest != hash {
+			t.Errorf("ConfigLayer().Digest() != ConfigName(); %v, %v", digest, hash)
+		}
+
+		diffid, err := layer.DiffID()
+		if err != nil {
+			t.Fatalf("DiffId() = %v", err)
+		}
+		if diffid != hash {
+			t.Errorf("ConfigLayer().DiffID() != ConfigName(); %v, %v", diffid, hash)
+		}
+
+		mt, err := layer.MediaType()
+		if err != nil {
+			t.Fatalf("Error getting config layer media type: %v", err)
+		}
+
+		if mt != types.OCIConfigJSON {
+			t.Errorf("MediaType() = %v, want %v", mt, types.OCIConfigJSON)
 		}
 	}
 }

--- a/pkg/v1/partial/uncompressed.go
+++ b/pkg/v1/partial/uncompressed.go
@@ -54,7 +54,7 @@ func (ule *uncompressedLayerExtender) Compressed() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v1util.GzipReadCloser(u)
+	return v1util.GzipReadCloser(u), nil
 }
 
 // Digest implements v1.Layer

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/google/go-containerregistry/pkg/v1/v1util"
 )
 
 // WithRawConfigFile defines the subset of v1.Image used by these helper methods
@@ -134,15 +133,6 @@ func RawConfigFile(i WithConfigFile) ([]byte, error) {
 type WithUncompressedLayer interface {
 	// UncompressedLayer is like UncompressedBlob, but takes the "diff id".
 	UncompressedLayer(v1.Hash) (io.ReadCloser, error)
-}
-
-// Layer is the same as Blob, but takes the "diff id".
-func Layer(wul WithUncompressedLayer, h v1.Hash) (io.ReadCloser, error) {
-	rc, err := wul.UncompressedLayer(h)
-	if err != nil {
-		return nil, err
-	}
-	return v1util.GzipReadCloser(rc)
 }
 
 // WithRawManifest defines the subset of v1.Image used by these helper methods
@@ -262,22 +252,6 @@ func DiffIDToBlob(wm WithManifestAndConfigFile, h v1.Hash) (v1.Hash, error) {
 		}
 	}
 	return v1.Hash{}, fmt.Errorf("unknown diffID %v", h)
-
-}
-
-// WithBlob defines the subset of v1.Image used by these helper methods
-type WithBlob interface {
-	// Blob returns a ReadCloser for streaming the blob's content.
-	Blob(v1.Hash) (io.ReadCloser, error)
-}
-
-// UncompressedBlob returns a ReadCloser for streaming the blob's content uncompressed.
-func UncompressedBlob(b WithBlob, h v1.Hash) (io.ReadCloser, error) {
-	rc, err := b.Blob(h)
-	if err != nil {
-		return nil, err
-	}
-	return v1util.GunzipReadCloser(rc)
 }
 
 // WithDiffID defines the subset of v1.Layer for exposing the DiffID method.

--- a/pkg/v1/partial/with_test.go
+++ b/pkg/v1/partial/with_test.go
@@ -1,0 +1,174 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partial_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func TestRawConfigFile(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	part, err := partial.RawConfigFile(img)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	method, err := img.RawConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(part) != string(method) {
+		t.Errorf("mismatched config file: %s vs %s", part, method)
+	}
+}
+
+func TestDigest(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	part, err := partial.Digest(img)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	method, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if part != method {
+		t.Errorf("mismatched digest: %s vs %s", part, method)
+	}
+}
+
+func TestManifest(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	part, err := partial.Manifest(img)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	method, err := img.Manifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(part, method); diff != "" {
+		t.Errorf("mismatched manifest: %v", diff)
+	}
+}
+
+func TestDiffIDToBlob(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := layers[0].Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := partial.DiffIDToBlob(img, cf.RootFS.DiffIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("mismatched digest: %v", diff)
+	}
+
+	if _, err := partial.DiffIDToBlob(img, want); err == nil {
+		t.Errorf("expected err, got nil")
+	}
+}
+
+func TestBlobToDiffID(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := layers[0].Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := cf.RootFS.DiffIDs[0]
+	got, err := partial.BlobToDiffID(img, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("mismatched digest: %v", diff)
+	}
+
+	if _, err := partial.BlobToDiffID(img, want); err == nil {
+		t.Errorf("expected err, got nil")
+	}
+}
+
+func TestBlobSize(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := img.Manifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := m.Layers[0].Size
+	got, err := partial.BlobSize(img, m.Layers[0].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("mismatched blob size: %v", diff)
+	}
+
+	if _, err := partial.BlobSize(img, v1.Hash{}); err == nil {
+		t.Errorf("expected err, got nil")
+	}
+}

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -329,7 +330,7 @@ func TestImage(t *testing.T) {
 	}
 
 	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
-	rmt, err := Image(tag, WithTransport(http.DefaultTransport))
+	rmt, err := Image(tag, WithTransport(http.DefaultTransport), WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		t.Errorf("Image() = %v", err)
 	}

--- a/pkg/v1/tarball/image_test.go
+++ b/pkg/v1/tarball/image_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 func TestManifestAndConfig(t *testing.T) {
@@ -39,6 +40,10 @@ func TestManifestAndConfig(t *testing.T) {
 	}
 	if len(config.History) != 1 {
 		t.Fatalf("history length should be 1, got %d", len(config.History))
+	}
+
+	if err := validate.Image(img); err != nil {
+		t.Errorf("Validate() = %v", err)
 	}
 }
 
@@ -75,6 +80,10 @@ func TestBundleMultiple(t *testing.T) {
 			}
 			if _, err := img.Manifest(); err != nil {
 				t.Fatalf("Unexpected error loading manifest: %v", err)
+			}
+
+			if err := validate.Image(img); err != nil {
+				t.Errorf("Validate() = %v", err)
 			}
 		})
 	}

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -45,7 +45,7 @@ func (l *layer) DiffID() (v1.Hash, error) {
 func (l *layer) Compressed() (io.ReadCloser, error) {
 	rc, err := l.opener()
 	if err == nil && !l.compressed {
-		return v1util.GzipReadCloser(rc)
+		return v1util.GzipReadCloser(rc), nil
 	}
 
 	return rc, err
@@ -132,12 +132,7 @@ func computeDigest(opener Opener, compressed bool) (v1.Hash, int64, error) {
 		return v1.SHA256(rc)
 	}
 
-	reader, err := v1util.GzipReadCloser(ioutil.NopCloser(rc))
-	if err != nil {
-		return v1.Hash{}, 0, err
-	}
-
-	return v1.SHA256(reader)
+	return v1.SHA256(v1util.GzipReadCloser(ioutil.NopCloser(rc)))
 }
 
 func computeDiffID(opener Opener, compressed bool) (v1.Hash, error) {

--- a/pkg/v1/tarball/layer_test.go
+++ b/pkg/v1/tarball/layer_test.go
@@ -45,6 +45,7 @@ func TestLayerFromFile(t *testing.T) {
 	assertCompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertUncompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertSizesAreEqual(t, tarLayer, tarGzLayer)
+	assertMediaTypesAreEqual(t, tarLayer, tarGzLayer)
 }
 
 func TestLayerFromOpenerReader(t *testing.T) {
@@ -80,6 +81,7 @@ func TestLayerFromOpenerReader(t *testing.T) {
 	assertCompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertUncompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertSizesAreEqual(t, tarLayer, tarGzLayer)
+	assertMediaTypesAreEqual(t, tarLayer, tarGzLayer)
 }
 
 func TestLayerFromReader(t *testing.T) {
@@ -109,6 +111,7 @@ func TestLayerFromReader(t *testing.T) {
 	assertCompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertUncompressedStreamsAreEqual(t, tarLayer, tarGzLayer)
 	assertSizesAreEqual(t, tarLayer, tarGzLayer)
+	assertMediaTypesAreEqual(t, tarLayer, tarGzLayer)
 }
 
 func assertDigestsAreEqual(t *testing.T, a, b v1.Layer) {
@@ -200,6 +203,24 @@ func assertUncompressedStreamsAreEqual(t *testing.T, a, b v1.Layer) {
 
 	if diff := cmp.Diff(saBytes, sbBytes); diff != "" {
 		t.Fatalf("Uncompressed streams were different: %v", diff)
+	}
+}
+
+func assertMediaTypesAreEqual(t *testing.T, a, b v1.Layer) {
+	t.Helper()
+
+	ma, err := a.MediaType()
+	if err != nil {
+		t.Fatalf("Unable to fetch MediaType for layer: %v", err)
+	}
+
+	mb, err := b.MediaType()
+	if err != nil {
+		t.Fatalf("Unable to fetch MediaType for layer: %v", err)
+	}
+
+	if ma != mb {
+		t.Fatalf("MediaType of each layer is different - %s != %s", ma, mb)
 	}
 }
 

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -26,6 +26,12 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+var (
+	// Keeping this around to avoid breaking callers.
+	MultiRefWriteToFile = MultiWriteToFile
+	MultiRefWrite       = MultiWrite
+)
+
 // WriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.Write with a new file.
 func WriteToFile(p string, ref name.Reference, img v1.Image) error {
@@ -39,30 +45,19 @@ func WriteToFile(p string, ref name.Reference, img v1.Image) error {
 }
 
 // MultiWriteToFile writes in the compressed format to a tarball, on disk.
-// This is just syntactic sugar wrapping tarball.MultiWrite with a new file.
-func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image) error {
-	var refToImage map[name.Reference]v1.Image = make(map[name.Reference]v1.Image, len(tagToImage))
-	for i, d := range tagToImage {
-		refToImage[i] = d
-	}
-	return MultiRefWriteToFile(p, refToImage)
-}
-
-// MultiRefWriteToFile writes in the compressed format to a tarball, on disk.
-// This is just syntactic sugar wrapping tarball.MultiRefWrite with a new file.
-func MultiRefWriteToFile(p string, refToImage map[name.Reference]v1.Image) error {
+func MultiWriteToFile(p string, refToImage map[name.Reference]v1.Image) error {
 	w, err := os.Create(p)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 
-	return MultiRefWrite(refToImage, w)
+	return MultiWrite(refToImage, w)
 }
 
-// Write is a wrapper to write a single image and tag to a tarball.
+// Write is a wrapper to write a single image and reference to a tarball.
 func Write(ref name.Reference, img v1.Image, w io.Writer) error {
-	return MultiRefWrite(map[name.Reference]v1.Image{ref: img}, w)
+	return MultiWrite(map[name.Reference]v1.Image{ref: img}, w)
 }
 
 // MultiWrite writes the contents of each image to the provided reader, in the compressed format.
@@ -70,20 +65,7 @@ func Write(ref name.Reference, img v1.Image, w io.Writer) error {
 // One manifest.json file at the top level containing information about several images.
 // One file for each layer, named after the layer's SHA.
 // One file for the config blob, named after its SHA.
-func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
-	var refToImage map[name.Reference]v1.Image = make(map[name.Reference]v1.Image, len(tagToImage))
-	for i, d := range tagToImage {
-		refToImage[i] = d
-	}
-	return MultiRefWrite(refToImage, w)
-}
-
-// MultiRefWrite writes the contents of each image to the provided reader, in the compressed format.
-// The contents are written in the following format:
-// One manifest.json file at the top level containing information about several images.
-// One file for each layer, named after the layer's SHA.
-// One file for the config blob, named after its SHA.
-func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
+func MultiWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 	tf := tar.NewWriter(w)
 	defer tf.Close()
 

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -119,7 +119,7 @@ func TestMultiWriteSameImage(t *testing.T) {
 	refToImage[dig3] = randImage
 
 	// Write the images with both tags to the tarball
-	if err := MultiRefWriteToFile(fp.Name(), refToImage); err != nil {
+	if err := MultiWriteToFile(fp.Name(), refToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for ref := range refToImage {
@@ -198,7 +198,7 @@ func TestMultiWriteDifferentImages(t *testing.T) {
 	refToImage[dig3] = randImage3
 
 	// Write both images to the tarball.
-	if err := MultiRefWriteToFile(fp.Name(), refToImage); err != nil {
+	if err := MultiWriteToFile(fp.Name(), refToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for ref, img := range refToImage {

--- a/pkg/v1/v1util/verify_test.go
+++ b/pkg/v1/v1util/verify_test.go
@@ -56,3 +56,14 @@ func TestVerification(t *testing.T) {
 		t.Errorf("ReadAll() = %v", err)
 	}
 }
+
+func TestBadHash(t *testing.T) {
+	h := v1.Hash{
+		Algorithm: "fake256",
+		Hex:       "whatever",
+	}
+	_, err := VerifyReadCloser(ioutil.NopCloser(strings.NewReader("hi")), h)
+	if err == nil {
+		t.Errorf("VerifyReadCloser() = %v, wanted err", err)
+	}
+}

--- a/pkg/v1/v1util/zip_test.go
+++ b/pkg/v1/v1util/zip_test.go
@@ -16,17 +16,16 @@ package v1util
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
 func TestReader(t *testing.T) {
 	want := "This is the input string."
 	buf := bytes.NewBufferString(want)
-	zipped, err := GzipReadCloser(ioutil.NopCloser(buf))
-	if err != nil {
-		t.Errorf("GzipReadCloser() = %v", err)
-	}
+	zipped := GzipReadCloser(ioutil.NopCloser(buf))
 	unzipped, err := GunzipReadCloser(zipped)
 	if err != nil {
 		t.Errorf("GunzipReadCloser() = %v", err)
@@ -38,6 +37,9 @@ func TestReader(t *testing.T) {
 	}
 	if got := string(b); got != want {
 		t.Errorf("ReadAll(); got %q, want %q", got, want)
+	}
+	if err := unzipped.Close(); err != nil {
+		t.Errorf("Close() = %v", err)
 	}
 }
 
@@ -60,5 +62,37 @@ func TestIsGzipped(t *testing.T) {
 		if err != test.err {
 			t.Errorf("IsGzipped; err: got %v, wanted %v\n", err, test.err)
 		}
+	}
+}
+
+var (
+	readErr = fmt.Errorf("Read failed")
+)
+
+type failReader struct{}
+
+func (f failReader) Read(_ []byte) (int, error) {
+	return 0, readErr
+}
+
+func TestReadErrors(t *testing.T) {
+	fr := failReader{}
+	if _, err := IsGzipped(fr); err != readErr {
+		t.Errorf("IsGzipped: expected readErr, got %v", err)
+	}
+
+	frc := ioutil.NopCloser(fr)
+	if _, err := GunzipReadCloser(frc); err != readErr {
+		t.Errorf("GunzipReadCloser: expected readErr, got %v", err)
+	}
+
+	zr := GzipReadCloser(ioutil.NopCloser(fr))
+	if _, err := zr.Read(nil); err != readErr {
+		t.Errorf("GzipReadCloser: expected readErr, got %v", err)
+	}
+
+	zr = GzipReadCloserLevel(ioutil.NopCloser(strings.NewReader("zip me")), -10)
+	if _, err := zr.Read(nil); err == nil {
+		t.Errorf("Expected invalid level error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Add test coverage for any low hanging fruit.
Add some more validation to pkg/v1/validate.
Add .codecov.yml to ignore generated files.

Real fixes this exposed:

* Drop unused method in partial.
* Make crane.Export take a Writer instead of WriteCloser.
* Fix log.Fatal instead of returning err in pkg/crane.
* Fix some invalid error messages in pkg/crane.
* Make GzipReadCloserLevel not return an error.
* Fix dropped pipe errors (https://golang.org/issue/24283).
* Make ParseReference return an ErrBadName.
* Remove redundant tarball.Write functions.