### PR TITLE
Add Size to v1.Image and v1.ImageIndex

### DIFF
--- a/pkg/v1/empty/index.go
+++ b/pkg/v1/empty/index.go
@@ -36,6 +36,10 @@ func (i emptyIndex) Digest() (v1.Hash, error) {
 	return partial.Digest(i)
 }
 
+func (i emptyIndex) Size() (int64, error) {
+	return partial.Size(i)
+}
+
 func (i emptyIndex) IndexManifest() (*v1.IndexManifest, error) {
 	return base(), nil
 }

--- a/pkg/v1/fake/image.go
+++ b/pkg/v1/fake/image.go
@@ -131,6 +131,18 @@ type FakeImage struct {
 		result1 []byte
 		result2 error
 	}
+	SizeStub        func() (int64, error)
+	sizeMutex       sync.RWMutex
+	sizeArgsForCall []struct {
+	}
+	sizeReturns struct {
+		result1 int64
+		result2 error
+	}
+	sizeReturnsOnCall map[int]struct {
+		result1 int64
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -601,6 +613,51 @@ func (fake *FakeImage) RawManifestReturnsOnCall(i int, result1 []byte, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeImage) Size() (int64, error) {
+	fake.sizeMutex.Lock()
+	ret, specificReturn := fake.sizeReturnsOnCall[len(fake.sizeArgsForCall)]
+	fake.sizeArgsForCall = append(fake.sizeArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Size", []interface{}{})
+	fake.sizeMutex.Unlock()
+	if fake.SizeStub != nil {
+		return fake.SizeStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.sizeReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImage) SizeCallCount() int {
+	fake.sizeMutex.RLock()
+	defer fake.sizeMutex.RUnlock()
+	return len(fake.sizeArgsForCall)
+}
+
+func (fake *FakeImage) SizeReturns(result1 int64, result2 error) {
+	fake.SizeStub = nil
+	fake.sizeReturns = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImage) SizeReturnsOnCall(i int, result1 int64, result2 error) {
+	fake.SizeStub = nil
+	if fake.sizeReturnsOnCall == nil {
+		fake.sizeReturnsOnCall = make(map[int]struct {
+			result1 int64
+			result2 error
+		})
+	}
+	fake.sizeReturnsOnCall[i] = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImage) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -624,6 +681,8 @@ func (fake *FakeImage) Invocations() map[string][][]interface{} {
 	defer fake.rawConfigFileMutex.RUnlock()
 	fake.rawManifestMutex.RLock()
 	defer fake.rawManifestMutex.RUnlock()
+	fake.sizeMutex.RLock()
+	defer fake.sizeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/v1/fake/index.go
+++ b/pkg/v1/fake/index.go
@@ -83,6 +83,18 @@ type FakeImageIndex struct {
 		result1 []byte
 		result2 error
 	}
+	SizeStub        func() (int64, error)
+	sizeMutex       sync.RWMutex
+	sizeArgsForCall []struct {
+	}
+	sizeReturns struct {
+		result1 int64
+		result2 error
+	}
+	sizeReturnsOnCall map[int]struct {
+		result1 int64
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -373,6 +385,51 @@ func (fake *FakeImageIndex) RawManifestReturnsOnCall(i int, result1 []byte, resu
 	}{result1, result2}
 }
 
+func (fake *FakeImageIndex) Size() (int64, error) {
+	fake.sizeMutex.Lock()
+	ret, specificReturn := fake.sizeReturnsOnCall[len(fake.sizeArgsForCall)]
+	fake.sizeArgsForCall = append(fake.sizeArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Size", []interface{}{})
+	fake.sizeMutex.Unlock()
+	if fake.SizeStub != nil {
+		return fake.SizeStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.sizeReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImageIndex) SizeCallCount() int {
+	fake.sizeMutex.RLock()
+	defer fake.sizeMutex.RUnlock()
+	return len(fake.sizeArgsForCall)
+}
+
+func (fake *FakeImageIndex) SizeReturns(result1 int64, result2 error) {
+	fake.SizeStub = nil
+	fake.sizeReturns = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImageIndex) SizeReturnsOnCall(i int, result1 int64, result2 error) {
+	fake.SizeStub = nil
+	if fake.sizeReturnsOnCall == nil {
+		fake.sizeReturnsOnCall = make(map[int]struct {
+			result1 int64
+			result2 error
+		})
+	}
+	fake.sizeReturnsOnCall[i] = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImageIndex) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -388,6 +445,8 @@ func (fake *FakeImageIndex) Invocations() map[string][][]interface{} {
 	defer fake.mediaTypeMutex.RUnlock()
 	fake.rawManifestMutex.RLock()
 	defer fake.rawManifestMutex.RUnlock()
+	fake.sizeMutex.RLock()
+	defer fake.sizeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/v1/image.go
+++ b/pkg/v1/image.go
@@ -28,6 +28,9 @@ type Image interface {
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 
+	// Size returns the size of the manifest.
+	Size() (int64, error)
+
 	// ConfigName returns the hash of the image's config file.
 	ConfigName() (Hash, error)
 

--- a/pkg/v1/index.go
+++ b/pkg/v1/index.go
@@ -27,6 +27,9 @@ type ImageIndex interface {
 	// Digest returns the sha256 of this index's manifest.
 	Digest() (Hash, error)
 
+	// Size returns the size of the manifest.
+	Size() (int64, error)
+
 	// IndexManifest returns this image index's manifest object.
 	IndexManifest() (*IndexManifest, error)
 

--- a/pkg/v1/layout/index.go
+++ b/pkg/v1/layout/index.go
@@ -64,6 +64,10 @@ func (i *layoutIndex) Digest() (v1.Hash, error) {
 	return partial.Digest(i)
 }
 
+func (i *layoutIndex) Size() (int64, error) {
+	return partial.Size(i)
+}
+
 func (i *layoutIndex) IndexManifest() (*v1.IndexManifest, error) {
 	var index v1.IndexManifest
 	err := json.Unmarshal(i.rawIndex, &index)

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -279,6 +279,14 @@ func (i *image) Digest() (v1.Hash, error) {
 	return partial.Digest(i)
 }
 
+// Size implements v1.Image.
+func (i *image) Size() (int64, error) {
+	if err := i.compute(); err != nil {
+		return -1, err
+	}
+	return partial.Size(i)
+}
+
 // Manifest returns this image's Manifest object.
 func (i *image) Manifest() (*v1.Manifest, error) {
 	if err := i.compute(); err != nil {

--- a/pkg/v1/partial/compressed.go
+++ b/pkg/v1/partial/compressed.go
@@ -150,6 +150,11 @@ func (i *compressedImageExtender) Manifest() (*v1.Manifest, error) {
 	return Manifest(i)
 }
 
+// Size implements v1.Image
+func (i *compressedImageExtender) Size() (int64, error) {
+	return Size(i)
+}
+
 // CompressedToImage fills in the missing methods from a CompressedImageCore so that it implements v1.Image
 func CompressedToImage(cic CompressedImageCore) (v1.Image, error) {
 	return &compressedImageExtender{

--- a/pkg/v1/partial/uncompressed.go
+++ b/pkg/v1/partial/uncompressed.go
@@ -180,6 +180,11 @@ func (i *uncompressedImageExtender) RawManifest() ([]byte, error) {
 	return RawManifest(i)
 }
 
+// Size implements v1.Image
+func (i *uncompressedImageExtender) Size() (int64, error) {
+	return Size(i)
+}
+
 // ConfigName implements v1.Image
 func (i *uncompressedImageExtender) ConfigName() (v1.Hash, error) {
 	return ConfigName(i)

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -175,6 +175,15 @@ func RawManifest(i WithManifest) ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// Size is a helper for implementing v1.Image
+func Size(i WithRawManifest) (int64, error) {
+	b, err := i.RawManifest()
+	if err != nil {
+		return -1, err
+	}
+	return int64(len(b)), nil
+}
+
 // FSLayers is a helper for implementing v1.Image
 func FSLayers(i WithManifest) ([]v1.Hash, error) {
 	m, err := i.Manifest()

--- a/pkg/v1/partial/with_test.go
+++ b/pkg/v1/partial/with_test.go
@@ -86,6 +86,27 @@ func TestManifest(t *testing.T) {
 	}
 }
 
+func TestSize(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	part, err := partial.Size(img)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	method, err := img.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(part, method); diff != "" {
+		t.Errorf("mismatched size: %v", diff)
+	}
+}
+
 func TestDiffIDToBlob(t *testing.T) {
 	img, err := random.Image(1024, 1)
 	if err != nil {

--- a/pkg/v1/random/index.go
+++ b/pkg/v1/random/index.go
@@ -80,6 +80,10 @@ func (i *randomIndex) Digest() (v1.Hash, error) {
 	return partial.Digest(i)
 }
 
+func (i *randomIndex) Size() (int64, error) {
+	return partial.Size(i)
+}
+
 func (i *randomIndex) IndexManifest() (*v1.IndexManifest, error) {
 	return i.manifest, nil
 }

--- a/pkg/v1/random/index_test.go
+++ b/pkg/v1/random/index_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 func TestRandomIndex(t *testing.T) {
@@ -26,25 +27,8 @@ func TestRandomIndex(t *testing.T) {
 		t.Fatalf("Error loading index: %v", err)
 	}
 
-	manifest, err := ii.IndexManifest()
-	if err != nil {
-		t.Fatalf("Error reading manifest: %v", err)
-	}
-
-	for _, desc := range manifest.Manifests {
-		img, err := ii.Image(desc.Digest)
-		if err != nil {
-			t.Fatalf("Image(%s): unexpected err: %v", desc.Digest, err)
-		}
-
-		digest, err := img.Digest()
-		if err != nil {
-			t.Fatalf("Image(%s).Digest(): unexpected err: %v", desc.Digest, err)
-		}
-
-		if got, want := digest.String(), desc.Digest.String(); got != want {
-			t.Errorf("Image(%s).Digest(): wrong value, got: %s, want: %s", desc.Digest, got, want)
-		}
+	if err := validate.Index(ii); err != nil {
+		t.Errorf("validate.Index() = %v", err)
 	}
 
 	digest, err := ii.Digest()

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -59,6 +59,10 @@ func (r *remoteIndex) Digest() (v1.Hash, error) {
 	return partial.Digest(r)
 }
 
+func (r *remoteIndex) Size() (int64, error) {
+	return partial.Size(r)
+}
+
 func (r *remoteIndex) RawManifest() ([]byte, error) {
 	r.manifestLock.Lock()
 	defer r.manifestLock.Unlock()

--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -289,6 +289,11 @@ func validateManifest(img v1.Image) error {
 		return err
 	}
 
+	size, err := img.Size()
+	if err != nil {
+		return err
+	}
+
 	rm, err := img.RawManifest()
 	if err != nil {
 		return err
@@ -316,6 +321,10 @@ func validateManifest(img v1.Image) error {
 
 	if diff := cmp.Diff(pm, m); diff != "" {
 		errs = append(errs, fmt.Sprintf("mismatched manifest content: (-ParseManifest(RawManifest()) +Manifest()) %s", diff))
+	}
+
+	if size != int64(len(rm)) {
+		errs = append(errs, fmt.Sprintf("mismatched manifest size: Size()=%d, len(RawManifest())=%d", size, len(rm)))
 	}
 
 	if len(errs) != 0 {

--- a/pkg/v1/validate/index.go
+++ b/pkg/v1/validate/index.go
@@ -108,6 +108,11 @@ func validateIndexManifest(idx v1.ImageIndex) error {
 		return err
 	}
 
+	size, err := idx.Size()
+	if err != nil {
+		return err
+	}
+
 	rm, err := idx.RawManifest()
 	if err != nil {
 		return err
@@ -135,6 +140,10 @@ func validateIndexManifest(idx v1.ImageIndex) error {
 
 	if diff := cmp.Diff(pm, m); diff != "" {
 		errs = append(errs, fmt.Sprintf("mismatched manifest content: (-ParseIndexManifest(RawManifest()) +Manifest()) %s", diff))
+	}
+
+	if size != int64(len(rm)) {
+		errs = append(errs, fmt.Sprintf("mismatched manifest size: Size()=%d, len(RawManifest())=%d", size, len(rm)))
 	}
 
 	if len(errs) != 0 {

--- a/pkg/v1/zz_deepcopy_generated.go
+++ b/pkg/v1/zz_deepcopy_generated.go
@@ -269,6 +269,11 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Features != nil {
+		in, out := &in.Features, &out.Features
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
In isolation, this seems rather silly, since you can get just `RawManifest` from either, but this allows us to use a common interface between `v1.Image`,`v1.ImageIndex`, and `v1.Layer` that has enough methods to generate a minimum viable `v1.Descriptor` 🎉 

This is useful for appending things to an index, see https://github.com/google/go-containerregistry/pull/520#issuecomment-530463027

This is breaking but I suspect there aren't that many implementations of `v1.Image` outside of this library. If there are, this is a trivial method to implement (and you get it for free if you're using `partial`).