### PR TITLE
Use a trimmed-down copy of `wait.go` to avoid large k8s.io dependency.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -770,7 +770,6 @@
     "golang.org/x/sync/errgroup",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/rest",

--- a/pkg/internal/retry/retry.go
+++ b/pkg/internal/retry/retry.go
@@ -19,8 +19,10 @@ package retry
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/google/go-containerregistry/pkg/internal/retry/wait"
 )
+
+type Backoff = wait.Backoff
 
 // This is implemented by several errors in the net package as well as our
 // transport.Error.

--- a/pkg/internal/retry/retry_test.go
+++ b/pkg/internal/retry/retry_test.go
@@ -17,8 +17,6 @@ package retry
 import (
 	"fmt"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type temp struct{}
@@ -55,7 +53,7 @@ func TestRetry(t *testing.T) {
 	}} {
 		// Make sure we retry 5 times if we shouldRetry.
 		steps := 5
-		backoff := wait.Backoff{
+		backoff := Backoff{
 			Steps: steps,
 		}
 
@@ -78,10 +76,10 @@ func TestRetry(t *testing.T) {
 
 // Make sure we don't panic.
 func TestNil(t *testing.T) {
-	if err := Retry(nil, nil, wait.Backoff{}); err == nil {
+	if err := Retry(nil, nil, Backoff{}); err == nil {
 		t.Errorf("got nil when passing in nil f")
 	}
-	if err := Retry(func() error { return nil }, nil, wait.Backoff{}); err == nil {
+	if err := Retry(func() error { return nil }, nil, Backoff{}); err == nil {
 		t.Errorf("got nil when passing in nil p")
 	}
 }

--- a/pkg/internal/retry/wait/kubernetes_apimachinery_wait.go
+++ b/pkg/internal/retry/wait/kubernetes_apimachinery_wait.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+// Jitter returns a time.Duration between duration and duration + maxFactor *
+// duration.
+//
+// This allows clients to avoid converging on periodic behavior. If maxFactor
+// is 0.0, a suggested default value will be chosen.
+func Jitter(duration time.Duration, maxFactor float64) time.Duration {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
+	return wait
+}
+
+// ErrWaitTimeout is returned when the condition exited without success.
+var ErrWaitTimeout = errors.New("timed out waiting for the condition")
+
+// ConditionFunc returns true if the condition is satisfied, or an error
+// if the loop should be aborted.
+type ConditionFunc func() (done bool, err error)
+
+// Backoff holds parameters applied to a Backoff function.
+type Backoff struct {
+	// The initial duration.
+	Duration time.Duration
+	// Duration is multiplied by factor each iteration, if factor is not zero
+	// and the limits imposed by Steps and Cap have not been reached.
+	// Should not be negative.
+	// The jitter does not contribute to the updates to the duration parameter.
+	Factor float64
+	// The sleep at each iteration is the duration plus an additional
+	// amount chosen uniformly at random from the interval between
+	// zero and `jitter*duration`.
+	Jitter float64
+	// The remaining number of iterations in which the duration
+	// parameter may change (but progress can be stopped earlier by
+	// hitting the cap). If not positive, the duration is not
+	// changed. Used for exponential backoff in combination with
+	// Factor and Cap.
+	Steps int
+	// A limit on revised values of the duration parameter. If a
+	// multiplication by the factor parameter would make the duration
+	// exceed the cap then the duration is set to the cap and the
+	// steps parameter is set to zero.
+	Cap time.Duration
+}
+
+// Step (1) returns an amount of time to sleep determined by the
+// original Duration and Jitter and (2) mutates the provided Backoff
+// to update its Steps and Duration.
+func (b *Backoff) Step() time.Duration {
+	if b.Steps < 1 {
+		if b.Jitter > 0 {
+			return Jitter(b.Duration, b.Jitter)
+		}
+		return b.Duration
+	}
+	b.Steps--
+
+	duration := b.Duration
+
+	// calculate the next step
+	if b.Factor != 0 {
+		b.Duration = time.Duration(float64(b.Duration) * b.Factor)
+		if b.Cap > 0 && b.Duration > b.Cap {
+			b.Duration = b.Cap
+			b.Steps = 0
+		}
+	}
+
+	if b.Jitter > 0 {
+		duration = Jitter(duration, b.Jitter)
+	}
+	return duration
+}
+
+// ExponentialBackoff repeats a condition check with exponential backoff.
+//
+// It repeatedly checks the condition and then sleeps, using `backoff.Step()`
+// to determine the length of the sleep and adjust Duration and Steps.
+// Stops and returns as soon as:
+// 1. the condition check returns true or an error,
+// 2. `backoff.Steps` checks of the condition have been done, or
+// 3. a sleep truncated by the cap on duration has been completed.
+// In case (1) the returned error is what the condition function returned.
+// In all other cases, ErrWaitTimeout is returned.
+func ExponentialBackoff(backoff Backoff, condition ConditionFunc) error {
+	for backoff.Steps > 0 {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+		if backoff.Steps == 1 {
+			break
+		}
+		time.Sleep(backoff.Step())
+	}
+	return ErrWaitTimeout
+}

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -19,11 +19,10 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/internal/retry"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Sleep for 0.1, 0.3, 0.9, 2.7 seconds. This should cover networking blips.
-var defaultBackoff = wait.Backoff{
+var defaultBackoff = retry.Backoff{
 	Duration: 100 * time.Millisecond,
 	Factor:   3.0,
 	Jitter:   0.1,
@@ -35,7 +34,7 @@ var _ http.RoundTripper = (*retryTransport)(nil)
 // retryTransport wraps a RoundTripper and retries temporary network errors.
 type retryTransport struct {
 	inner     http.RoundTripper
-	backoff   wait.Backoff
+	backoff   retry.Backoff
 	predicate retry.Predicate
 }
 
@@ -43,12 +42,12 @@ type retryTransport struct {
 type Option func(*options)
 
 type options struct {
-	backoff   wait.Backoff
+	backoff   retry.Backoff
 	predicate retry.Predicate
 }
 
 // WithRetryBackoff sets the backoff for retry operations.
-func WithRetryBackoff(backoff wait.Backoff) Option {
+func WithRetryBackoff(backoff retry.Backoff) Option {
 	return func(o *options) {
 		o.backoff = backoff
 	}

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/internal/retry"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type mockTransport struct {
@@ -69,7 +68,7 @@ func TestRetryTransport(t *testing.T) {
 			errs: test.errs,
 		}
 
-		tr := NewRetry(&mt, WithRetryBackoff(wait.Backoff{Steps: 3}), WithRetryPredicate(retry.IsTemporary))
+		tr := NewRetry(&mt, WithRetryBackoff(retry.Backoff{Steps: 3}), WithRetryPredicate(retry.IsTemporary))
 
 		tr.RoundTrip(nil)
 		if mt.count != test.count {

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type manifest interface {
@@ -346,7 +345,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 	}
 
 	// Try this three times, waiting 1s after first failure, 3s after second.
-	backoff := wait.Backoff{
+	backoff := retry.Backoff{
 		Duration: 1.0 * time.Second,
 		Factor:   3.0,
 		Jitter:   0.1,


### PR DESCRIPTION
The core container pushing logic uses Kubernetes helper libraries to implement exponential backoff in the retry logic. This is a fairly small behavior but an enormous dependency, and it brings in transitive deps such as `k8s.io/klog` that conflict with other broadly used libraries (in our case, `github.com/golang/glog`).

This PR commits a trimmed-down version of `k8s.io/apimachinery/pkg/util/wait` as `github.com/google/go-containerregistry/pkg/internal/retry/wait`, containing only the code required to implement `wait.ExponentialBackoff()`.