### PR TITLE
Invert empty's dependency on random

### DIFF
--- a/pkg/v1/mutate/rebase_test.go
+++ b/pkg/v1/mutate/rebase_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mutate
+package mutate_test
 
 import (
 	"testing"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
@@ -65,7 +66,7 @@ func TestRebase(t *testing.T) {
 		CreatedBy: "test",
 		Comment:   "this is a test",
 	}
-	orig, err := Append(oldBase, Addendum{
+	orig, err := mutate.Append(oldBase, mutate.Addendum{
 		Layer:   topLayers[0],
 		History: topHistory,
 	})
@@ -85,7 +86,7 @@ func TestRebase(t *testing.T) {
 	newBaseLayerDigests := layerDigests(t, newBase)
 
 	// Rebase original image onto new base.
-	rebased, err := Rebase(orig, oldBase, newBase)
+	rebased, err := mutate.Rebase(orig, oldBase, newBase)
 	if err != nil {
 		t.Fatalf("Rebase: %v", err)
 	}

--- a/pkg/v1/mutate/whiteout_test.go
+++ b/pkg/v1/mutate/whiteout_test.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"testing"
+)
+
+func TestWhiteoutDir(t *testing.T) {
+	fsMap := map[string]bool{
+		"baz":      true,
+		"red/blue": true,
+	}
+	var tests = []struct {
+		path     string
+		whiteout bool
+	}{
+		{"usr/bin", false},
+		{"baz/foo.txt", true},
+		{"baz/bar/foo.txt", true},
+		{"red/green", false},
+		{"red/yellow.txt", false},
+	}
+
+	for _, tt := range tests {
+		whiteout := inWhiteoutDir(fsMap, tt.path)
+		if whiteout != tt.whiteout {
+			t.Errorf("Whiteout %s: expected %v, but got %v", tt.path, tt.whiteout, whiteout)
+		}
+	}
+}

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tarball
+package tarball_test
 
 import (
 	"io/ioutil"
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 func TestWrite(t *testing.T) {
@@ -45,14 +46,14 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating test tag.")
 	}
-	if err := WriteToFile(fp.Name(), tag, randImage); err != nil {
+	if err := tarball.WriteToFile(fp.Name(), tag, randImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 
 	// Make sure the image is valid and can be loaded.
 	// Load it both by nil and by its name.
 	for _, it := range []*name.Tag{nil, &tag} {
-		tarImage, err := ImageFromPath(fp.Name(), it)
+		tarImage, err := tarball.ImageFromPath(fp.Name(), it)
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}
@@ -79,7 +80,7 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error generating tag: %v", err)
 	}
-	if _, err := ImageFromPath(fp.Name(), &fakeTag); err == nil {
+	if _, err := tarball.ImageFromPath(fp.Name(), &fakeTag); err == nil {
 		t.Errorf("Expected error loading tag %v from image", fakeTag)
 	}
 }
@@ -119,7 +120,7 @@ func TestMultiWriteSameImage(t *testing.T) {
 	refToImage[dig3] = randImage
 
 	// Write the images with both tags to the tarball
-	if err := MultiWriteToFile(fp.Name(), refToImage); err != nil {
+	if err := tarball.MultiWriteToFile(fp.Name(), refToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for ref := range refToImage {
@@ -128,7 +129,7 @@ func TestMultiWriteSameImage(t *testing.T) {
 			continue
 		}
 
-		tarImage, err := ImageFromPath(fp.Name(), &tag)
+		tarImage, err := tarball.ImageFromPath(fp.Name(), &tag)
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}
@@ -198,7 +199,7 @@ func TestMultiWriteDifferentImages(t *testing.T) {
 	refToImage[dig3] = randImage3
 
 	// Write both images to the tarball.
-	if err := MultiWriteToFile(fp.Name(), refToImage); err != nil {
+	if err := tarball.MultiWriteToFile(fp.Name(), refToImage); err != nil {
 		t.Fatalf("Unexpected error writing tarball: %v", err)
 	}
 	for ref, img := range refToImage {
@@ -207,7 +208,7 @@ func TestMultiWriteDifferentImages(t *testing.T) {
 			continue
 		}
 
-		tarImage, err := ImageFromPath(fp.Name(), &tag)
+		tarImage, err := tarball.ImageFromPath(fp.Name(), &tag)
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}


### PR DESCRIPTION
This inverts the dependency between empty.Image and random.Image.

Previously, empty.Image was implemented as `random.Image(0, 0)`, which is cute, but ended up duplicating things we didn't need. Instead, `random.Image` is implemented by appending `random.Layers`s to an `empty.Image`, which dramatically simplifies the implementation of `random.Image`.

In order to make that work, I needed to shuffle around some tests to avoid import cycles.

I also dropped a ton of test code that was duplicating what `validate.Image` does.