### PR TITLE
Add remote.Layer, remote.WriteLayer

### DIFF
--- a/pkg/v1/remote/layer.go
+++ b/pkg/v1/remote/layer.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"io"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// remoteImagelayer implements partial.CompressedLayer
+type remoteLayer struct {
+	fetcher
+	digest v1.Hash
+}
+
+// Compressed implements partial.CompressedLayer
+func (rl *remoteLayer) Compressed() (io.ReadCloser, error) {
+	return rl.fetchBlob(rl.digest)
+}
+
+// Compressed implements partial.CompressedLayer
+func (rl *remoteLayer) Size() (int64, error) {
+	resp, err := rl.headBlob(rl.digest)
+	if err != nil {
+		return -1, err
+	}
+	return resp.ContentLength, nil
+}
+
+// Digest implements partial.CompressedLayer
+func (rl *remoteLayer) Digest() (v1.Hash, error) {
+	return rl.digest, nil
+}
+
+// MediaType implements v1.Layer
+func (rl *remoteLayer) MediaType() (types.MediaType, error) {
+	return types.DockerLayer, nil
+}
+
+// Layer reads the given blob reference from a registry as a Layer. A blob
+// reference here is just a punned name.Digest where the digest portion is the
+// digest of the blob to be read and the repository portion is the repo where
+// that blob lives.
+func Layer(ref name.Digest, options ...Option) (v1.Layer, error) {
+	o, err := makeOptions(ref.Context().Registry, options...)
+	if err != nil {
+		return nil, err
+	}
+	f, err := makeFetcher(ref, o)
+	if err != nil {
+		return nil, err
+	}
+	h, err := v1.NewHash(ref.Identifier())
+	if err != nil {
+		return nil, err
+	}
+	l, err := partial.CompressedToLayer(&remoteLayer{
+		fetcher: *f,
+		digest:  h,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &MountableLayer{
+		Layer:     l,
+		Reference: ref,
+	}, nil
+}

--- a/pkg/v1/remote/layer_test.go
+++ b/pkg/v1/remote/layer_test.go
@@ -1,0 +1,122 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestRemoteLayer(t *testing.T) {
+	layer, err := random.Layer(1024, types.DockerLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := layer.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up a fake registry and write what we pulled to it.
+	// This ensures we get coverage for the remoteLayer.MediaType path.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	t.Log(s.URL)
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(u)
+	dst := fmt.Sprintf("%s/some/path@%s", u.Host, digest)
+	t.Log(dst)
+	ref, err := name.NewDigest(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(ref)
+	if err := WriteLayer(ref, layer); err != nil {
+		t.Fatalf("failed to WriteLayer: %v", err)
+	}
+
+	got, err := Layer(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := got.MediaType(); err != nil {
+		t.Errorf("reading MediaType: %v", err)
+	}
+
+	compareLayers(t, got, layer)
+}
+
+func compareLayers(t *testing.T, got, want v1.Layer) {
+	t.Helper()
+
+	gotDigest, err := got.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDigest, err := want.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDigest != wantDigest {
+		t.Errorf("%s != %s", gotDigest, wantDigest)
+	}
+
+	gotSize, err := got.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSize, err := want.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSize != wantSize {
+		t.Errorf("%d != %d", gotSize, wantSize)
+	}
+
+	rc, err := got.Compressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := ioutil.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err = want.Compressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBytes, err := ioutil.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotBytes, wantBytes) {
+		t.Error("gotBytes != wantBytes")
+	}
+}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -481,3 +481,22 @@ func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
 	// to commit the image.
 	return w.commitImage(ii)
 }
+
+// WriteLayer uploads the provided Layer to the specified name.Digest.
+func WriteLayer(ref name.Digest, layer v1.Layer, options ...Option) error {
+	o, err := makeOptions(ref.Context().Registry, options...)
+	if err != nil {
+		return err
+	}
+	scopes := scopesForUploadingImage(ref, []v1.Layer{layer})
+	tr, err := transport.New(ref.Context().Registry, o.auth, o.transport, scopes)
+	if err != nil {
+		return err
+	}
+	w := writer{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	}
+
+	return w.uploadOne(layer)
+}


### PR DESCRIPTION
This provides direct access to a blob in a registry instead of having to
go through remote.Image.

Specifically, this is useful for:
* Accessing unreferenced layers in a registry.
* Pulling schema 1 layers.
* Inspecting the contents of a layer.

Progress towards https://github.com/google/go-containerregistry/issues/500