### PR TITLE
Add ability to cache/push compressed layers

### DIFF
--- a/pkg/v1/fake/image.go
+++ b/pkg/v1/fake/image.go
@@ -2,6 +2,7 @@
 package fake
 
 import (
+	"errors"
 	sync "sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -391,6 +392,10 @@ func (fake *FakeImage) Layers() ([]v1.Layer, error) {
 	}
 	fakeReturns := fake.layersReturns
 	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImage) CompressedLayers() ([]v1.Layer, error) {
+	return nil, errors.New("CompressedLayers not implemented for fake.FakeImage")
 }
 
 func (fake *FakeImage) LayersCallCount() int {

--- a/pkg/v1/image.go
+++ b/pkg/v1/image.go
@@ -25,6 +25,11 @@ type Image interface {
 	// The order of the list is oldest/base layer first, and most-recent/top layer last.
 	Layers() ([]Layer, error)
 
+	// CompressedLayers returns the ordered collection of compressed filesystem layers that
+	// comprise this image. The order of the list is oldest/base layer first, and
+	// most-recent/top layer last. CompressedLayers are useful for optimized pushing.
+	CompressedLayers() ([]Layer, error)
+
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -247,6 +247,26 @@ func (i *image) Layers() ([]v1.Layer, error) {
 	return ls, nil
 }
 
+func (i *image) CompressedLayers() ([]v1.Layer, error) {
+	compressedLayers := []v1.Layer{}
+
+	layers, err := i.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, l := range layers {
+		cl, err := partial.ToCompressedLayer(l)
+		if err != nil {
+			return nil, err
+		}
+
+		compressedLayers = append(compressedLayers, cl)
+	}
+
+	return compressedLayers, nil
+}
+
 // ConfigName returns the hash of the image's config file.
 func (i *image) ConfigName() (v1.Hash, error) {
 	if err := i.compute(); err != nil {

--- a/pkg/v1/partial/compressed.go
+++ b/pkg/v1/partial/compressed.go
@@ -122,6 +122,12 @@ func (i *compressedImageExtender) Layers() ([]v1.Layer, error) {
 	return ls, nil
 }
 
+// CompressedLayers implements v1.Image
+func (i *compressedImageExtender) CompressedLayers() ([]v1.Layer, error) {
+	// layers are already compressed
+	return i.Layers()
+}
+
 // LayerByDigest implements v1.Image
 func (i *compressedImageExtender) LayerByDigest(h v1.Hash) (v1.Layer, error) {
 	cl, err := i.CompressedImageCore.LayerByDigest(h)

--- a/pkg/v1/partial/uncompressed.go
+++ b/pkg/v1/partial/uncompressed.go
@@ -17,11 +17,13 @@ package partial
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/v1util"
+	"golang.org/x/sync/errgroup"
 )
 
 // UncompressedLayer represents the bare minimum interface a natively
@@ -108,6 +110,9 @@ func UncompressedToImage(uic UncompressedImageCore) (v1.Image, error) {
 type uncompressedImageExtender struct {
 	UncompressedImageCore
 
+	// this is used to cache compressedLayers if the layers ever get compressed, because compression can be expensive
+	compressedLayers []v1.Layer
+
 	lock     sync.Mutex
 	manifest *v1.Manifest
 }
@@ -148,7 +153,13 @@ func (i *uncompressedImageExtender) Manifest() (*v1.Manifest, error) {
 		},
 	}
 
-	ls, err := i.Layers()
+	// TODO this shouldn't depend on layers being populated
+	var ls []v1.Layer
+	if i.compressedLayers != nil {
+		ls, err = i.CompressedLayers()
+	} else {
+		ls, err = i.Layers()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +218,48 @@ func (i *uncompressedImageExtender) Layers() ([]v1.Layer, error) {
 	return ls, nil
 }
 
+// CompressedLayers implements v1.Image
+// This function compresses layers in parallel, so it is fairly expensive computationally.
+func (i *uncompressedImageExtender) CompressedLayers() ([]v1.Layer, error) {
+	if i.compressedLayers != nil {
+		return i.compressedLayers, nil
+	}
+
+	diffIDs, err := DiffIDs(i)
+	if err != nil {
+		return nil, err
+	}
+
+	ls := make([]v1.Layer, len(diffIDs), len(diffIDs))
+
+	var g errgroup.Group
+	for idx, d := range diffIDs {
+		idx := idx
+		d := d
+
+		g.Go(func() error {
+			l, err := i.LayerByDiffID(d)
+			if err != nil {
+				return err
+			}
+
+			ls[idx], err = ToCompressedLayer(l)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	i.compressedLayers = ls
+
+	return ls, nil
+}
+
 // LayerByDiffID implements v1.Image
 func (i *uncompressedImageExtender) LayerByDiffID(diffID v1.Hash) (v1.Layer, error) {
 	ul, err := i.UncompressedImageCore.LayerByDiffID(diffID)
@@ -223,4 +276,59 @@ func (i *uncompressedImageExtender) LayerByDigest(h v1.Hash) (v1.Layer, error) {
 		return nil, err
 	}
 	return i.LayerByDiffID(diffID)
+}
+
+// compressedLayerFromUncompressedLayer implements partial.CompressedLayer
+type compressedLayerFromUncompressedLayer struct {
+	digest    v1.Hash
+	contents  []byte
+	mediaType types.MediaType
+}
+
+// ToCompressedLayer converts an uncompressed layer to a compressed layer
+func ToCompressedLayer(l v1.Layer) (v1.Layer, error) {
+	mediaType, err := l.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	uncompressedReader, err := l.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+	gzipReadCloser := v1util.GzipReadCloser(uncompressedReader)
+
+	// TODO probably shouldnt cache the contents, should probably just re-gzip but aint nobody got time for that
+	buf := new(bytes.Buffer)
+	digest, _, err := v1.SHA256(io.TeeReader(gzipReadCloser, buf))
+	if err != nil {
+		return nil, err
+	}
+
+	cl := &compressedLayerFromUncompressedLayer{
+		mediaType: mediaType,
+		contents:  buf.Bytes(),
+		digest:    digest,
+	}
+
+	return CompressedToLayer(cl)
+}
+
+// Digest implements partial.CompressedLayer
+func (clft *compressedLayerFromUncompressedLayer) Digest() (v1.Hash, error) {
+	return clft.digest, nil
+}
+
+// Compressed implements partial.CompressedLayer
+func (clft *compressedLayerFromUncompressedLayer) Compressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader(clft.contents)), nil
+}
+
+// MediaType implements partial.CompressedLayer
+func (clft *compressedLayerFromUncompressedLayer) MediaType() (types.MediaType, error) {
+	return clft.mediaType, nil
+}
+
+// Size implements partial.CompressedLayer
+func (clft *compressedLayerFromUncompressedLayer) Size() (int64, error) {
+	return int64(len(clft.contents)), nil
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -32,13 +32,16 @@ type options struct {
 	keychain  authn.Keychain
 	transport http.RoundTripper
 	platform  v1.Platform
+
+	pushCompressedLayers bool
 }
 
 func makeOptions(reg name.Registry, opts ...Option) (*options, error) {
 	o := &options{
-		auth:      authn.Anonymous,
-		transport: http.DefaultTransport,
-		platform:  defaultPlatform,
+		auth:                 authn.Anonymous,
+		transport:            http.DefaultTransport,
+		platform:             defaultPlatform,
+		pushCompressedLayers: false,
 	}
 
 	for _, option := range opts {
@@ -105,6 +108,17 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 func WithPlatform(p v1.Platform) Option {
 	return func(o *options) error {
 		o.platform = p
+		return nil
+	}
+}
+
+// WithLayerCompression is a functional option that specifies whether the
+// layers should be compressed or not.
+//
+// By default, layers will be pulled out of the image uncompressed.
+func WithLayerCompression() Option {
+	return func(o *options) error {
+		o.pushCompressedLayers = true
 		return nil
 	}
 }


### PR DESCRIPTION
Hey!

I did a bunch of profiling on the library and made some optimizations. For the image I was experimenting with, push timing went from 2mins, 25 seconds to 49 seconds.

I know I've done some bad things here, but would love to work together to get some of these savings merged in some form or another.

I'll leave some comments throughout to share some thoughts so we can move forward.