### PR TITLE
Clean up #349 TODO

### DIFF
--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/internal/retry"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -137,61 +138,82 @@ func newCopier(src, dst string) (*copier, error) {
 	return &copier{srcRepo, dstRepo, srcAuth, dstAuth, tasks}, nil
 }
 
-func copyImage(src, dst string, srcAuth, dstAuth authn.Authenticator) error {
+func copyImage(src, dst string, srcAuth, dstAuth authn.Authenticator) (remote.Taggable, error) {
 	srcRef, err := name.ParseReference(src)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", src, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
 	dstRef, err := name.ParseReference(dst)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", dst, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", dst, err)
 	}
 
 	img, err := remote.Image(srcRef, remote.WithAuth(srcAuth))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return remote.Write(dstRef, img, remote.WithAuth(dstAuth))
+	if err := remote.Write(dstRef, img, remote.WithAuth(dstAuth)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
 }
 
-func copySchema1Image(src, dst string, srcAuth, dstAuth authn.Authenticator) error {
+// taggable implements remote.Taggable
+type taggable struct {
+	desc *remote.Descriptor
+}
+
+func (t *taggable) MediaType() (types.MediaType, error) { return t.desc.MediaType, nil }
+func (t *taggable) RawManifest() ([]byte, error)        { return t.desc.Manifest, nil }
+func (t *taggable) Digest() (v1.Hash, error)            { return t.desc.Digest, nil }
+
+func copySchema1Image(src, dst string, srcAuth, dstAuth authn.Authenticator) (remote.Taggable, error) {
 	srcRef, err := name.ParseReference(src)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", src, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
 	dstRef, err := name.ParseReference(dst)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", dst, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", dst, err)
 	}
 
 	desc, err := remote.Get(srcRef, remote.WithAuth(srcAuth))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return legacy.CopySchema1(desc, srcRef, dstRef, srcAuth, dstAuth)
+	if err := legacy.CopySchema1(desc, srcRef, dstRef, srcAuth, dstAuth); err != nil {
+		return nil, err
+	}
+
+	return &taggable{desc}, nil
 }
 
-func copyIndex(src, dst string, srcAuth, dstAuth authn.Authenticator) error {
+func copyIndex(src, dst string, srcAuth, dstAuth authn.Authenticator) (remote.Taggable, error) {
 	srcRef, err := name.ParseReference(src)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", src, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
 	dstRef, err := name.ParseReference(dst)
 	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", dst, err)
+		return nil, fmt.Errorf("parsing reference %q: %v", dst, err)
 	}
 
 	idx, err := remote.Index(srcRef, remote.WithAuth(srcAuth))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return remote.WriteIndex(dstRef, idx, remote.WithAuth(dstAuth))
+	if err := remote.WriteIndex(dstRef, idx, remote.WithAuth(dstAuth)); err != nil {
+		return nil, err
+	}
+
+	return idx, nil
 }
 
 // recursiveCopy copies images from repo src to repo dst.
