### PR TITLE
Implement schema 1 image copying

### DIFF
--- a/pkg/internal/legacy/copy.go
+++ b/pkg/internal/legacy/copy.go
@@ -1,0 +1,87 @@
+package legacy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// CopySchema1 allows `[g]crane cp` to work with old images without adding
+// full support for schema 1 images to this package.
+func CopySchema1(desc *remote.Descriptor, srcRef, dstRef name.Reference, srcAuth, dstAuth authn.Authenticator) error {
+	m := schema1{}
+	if err := json.NewDecoder(bytes.NewReader(desc.Manifest)).Decode(&m); err != nil {
+		return err
+	}
+
+	for _, layer := range m.FSLayers {
+		src := fmt.Sprintf("%s@%s", srcRef.Context(), layer.BlobSum)
+		blobSrc, err := name.NewDigest(src)
+		if err != nil {
+			return err
+		}
+		dst := fmt.Sprintf("%s@%s", dstRef.Context(), layer.BlobSum)
+		blobDst, err := name.NewDigest(dst)
+		if err != nil {
+			return err
+		}
+
+		blob, err := remote.Layer(blobSrc, remote.WithAuth(srcAuth))
+		if err != nil {
+			return err
+		}
+
+		if err := remote.WriteLayer(blobDst, blob, remote.WithAuth(dstAuth)); err != nil {
+			return err
+		}
+	}
+
+	return putManifest(desc.Manifest, desc.MediaType, dstRef, dstAuth)
+}
+
+// TODO: perhaps expose this in remote?
+func putManifest(body []byte, mt types.MediaType, dstRef name.Reference, dstAuth authn.Authenticator) error {
+	reg := dstRef.Context().Registry
+	scopes := []string{dstRef.Scope(transport.PushScope)}
+	tr, err := transport.New(reg, dstAuth, http.DefaultTransport, scopes)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Transport: tr}
+
+	u := url.URL{
+		Scheme: dstRef.Context().Registry.Scheme(),
+		Host:   dstRef.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/manifests/%s", dstRef.Context().RepositoryStr(), dstRef.Identifier()),
+	}
+
+	req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", string(mt))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return transport.CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted)
+}
+
+type fslayer struct {
+	BlobSum string `json:"blobSum"`
+}
+
+type schema1 struct {
+	FSLayers []fslayer `json:"fsLayers"`
+}

--- a/pkg/internal/legacy/copy_test.go
+++ b/pkg/internal/legacy/copy_test.go
@@ -1,0 +1,80 @@
+package legacy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestCopySchema1(t *testing.T) {
+	// Set up a fake registry.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We'll copy from src to dst.
+	src := fmt.Sprintf("%s/schema1/src", u.Host)
+	srcRef, err := name.ParseReference(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := fmt.Sprintf("%s/schema1/dst", u.Host)
+	dstRef, err := name.ParseReference(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a random layer.
+	layer, err := random.Layer(1024, types.DockerLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := layer.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerRef, err := name.NewDigest(fmt.Sprintf("%s@%s", src, digest))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate the registry with a layer and a schema 1 manifest referencing it.
+	if err := remote.WriteLayer(layerRef, layer); err != nil {
+		t.Fatal(err)
+	}
+	manifest := schema1{
+		FSLayers: []fslayer{{
+			BlobSum: digest.String(),
+		}},
+	}
+	b, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc := &remote.Descriptor{
+		Manifest: b,
+		Descriptor: v1.Descriptor{
+			MediaType: types.DockerManifestSchema1,
+		},
+	}
+	if err := putManifest(desc.Manifest, desc.MediaType, dstRef, authn.Anonymous); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopySchema1(desc, srcRef, dstRef, authn.Anonymous, authn.Anonymous); err != nil {
+		t.Errorf("failed to copy schema 1: %v", err)
+	}
+}


### PR DESCRIPTION
Adds a new package, pkg/internal/legacy, where we can keep this without worrying about the API being terrible.

Fixes https://github.com/google/go-containerregistry/issues/500