### PR TITLE
Implement index mutation

### DIFF
--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -1,0 +1,247 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type image struct {
+	base v1.Image
+	adds []Addendum
+
+	computed   bool
+	configFile *v1.ConfigFile
+	manifest   *v1.Manifest
+	diffIDMap  map[v1.Hash]v1.Layer
+	digestMap  map[v1.Hash]v1.Layer
+}
+
+var _ v1.Image = (*image)(nil)
+
+func (i *image) MediaType() (types.MediaType, error) { return i.base.MediaType() }
+
+func (i *image) compute() error {
+	// Don't re-compute if already computed.
+	if i.computed {
+		return nil
+	}
+	var configFile *v1.ConfigFile
+	if i.configFile != nil {
+		configFile = i.configFile
+	} else {
+		cf, err := i.base.ConfigFile()
+		if err != nil {
+			return err
+		}
+		configFile = cf.DeepCopy()
+	}
+	diffIDs := configFile.RootFS.DiffIDs
+	history := configFile.History
+
+	diffIDMap := make(map[v1.Hash]v1.Layer)
+	digestMap := make(map[v1.Hash]v1.Layer)
+
+	for _, add := range i.adds {
+		diffID, err := add.Layer.DiffID()
+		if err != nil {
+			return err
+		}
+		diffIDs = append(diffIDs, diffID)
+		history = append(history, add.History)
+		diffIDMap[diffID] = add.Layer
+	}
+
+	m, err := i.base.Manifest()
+	if err != nil {
+		return err
+	}
+	manifest := m.DeepCopy()
+	manifestLayers := manifest.Layers
+	for _, add := range i.adds {
+		d := v1.Descriptor{}
+		var err error
+
+		if d.Size, err = add.Layer.Size(); err != nil {
+			return err
+		}
+
+		if d.Digest, err = add.Layer.Digest(); err != nil {
+			return err
+		}
+
+		if d.MediaType, err = add.Layer.MediaType(); err != nil {
+			return err
+		}
+
+		d.Annotations = add.Annotations
+		d.URLs = add.URLs
+
+		manifestLayers = append(manifestLayers, d)
+		digestMap[d.Digest] = add.Layer
+	}
+
+	configFile.RootFS.DiffIDs = diffIDs
+	configFile.History = history
+
+	manifest.Layers = manifestLayers
+
+	rcfg, err := json.Marshal(configFile)
+	if err != nil {
+		return err
+	}
+	d, sz, err := v1.SHA256(bytes.NewBuffer(rcfg))
+	if err != nil {
+		return err
+	}
+	manifest.Config.Digest = d
+	manifest.Config.Size = sz
+
+	i.configFile = configFile
+	i.manifest = manifest
+	i.diffIDMap = diffIDMap
+	i.digestMap = digestMap
+	i.computed = true
+	return nil
+}
+
+// Layers returns the ordered collection of filesystem layers that comprise this image.
+// The order of the list is oldest/base layer first, and most-recent/top layer last.
+func (i *image) Layers() ([]v1.Layer, error) {
+	if err := i.compute(); err == stream.ErrNotComputed {
+		// Image contains a streamable layer which has not yet been
+		// consumed. Just return the layers we have in case the caller
+		// is going to consume the layers.
+		layers, err := i.base.Layers()
+		if err != nil {
+			return nil, err
+		}
+		for _, add := range i.adds {
+			layers = append(layers, add.Layer)
+		}
+		return layers, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	diffIDs, err := partial.DiffIDs(i)
+	if err != nil {
+		return nil, err
+	}
+	ls := make([]v1.Layer, 0, len(diffIDs))
+	for _, h := range diffIDs {
+		l, err := i.LayerByDiffID(h)
+		if err != nil {
+			return nil, err
+		}
+		ls = append(ls, l)
+	}
+	return ls, nil
+}
+
+// ConfigName returns the hash of the image's config file.
+func (i *image) ConfigName() (v1.Hash, error) {
+	if err := i.compute(); err != nil {
+		return v1.Hash{}, err
+	}
+	return partial.ConfigName(i)
+}
+
+// ConfigFile returns this image's config file.
+func (i *image) ConfigFile() (*v1.ConfigFile, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return i.configFile, nil
+}
+
+// RawConfigFile returns the serialized bytes of ConfigFile()
+func (i *image) RawConfigFile() ([]byte, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(i.configFile)
+}
+
+// Digest returns the sha256 of this image's manifest.
+func (i *image) Digest() (v1.Hash, error) {
+	if err := i.compute(); err != nil {
+		return v1.Hash{}, err
+	}
+	return partial.Digest(i)
+}
+
+// Size implements v1.Image.
+func (i *image) Size() (int64, error) {
+	if err := i.compute(); err != nil {
+		return -1, err
+	}
+	return partial.Size(i)
+}
+
+// Manifest returns this image's Manifest object.
+func (i *image) Manifest() (*v1.Manifest, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return i.manifest, nil
+}
+
+// RawManifest returns the serialized bytes of Manifest()
+func (i *image) RawManifest() ([]byte, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(i.manifest)
+}
+
+// LayerByDigest returns a Layer for interacting with a particular layer of
+// the image, looking it up by "digest" (the compressed hash).
+func (i *image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	if cn, err := i.ConfigName(); err != nil {
+		return nil, err
+	} else if h == cn {
+		return partial.ConfigLayer(i)
+	}
+	if layer, ok := i.digestMap[h]; ok {
+		return layer, nil
+	}
+	return i.base.LayerByDigest(h)
+}
+
+// LayerByDiffID is an analog to LayerByDigest, looking up by "diff id"
+// (the uncompressed hash).
+func (i *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
+	if layer, ok := i.diffIDMap[h]; ok {
+		return layer, nil
+	}
+	return i.base.LayerByDiffID(h)
+}
+
+func validate(adds []Addendum) error {
+	for _, add := range adds {
+		if add.Layer == nil {
+			return errors.New("unable to add a nil layer to the image")
+		}
+	}
+	return nil
+}

--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -1,0 +1,141 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"encoding/json"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func computeDescriptor(desc v1.Descriptor, add Appendable) (*v1.Descriptor, error) {
+	d, err := add.Digest()
+	if err != nil {
+		return nil, err
+	}
+	mt, err := add.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	sz, err := add.Size()
+	if err != nil {
+		return nil, err
+	}
+
+	// The IndexAddendum allows overriding These values.
+	if desc.Size == 0 {
+		desc.Size = sz
+	}
+	if string(desc.MediaType) == "" {
+		desc.MediaType = mt
+	}
+	if desc.Digest == (v1.Hash{}) {
+		desc.Digest = d
+	}
+	return &desc, nil
+}
+
+type index struct {
+	base v1.ImageIndex
+	adds []IndexAddendum
+
+	computed bool
+	manifest *v1.IndexManifest
+	imageMap map[v1.Hash]v1.Image
+	indexMap map[v1.Hash]v1.ImageIndex
+}
+
+var _ v1.ImageIndex = (*index)(nil)
+
+func (i *index) MediaType() (types.MediaType, error) { return i.base.MediaType() }
+func (i *index) Size() (int64, error)                { return partial.Size(i) }
+
+func (i *index) compute() error {
+	// Don't re-compute if already computed.
+	if i.computed {
+		return nil
+	}
+
+	i.imageMap = make(map[v1.Hash]v1.Image)
+	i.indexMap = make(map[v1.Hash]v1.ImageIndex)
+
+	m, err := i.base.IndexManifest()
+	if err != nil {
+		return err
+	}
+	manifest := m.DeepCopy()
+	manifests := manifest.Manifests
+	for _, add := range i.adds {
+		desc, err := computeDescriptor(add.Descriptor, add.Add)
+		if err != nil {
+			return err
+		}
+
+		manifests = append(manifests, *desc)
+		if idx, ok := add.Add.(v1.ImageIndex); ok {
+			i.indexMap[desc.Digest] = idx
+		} else if img, ok := add.Add.(v1.Image); ok {
+			i.imageMap[desc.Digest] = img
+		} else {
+			logs.Warn.Printf("Unexpected index addendum: %T", add.Add)
+		}
+	}
+	manifest.Manifests = manifests
+
+	i.manifest = manifest
+	i.computed = true
+	return nil
+}
+
+func (i *index) Image(h v1.Hash) (v1.Image, error) {
+	if img, ok := i.imageMap[h]; ok {
+		return img, nil
+	}
+	return i.base.Image(h)
+}
+
+func (i *index) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	if idx, ok := i.indexMap[h]; ok {
+		return idx, nil
+	}
+	return i.base.ImageIndex(h)
+}
+
+// Digest returns the sha256 of this image's manifest.
+func (i *index) Digest() (v1.Hash, error) {
+	if err := i.compute(); err != nil {
+		return v1.Hash{}, err
+	}
+	return partial.Digest(i)
+}
+
+// Manifest returns this image's Manifest object.
+func (i *index) IndexManifest() (*v1.IndexManifest, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return i.manifest, nil
+}
+
+// RawManifest returns the serialized bytes of Manifest()
+func (i *index) RawManifest() ([]byte, error) {
+	if err := i.compute(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(i.manifest)
+}

--- a/pkg/v1/mutate/index_test.go
+++ b/pkg/v1/mutate/index_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -80,5 +81,21 @@ func TestAppendIndex(t *testing.T) {
 
 	if got, want := m.Manifests[5].MediaType, types.OCIUncompressedRestrictedLayer; got != want {
 		t.Errorf("wrong MediaType for layer: %s != %s", got, want)
+	}
+
+	// Append the index to itself and make sure it still validates.
+	add = mutate.AppendManifests(add, mutate.IndexAddendum{
+		Add: add,
+	})
+	if err := validate.Index(add); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+
+	// Wrap the whole thing in another index and make sure it still validates.
+	add = mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
+		Add: add,
+	})
+	if err := validate.Index(add); err != nil {
+		t.Errorf("Validate() = %v", err)
 	}
 }