@@ -333,7 +355,8 @@ func (c *copier) copyRepo(ctx context.Context, oldRepo name.Repository, tags *go
 // copyImages starts a goroutine for each tag that points to the image
 // oldRepo@digest, or just copies the image by digest if there are no tags.
 func (c *copier) copyImages(ctx context.Context, t task) error {
-	copyFunc := copyImage
+	var copyFunc func(src, dst string, srcAuth, dstAuth authn.Authenticator) (remote.Taggable, error)
+
 	switch types.MediaType(t.manifest.MediaType) {
 	case types.OCIImageIndex, types.DockerManifestList:
 		copyFunc = copyIndex
@@ -347,17 +370,29 @@ func (c *copier) copyImages(ctx context.Context, t task) error {
 		srcImg := fmt.Sprintf("%s@%s", t.oldRepo, t.digest)
 		dstImg := fmt.Sprintf("%s@%s", t.newRepo, t.digest)
 
-		return copyFunc(srcImg, dstImg, c.srcAuth, c.dstAuth)
+		_, err := copyFunc(srcImg, dstImg, c.srcAuth, c.dstAuth)
+		return err
 	}
 
-	// Copy all the tags.
-	for _, tag := range t.manifest.Tags {
-		srcImg := fmt.Sprintf("%s:%s", t.oldRepo, tag)
-		dstImg := fmt.Sprintf("%s:%s", t.newRepo, tag)
+	// We only need to push the whole image once.
+	tag := t.manifest.Tags[0]
+	srcImg := fmt.Sprintf("%s:%s", t.oldRepo, tag)
+	dstImg := fmt.Sprintf("%s:%s", t.newRepo, tag)
 
-		// TODO(#349): We only need to copy one image, really. The rest can be
-		// done via a quicker PUT with the tag.
-		if err := copyFunc(srcImg, dstImg, c.srcAuth, c.dstAuth); err != nil {
+	taggable, err := copyFunc(srcImg, dstImg, c.srcAuth, c.dstAuth)
+	if err != nil {
+		return err
+	}
+
+	// Copy the rest of the tags.
+	for _, tag := range t.manifest.Tags[1:] {
+		dstImg := fmt.Sprintf("%s:%s", t.newRepo, tag)
+		t, err := name.NewTag(dstImg)
+		if err != nil {
+			return err
+		}
+
+		if err := remote.Tag(t, taggable, remote.WithAuth(c.dstAuth)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Leftover from https://github.com/google/go-containerregistry/issues/349

Before:
```
$ gcrane cp -r gcr.io/google-containers/busybox gcr.io/jonjohnson-test/google-containers/busybox
2019/09/12 13:27:30 existing blob: sha256:aab39f0bc16d3c109d7017bcbc13ee053b9b1b1c6985c432ec9b5dde1eb0d066
2019/09/12 13:27:30 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:27:30 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:27:30 existing blob: sha256:eeee0535bf3cec7a24bff2c6e97481afa3d37e2cdeff277c57cb5cbdb2fa9e92
2019/09/12 13:27:31 mounted blob: sha256:138cfc514ce4b3f1f8d57b2f9766fcb5ffab791110bcd8610e8d762cc78d28b2
2019/09/12 13:27:31 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:27:31 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:27:32 pushed blob: sha256:54511612f1c4d97e93430fc3d5dc2f05dfbe8fb7e6259b7351deeca95eaf2971
2019/09/12 13:27:32 gcr.io/jonjohnson-test/google-containers/busybox:1.27: digest: sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b size: 527
2019/09/12 13:27:32 existing blob: sha256:aab39f0bc16d3c109d7017bcbc13ee053b9b1b1c6985c432ec9b5dde1eb0d066
2019/09/12 13:27:33 existing blob: sha256:54511612f1c4d97e93430fc3d5dc2f05dfbe8fb7e6259b7351deeca95eaf2971
2019/09/12 13:27:33 gcr.io/jonjohnson-test/google-containers/busybox:1.27.2: digest: sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b size: 527
```

After:
```
$ gcrane cp -r gcr.io/google-containers/busybox gcr.io/jonjohnson-test/google-containers/busybox
2019/09/12 13:29:00 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:29:00 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:29:00 existing blob: sha256:aab39f0bc16d3c109d7017bcbc13ee053b9b1b1c6985c432ec9b5dde1eb0d066
2019/09/12 13:29:00 existing blob: sha256:eeee0535bf3cec7a24bff2c6e97481afa3d37e2cdeff277c57cb5cbdb2fa9e92
2019/09/12 13:29:01 mounted blob: sha256:138cfc514ce4b3f1f8d57b2f9766fcb5ffab791110bcd8610e8d762cc78d28b2
2019/09/12 13:29:01 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:29:01 existing blob: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
2019/09/12 13:29:02 pushed blob: sha256:54511612f1c4d97e93430fc3d5dc2f05dfbe8fb7e6259b7351deeca95eaf2971
2019/09/12 13:29:03 gcr.io/jonjohnson-test/google-containers/busybox:1.27: digest: sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b size: 527
2019/09/12 13:29:04 gcr.io/jonjohnson-test/google-containers/busybox:1.27.2: digest: sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b size: 527
```

Notably, we don't do the existence checks anymore when re-tagging 1.27 as 1.27.2.