### PR TITLE
Implement foreign layer support

### DIFF
--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -62,6 +62,18 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	return h.parse(s)
 }
 
+// MarshalText implements encoding.TextMarshaler. This is required to use
+// v1.Hash as a key in a map when marshalling JSON.
+func (h Hash) MarshalText() (text []byte, err error) {
+	return []byte(h.String()), nil
+}
+
+// MarshalText implements encoding.TextUnmarshaler. This is required to use
+// v1.Hash as a key in a map when unmarshalling JSON.
+func (h *Hash) UnmarshalText(text []byte) error {
+	return h.parse(string(text))
+}
+
 // Hasher returns a hash.Hash for the named algorithm (e.g. "sha256")
 func Hasher(name string) (hash.Hash, error) {
 	switch name {

--- a/pkg/v1/hash_test.go
+++ b/pkg/v1/hash_test.go
@@ -83,3 +83,28 @@ func TestSHA256(t *testing.T) {
 		t.Errorf("n; got %v, want %v", got, want)
 	}
 }
+
+// This tests that you can use Hash as a key in a map (needs to implement both
+// MarshalText and UnmarshalText).
+func TestTextMarshalling(t *testing.T) {
+	foo := make(map[Hash]string)
+	b, err := json.Marshal(foo)
+	if err != nil {
+		t.Fatalf("could not marshal: %v", err)
+	}
+	if err := json.Unmarshal(b, &foo); err != nil {
+		t.Errorf("could not unmarshal: %v", err)
+	}
+
+	h := &Hash{
+		Algorithm: "sha256",
+		Hex:       strings.Repeat("a", 64),
+	}
+	text, err := h.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.UnmarshalText(text); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/v1/hash_test.go
+++ b/pkg/v1/hash_test.go
@@ -100,11 +100,16 @@ func TestTextMarshalling(t *testing.T) {
 		Algorithm: "sha256",
 		Hex:       strings.Repeat("a", 64),
 	}
+	g := &Hash{}
 	text, err := h.MarshalText()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := h.UnmarshalText(text); err != nil {
+	if err := g.UnmarshalText(text); err != nil {
 		t.Fatal(err)
+	}
+
+	if h.String() != g.String() {
+		t.Errorf("mismatched hash: %s != %s", h, g)
 	}
 }

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -190,16 +190,30 @@ func FSLayers(i WithManifest) ([]v1.Hash, error) {
 
 // BlobSize is a helper for implementing v1.Image
 func BlobSize(i WithManifest, h v1.Hash) (int64, error) {
-	m, err := i.Manifest()
+	d, err := BlobDescriptor(i, h)
 	if err != nil {
 		return -1, err
 	}
+	return d.Size, nil
+}
+
+// BlobDescriptor is a helper for implementing v1.Image
+func BlobDescriptor(i WithManifest, h v1.Hash) (v1.Descriptor, error) {
+	m, err := i.Manifest()
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+
+	if m.Config.Digest == h {
+		return m.Config, nil
+	}
+
 	for _, l := range m.Layers {
 		if l.Digest == h {
-			return l.Size, nil
+			return l, nil
 		}
 	}
-	return -1, fmt.Errorf("blob %v not found", h)
+	return v1.Descriptor{}, fmt.Errorf("blob %v not found", h)
 }
 
 // WithManifestAndConfigFile defines the subset of v1.Image used by these helper methods

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -145,7 +145,9 @@ func (rl *remoteImageLayer) Compressed() (io.ReadCloser, error) {
 	}
 
 	// The lastErr for most pulls will be the same (the first error), but for
-	// foreign layers we'll want to surface the last one.
+	// foreign layers we'll want to surface the last one, since we try to pull
+	// from the registry first, which would often fail.
+	// TODO: Maybe we don't want to try pulling from the registry first?
 	var lastErr error
 	for _, u := range urls {
 		resp, err := rl.ri.Client.Get(u.String())

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -15,7 +15,6 @@
 package remote
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -174,18 +173,12 @@ func (rl *remoteImageLayer) Manifest() (*v1.Manifest, error) {
 
 // MediaType implements v1.Layer
 func (rl *remoteImageLayer) MediaType() (types.MediaType, error) {
-	m, err := rl.Manifest()
+	bd, err := partial.BlobDescriptor(rl, rl.digest)
 	if err != nil {
 		return "", err
 	}
 
-	for _, layer := range m.Layers {
-		if layer.Digest == rl.digest {
-			return layer.MediaType, nil
-		}
-	}
-
-	return "", fmt.Errorf("unable to find layer with digest: %v", rl.digest)
+	return bd.MediaType, nil
 }
 
 // Size implements partial.CompressedLayer

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -69,6 +69,16 @@ func Write(ref name.Reference, img v1.Image, options ...Option) error {
 	for _, l := range ls {
 		l := l
 
+		// Handle foreign layers.
+		mt, err := l.MediaType()
+		if err != nil {
+			return err
+		}
+		if !mt.IsDistributable() {
+			// TODO(jonjohnsonjr): Add "allow-nondistributable-artifacts" option.
+			continue
+		}
+
 		// Streaming layers calculate their digests while uploading them. Assume
 		// an error here indicates we need to upload the layer.
 		h, err := l.Digest()

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -105,6 +105,9 @@ type singleImageTarDescriptor struct {
 	Config   string
 	RepoTags []string
 	Layers   []string
+
+	// Tracks foreign layer info. Key is DiffID.
+	LayerSources map[v1.Hash]v1.Descriptor `json:",omitempty"`
 }
 
 // tarDescriptor is the struct used inside the `manifest.json` file of a `docker save` tarball.

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -316,14 +316,14 @@ func (c *compressedImage) RawManifest() ([]byte, error) {
 
 // compressedLayerFromTarball implements partial.CompressedLayer
 type compressedLayerFromTarball struct {
-	digest   v1.Hash
+	desc     v1.Descriptor
 	opener   Opener
 	filePath string
 }
 
 // Digest implements partial.CompressedLayer
 func (clft *compressedLayerFromTarball) Digest() (v1.Hash, error) {
-	return clft.digest, nil
+	return clft.desc.Digest, nil
 }
 
 // Compressed implements partial.CompressedLayer
@@ -333,18 +333,12 @@ func (clft *compressedLayerFromTarball) Compressed() (io.ReadCloser, error) {
 
 // MediaType implements partial.CompressedLayer
 func (clft *compressedLayerFromTarball) MediaType() (types.MediaType, error) {
-	return types.DockerLayer, nil
+	return clft.desc.MediaType, nil
 }
 
 // Size implements partial.CompressedLayer
 func (clft *compressedLayerFromTarball) Size() (int64, error) {
-	r, err := clft.Compressed()
-	if err != nil {
-		return -1, err
-	}
-	defer r.Close()
-	_, i, err := v1.SHA256(r)
-	return i, err
+	return clft.desc.Size, nil
 }
 
 func (c *compressedImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
@@ -356,7 +350,7 @@ func (c *compressedImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, err
 		if l.Digest == h {
 			fp := c.imgDescriptor.Layers[i]
 			return &compressedLayerFromTarball{
-				digest:   h,
+				desc:     l,
 				opener:   c.opener,
 				filePath: fp,
 			}, nil

--- a/pkg/v1/types/types.go
+++ b/pkg/v1/types/types.go
@@ -38,3 +38,13 @@ const (
 	DockerForeignLayer          MediaType = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 	DockerUncompressedLayer     MediaType = "application/vnd.docker.image.rootfs.diff.tar"
 )
+
+// IsDistributable returns true if a layer is distributable, see:
+// https://github.com/opencontainers/image-spec/blob/master/layer.md#non-distributable-layers
+func (m MediaType) IsDistributable() bool {
+	switch m {
+	case DockerForeignLayer, OCIRestrictedLayer, OCIUncompressedRestrictedLayer:
+		return false
+	}
+	return true
+}

--- a/pkg/v1/types/types_test.go
+++ b/pkg/v1/types/types_test.go
@@ -1,0 +1,36 @@
+package types
+
+import "testing"
+
+func TestIsDistributable(t *testing.T) {
+	for _, mt := range []MediaType{
+		OCIRestrictedLayer,
+		OCIUncompressedRestrictedLayer,
+		DockerForeignLayer,
+	} {
+		if mt.IsDistributable() {
+			t.Errorf("%s: should not be distributable", mt)
+		}
+	}
+
+	for _, mt := range []MediaType{
+		OCIContentDescriptor,
+		OCIImageIndex,
+		OCIManifestSchema1,
+		OCIConfigJSON,
+		OCILayer,
+		OCIUncompressedLayer,
+		DockerManifestSchema1,
+		DockerManifestSchema1Signed,
+		DockerManifestSchema2,
+		DockerManifestList,
+		DockerLayer,
+		DockerConfigJSON,
+		DockerPluginConfig,
+		DockerUncompressedLayer,
+	} {
+		if !mt.IsDistributable() {
+			t.Errorf("%s: should be distributable", mt)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/207

* Support downloading layers from the `URLs` field in a `remote.Image` manifest.
* Skip uploading foreign layers.
* Populate `LayerSources` when writing a `tarball.Image`.
* Read `LayeSources` when reading a `tarball.Image`.