--- a/pkg/v1/mutate/index_test.go
+++ b/pkg/v1/mutate/index_test.go
@@ -1,0 +1,84 @@
+package mutate_test
+
+import (
+	"log"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
+)
+
+func TestAppendIndex(t *testing.T) {
+	base, err := random.Index(1024, 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx, err := random.Index(2048, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := random.Image(4096, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := random.Layer(1024, types.OCIUncompressedRestrictedLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	add := mutate.AppendManifests(base, mutate.IndexAddendum{
+		Add: idx,
+		Descriptor: v1.Descriptor{
+			URLs: []string{"index.example.com"},
+		},
+	}, mutate.IndexAddendum{
+		Add: img,
+		Descriptor: v1.Descriptor{
+			URLs: []string{"image.example.com"},
+		},
+	}, mutate.IndexAddendum{
+		Add: l,
+		Descriptor: v1.Descriptor{
+			URLs: []string{"layer.example.com"},
+		},
+	})
+
+	if err := validate.Index(add); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+
+	got, err := add.MediaType()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := base.MediaType()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("MediaType() = %s != %s", got, want)
+	}
+
+	// TODO(jonjohnsonjr): There's no way to grab layers from v1.ImageIndex.
+	m, err := add.IndexManifest()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, want := range map[int]string{
+		3: "index.example.com",
+		4: "image.example.com",
+		5: "layer.example.com",
+	} {
+		if got := m.Manifests[i].URLs[0]; got != want {
+			t.Errorf("wrong URLs[0] for Manifests[%d]: %s != %s", i, got, want)
+		}
+	}
+
+	if got, want := m.Manifests[5].MediaType, types.OCIUncompressedRestrictedLayer; got != want {
+		t.Errorf("wrong MediaType for layer: %s != %s", got, want)
+	}
+}

--- a/pkg/v1/mutate/index_test.go
+++ b/pkg/v1/mutate/index_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mutate_test
 
 import (

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -42,7 +42,7 @@ type Addendum struct {
 	Annotations map[string]string
 }
 
-// AppendLayers applies layers to a base image
+// AppendLayers applies layers to a base image.
 func AppendLayers(base v1.Image, layers ...v1.Layer) (v1.Image, error) {
 	additions := make([]Addendum, 0, len(layers))
 	for _, layer := range layers {
@@ -67,12 +67,17 @@ func Append(base v1.Image, adds ...Addendum) (v1.Image, error) {
 	}, nil
 }
 
+// Appendable is an interface that represents something that can be appended
+// to an ImageIndex. We need to be able to construct a v1.Descriptor in order
+// to append something, and this is the minimum required information for that.
 type Appendable interface {
 	MediaType() (types.MediaType, error)
 	Digest() (v1.Hash, error)
 	Size() (int64, error)
 }
 
+// IndexAddendum represents an appendable thing and all the properties that
+// we may want to override in the resulting v1.Descriptor.
 type IndexAddendum struct {
 	Add Appendable
 	v1.Descriptor

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -17,8 +17,6 @@ package mutate
 import (
 	"archive/tar"
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,8 +26,6 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/partial"
-	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/v1util"
@@ -69,6 +65,25 @@ func Append(base v1.Image, adds ...Addendum) (v1.Image, error) {
 		base: base,
 		adds: adds,
 	}, nil
+}
+
+type Appendable interface {
+	MediaType() (types.MediaType, error)
+	Digest() (v1.Hash, error)
+	Size() (int64, error)
+}
+
+type IndexAddendum struct {
+	Add Appendable
+	v1.Descriptor
+}
+
+// AppendManifest appends a manifest to tbe ImageIndex.
+func AppendManifests(base v1.ImageIndex, adds ...IndexAddendum) v1.ImageIndex {
+	return &index{
+		base: base,
+		adds: adds,
+	}
 }
 
 // Config mutates the provided v1.Image to have the provided v1.Config
@@ -112,227 +127,6 @@ func CreatedAt(base v1.Image, created v1.Time) (v1.Image, error) {
 	cfg.Created = created
 
 	return ConfigFile(base, cfg)
-}
-
-type image struct {
-	base v1.Image
-	adds []Addendum
-
-	computed   bool
-	configFile *v1.ConfigFile
-	manifest   *v1.Manifest
-	diffIDMap  map[v1.Hash]v1.Layer
-	digestMap  map[v1.Hash]v1.Layer
-}
-
-var _ v1.Image = (*image)(nil)
-
-func (i *image) MediaType() (types.MediaType, error) { return i.base.MediaType() }
-
-func (i *image) compute() error {
-	// Don't re-compute if already computed.
-	if i.computed {
-		return nil
-	}
-	var configFile *v1.ConfigFile
-	if i.configFile != nil {
-		configFile = i.configFile
-	} else {
-		cf, err := i.base.ConfigFile()
-		if err != nil {
-			return err
-		}
-		configFile = cf.DeepCopy()
-	}
-	diffIDs := configFile.RootFS.DiffIDs
-	history := configFile.History
-
-	diffIDMap := make(map[v1.Hash]v1.Layer)
-	digestMap := make(map[v1.Hash]v1.Layer)
-
-	for _, add := range i.adds {
-		diffID, err := add.Layer.DiffID()
-		if err != nil {
-			return err
-		}
-		diffIDs = append(diffIDs, diffID)
-		history = append(history, add.History)
-		diffIDMap[diffID] = add.Layer
-	}
-
-	m, err := i.base.Manifest()
-	if err != nil {
-		return err
-	}
-	manifest := m.DeepCopy()
-	manifestLayers := manifest.Layers
-	for _, add := range i.adds {
-		d := v1.Descriptor{}
-		var err error
-
-		if d.Size, err = add.Layer.Size(); err != nil {
-			return err
-		}
-
-		if d.Digest, err = add.Layer.Digest(); err != nil {
-			return err
-		}
-
-		if d.MediaType, err = add.Layer.MediaType(); err != nil {
-			return err
-		}
-
-		d.Annotations = add.Annotations
-		d.URLs = add.URLs
-
-		manifestLayers = append(manifestLayers, d)
-		digestMap[d.Digest] = add.Layer
-	}
-
-	configFile.RootFS.DiffIDs = diffIDs
-	configFile.History = history
-
-	manifest.Layers = manifestLayers
-
-	rcfg, err := json.Marshal(configFile)
-	if err != nil {
-		return err
-	}
-	d, sz, err := v1.SHA256(bytes.NewBuffer(rcfg))
-	if err != nil {
-		return err
-	}
-	manifest.Config.Digest = d
-	manifest.Config.Size = sz
-
-	i.configFile = configFile
-	i.manifest = manifest
-	i.diffIDMap = diffIDMap
-	i.digestMap = digestMap
-	i.computed = true
-	return nil
-}
-
-// Layers returns the ordered collection of filesystem layers that comprise this image.
-// The order of the list is oldest/base layer first, and most-recent/top layer last.
-func (i *image) Layers() ([]v1.Layer, error) {
-	if err := i.compute(); err == stream.ErrNotComputed {
-		// Image contains a streamable layer which has not yet been
-		// consumed. Just return the layers we have in case the caller
-		// is going to consume the layers.
-		layers, err := i.base.Layers()
-		if err != nil {
-			return nil, err
-		}
-		for _, add := range i.adds {
-			layers = append(layers, add.Layer)
-		}
-		return layers, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	diffIDs, err := partial.DiffIDs(i)
-	if err != nil {
-		return nil, err
-	}
-	ls := make([]v1.Layer, 0, len(diffIDs))
-	for _, h := range diffIDs {
-		l, err := i.LayerByDiffID(h)
-		if err != nil {
-			return nil, err
-		}
-		ls = append(ls, l)
-	}
-	return ls, nil
-}
-
-// ConfigName returns the hash of the image's config file.
-func (i *image) ConfigName() (v1.Hash, error) {
-	if err := i.compute(); err != nil {
-		return v1.Hash{}, err
-	}
-	return partial.ConfigName(i)
-}
-
-// ConfigFile returns this image's config file.
-func (i *image) ConfigFile() (*v1.ConfigFile, error) {
-	if err := i.compute(); err != nil {
-		return nil, err
-	}
-	return i.configFile, nil
-}
-
-// RawConfigFile returns the serialized bytes of ConfigFile()
-func (i *image) RawConfigFile() ([]byte, error) {
-	if err := i.compute(); err != nil {
-		return nil, err
-	}
-	return json.Marshal(i.configFile)
-}
-
-// Digest returns the sha256 of this image's manifest.
-func (i *image) Digest() (v1.Hash, error) {
-	if err := i.compute(); err != nil {
-		return v1.Hash{}, err
-	}
-	return partial.Digest(i)
-}
-
-// Size implements v1.Image.
-func (i *image) Size() (int64, error) {
-	if err := i.compute(); err != nil {
-		return -1, err
-	}
-	return partial.Size(i)
-}
-
-// Manifest returns this image's Manifest object.
-func (i *image) Manifest() (*v1.Manifest, error) {
-	if err := i.compute(); err != nil {
-		return nil, err
-	}
-	return i.manifest, nil
-}
-
-// RawManifest returns the serialized bytes of Manifest()
-func (i *image) RawManifest() ([]byte, error) {
-	if err := i.compute(); err != nil {
-		return nil, err
-	}
-	return json.Marshal(i.manifest)
-}
-
-// LayerByDigest returns a Layer for interacting with a particular layer of
-// the image, looking it up by "digest" (the compressed hash).
-func (i *image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
-	if cn, err := i.ConfigName(); err != nil {
-		return nil, err
-	} else if h == cn {
-		return partial.ConfigLayer(i)
-	}
-	if layer, ok := i.digestMap[h]; ok {
-		return layer, nil
-	}
-	return i.base.LayerByDigest(h)
-}
-
-// LayerByDiffID is an analog to LayerByDigest, looking up by "diff id"
-// (the uncompressed hash).
-func (i *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
-	if layer, ok := i.diffIDMap[h]; ok {
-		return layer, nil
-	}
-	return i.base.LayerByDiffID(h)
-}
-
-func validate(adds []Addendum) error {
-	for _, add := range adds {
-		if add.Layer == nil {
-			return errors.New("unable to add a nil layer to the image")
-		}
-	}
-	return nil
 }
 
 // Extract takes an image and returns an io.ReadCloser containing the image's

--- a/pkg/v1/validate/index.go
+++ b/pkg/v1/validate/index.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -75,7 +76,7 @@ func validateChildren(idx v1.ImageIndex) error {
 				errs = append(errs, fmt.Sprintf("failed to validate image MediaType[%d](%s): %v", i, desc.Digest, err))
 			}
 		default:
-			return fmt.Errorf("todo: validate index Blob()")
+			logs.Warn.Printf("Unexpected manifest: %s", desc.MediaType)
 		}
 	}
 


### PR DESCRIPTION
Add an `AppendManifests` function that adds entries to the `manifests` clause of an index.

Fixes https://github.com/google/go-containerregistry/issues/474