### PR TITLE
Expand mutate.Addendum

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -40,8 +40,10 @@ const whiteoutPrefix = ".wh."
 // Addendum contains layers and history to be appended
 // to a base image
 type Addendum struct {
-	Layer   v1.Layer
-	History v1.History
+	Layer       v1.Layer
+	History     v1.History
+	URLs        []string
+	Annotations map[string]string
 }
 
 // AppendLayers applies layers to a base image
@@ -179,6 +181,9 @@ func (i *image) compute() error {
 		if d.MediaType, err = add.Layer.MediaType(); err != nil {
 			return err
 		}
+
+		d.Annotations = add.Annotations
+		d.URLs = add.URLs
 
 		manifestLayers = append(manifestLayers, d)
 		digestMap[d.Digest] = add.Layer

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -153,13 +153,19 @@ func TestNoopCondition(t *testing.T) {
 	}
 }
 
-func TestAppendWithHistory(t *testing.T) {
+func TestAppendWithAddendum(t *testing.T) {
 	source := sourceImage(t)
 
 	addendum := Addendum{
 		Layer: mockLayer{},
 		History: v1.History{
 			Author: "dave",
+		},
+		URLs: []string{
+			"example.com",
+		},
+		Annotations: map[string]string{
+			"foo": "bar",
 		},
 	}
 
@@ -182,6 +188,19 @@ func TestAppendWithHistory(t *testing.T) {
 
 	if diff := cmp.Diff(cf.History[1], addendum.History); diff != "" {
 		t.Fatalf("the appended history is not the same (-got, +want) %s", diff)
+	}
+
+	m, err := result.Manifest()
+	if err != nil {
+		t.Fatalf("failed to get manifest: %v", err)
+	}
+
+	if diff := cmp.Diff(m.Layers[1].URLs, addendum.URLs); diff != "" {
+		t.Fatalf("the appended URLs is not the same (-got, +want) %s", diff)
+	}
+
+	if diff := cmp.Diff(m.Layers[1].Annotations, addendum.Annotations); diff != "" {
+		t.Fatalf("the appended Annotations is not the same (-got, +want) %s", diff)
 	}
 }
 


### PR DESCRIPTION
Add URLs and Annotations to what you can append with mutate.Append.

This makes it possible to easily create images:
* with foreign layers and
* with annotations.

Progress towards https://github.com/google/go-containerregistry/issues/207