### PR TITLE
Preserve input strings for name.Reference

### DIFF
--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -55,6 +55,7 @@ func (d Digest) Name() string {
 	return d.Repository.Name() + digestDelim + d.DigestStr()
 }
 
+// String returns the original input string.
 func (d Digest) String() string {
 	return d.original
 }

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -28,7 +28,8 @@ const (
 // Digest stores a digest name in a structured form.
 type Digest struct {
 	Repository
-	digest string
+	digest   string
+	original string
 }
 
 // Ensure Digest implements Reference
@@ -55,7 +56,7 @@ func (d Digest) Name() string {
 }
 
 func (d Digest) String() string {
-	return d.Name()
+	return d.original
 }
 
 func checkDigest(name string) error {
@@ -86,5 +87,9 @@ func NewDigest(name string, opts ...Option) (Digest, error) {
 	if err != nil {
 		return Digest{}, err
 	}
-	return Digest{repo, digest}, nil
+	return Digest{
+		Repository: repo,
+		digest:     digest,
+		original:   name,
+	}, nil
 }

--- a/pkg/name/errors_test.go
+++ b/pkg/name/errors_test.go
@@ -23,7 +23,7 @@ func TestBadName(t *testing.T) {
 	if !IsErrBadName(err) {
 		t.Errorf("IsBadErrName == false: %v", err)
 	}
-	if err.Error() != "could not parse reference" {
+	if err.Error() != "could not parse reference: @@" {
 		t.Errorf("Unexpected string: %v", err)
 	}
 }

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -45,5 +45,6 @@ func ParseReference(s string, opts ...Option) (Reference, error) {
 		return d, nil
 	}
 	// TODO: Combine above errors into something more useful?
-	return nil, NewErrBadName("could not parse reference")
+	return nil, NewErrBadName("could not parse reference: " + s)
+
 }

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -44,7 +44,6 @@ func ParseReference(s string, opts ...Option) (Reference, error) {
 	if d, err := NewDigest(s, opts...); err == nil {
 		return d, nil
 	}
-	// TODO: Combine above errors into something more useful?
 	return nil, NewErrBadName("could not parse reference: " + s)
 
 }

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -58,6 +58,7 @@ func (t Tag) Name() string {
 	return t.Repository.Name() + tagDelim + t.TagStr()
 }
 
+// String returns the original input string.
 func (t Tag) String() string {
 	return t.original
 }

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -28,7 +28,8 @@ const (
 // Tag stores a docker tag name in a structured form.
 type Tag struct {
 	Repository
-	tag string
+	tag      string
+	original string
 }
 
 // Ensure Tag implements Reference
@@ -58,7 +59,7 @@ func (t Tag) Name() string {
 }
 
 func (t Tag) String() string {
-	return t.Name()
+	return t.original
 }
 
 // Scope returns the scope required to perform the given action on the tag.
@@ -98,5 +99,9 @@ func NewTag(name string, opts ...Option) (Tag, error) {
 	if err != nil {
 		return Tag{}, err
 	}
-	return Tag{repo, tag}, nil
+	return Tag{
+		Repository: repo,
+		tag:        tag,
+		original:   name,
+	}, nil
 }


### PR DESCRIPTION
This modifies String() to return the original input and Name() returns
the defaulted string.

Fixes https://github.com/google/go-containerregistry/issues/527