### PR TITLE
Implement ability to generate v1 image tarballs

### DIFF
--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -72,19 +72,24 @@ func checkTag(name string) error {
 	return checkElement("tag", name, tagChars, 1, 127)
 }
 
-// NewTag returns a new Tag representing the given name, according to the given strictness.
-func NewTag(name string, opts ...Option) (Tag, error) {
-	opt := makeOptions(opts...)
-	base := name
-	tag := ""
-
+// SplitTag splits the given tagged image name <registry>/<repository>:<tag>
+// into <registry>/<repository> and <tag>.
+func SplitTag(name string) (string, string) {
 	// Split on ":"
 	parts := strings.Split(name, tagDelim)
 	// Verify that we aren't confusing a tag for a hostname w/ port for the purposes of weak validation.
 	if len(parts) > 1 && !strings.Contains(parts[len(parts)-1], regRepoDelimiter) {
-		base = strings.Join(parts[:len(parts)-1], tagDelim)
-		tag = parts[len(parts)-1]
+		base := strings.Join(parts[:len(parts)-1], tagDelim)
+		tag := parts[len(parts)-1]
+		return base, tag
 	}
+	return name, ""
+}
+
+// NewTag returns a new Tag representing the given name, according to the given strictness.
+func NewTag(name string, opts ...Option) (Tag, error) {
+	opt := makeOptions(opts...)
+	base, tag := SplitTag(name)
 
 	// We don't require a tag, but if we get one check it's valid,
 	// even when not being strict.

--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -35,6 +35,9 @@ type ConfigFile struct {
 	Config          Config    `json:"config"`
 	ContainerConfig Config    `json:"container_config,omitempty"`
 	OSVersion       string    `json:"osversion,omitempty"`
+	ID              string    `json:"id,omitempty"`
+	Parent          string    `json:"parent,omitempty"`
+	Throwaway       bool      `json:"throwaway,omitempty"`
 }
 
 // History is one entry of a list recording how this container image was built.

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -110,6 +110,9 @@ type singleImageTarDescriptor struct {
 	LayerSources map[v1.Hash]v1.Descriptor `json:",omitempty"`
 }
 
+// repositoriesTarDescriptor represents the repositories file inside a `docker save` tarball.
+type repositoriesTarDescriptor map[string]map[string]string
+
 // tarDescriptor is the struct used inside the `manifest.json` file of a `docker save` tarball.
 type tarDescriptor []singleImageTarDescriptor
 

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -212,7 +212,11 @@ func WriteV1(ref name.Reference, img v1.Image, w io.Writer) error {
 // MultiWriteV1 writes the contents of each image to the provided reader, in the V1 image tarball format.
 // The contents are written in the following format:
 // One manifest.json file at the top level containing information about several images.
-// One file for each layer, named after the layer's SHA.
+// One repositories file mapping from the image <registry>/<repo name> to <tag> to the id of the top most layer.
+// For every layer, a directory named with the layer ID is created with the following contents:
+//   layer.tar - The uncompressed layer tarball.
+//   <layer id>.json- Layer metadata json.
+//   VERSION- Schema version string. Always set to "1.0".
 // One file for the config blob, named after its SHA.
 func MultiWriteV1(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
 	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -339,11 +339,12 @@ func MultiRefWriteV1(refToImage map[name.Reference]v1.Image, w io.Writer) error 
 		if err != nil {
 			return err
 		}
+		cfgFileName := fmt.Sprintf("%s.json", cfgName.Hex)
 		cfgBlob, err := img.RawConfigFile()
 		if err != nil {
 			return err
 		}
-		if err := writeTarEntry(tf, cfgName.Hex, bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
+		if err := writeTarEntry(tf, cfgFileName, bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
 			return err
 		}
 		cfg, err := img.ConfigFile()
@@ -420,7 +421,7 @@ func MultiRefWriteV1(refToImage map[name.Reference]v1.Image, w io.Writer) error 
 
 		// Generate the tar descriptor and write it.
 		sitd := singleImageTarDescriptor{
-			Config:       cfgName.Hex,
+			Config:       cfgFileName,
 			RepoTags:     tags,
 			Layers:       layerFiles,
 			LayerSources: layerSources,

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -17,10 +17,15 @@ package tarball
 import (
 	"archive/tar"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -174,6 +179,276 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 		return err
 	}
 	return writeTarEntry(tf, "manifest.json", bytes.NewReader(tdBytes), int64(len(tdBytes)))
+}
+
+// WriteToFileV1 writes in the compressed format to a tarball, on disk.
+// This is just syntactic sugar wrapping tarball.Write with a new file.
+func WriteToFileV1(p string, ref name.Reference, img v1.Image) error {
+	w, err := os.Create(p)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	return WriteV1(ref, img, w)
+}
+
+// MultiWriteToFileV1 writes in the V1 image tarball format to a tarball, on disk.
+// This is just syntactic sugar wrapping tarball.MultiWrite with a new file.
+func MultiWriteToFileV1(p string, tagToImage map[name.Tag]v1.Image) error {
+	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))
+	for i, d := range tagToImage {
+		refToImage[i] = d
+	}
+	return MultiRefWriteToFile(p, refToImage)
+}
+
+// MultiRefWriteToFileV1 writes in the V1 image tarball format to a tarball, on disk.
+// This is just syntactic sugar wrapping tarball.MultiRefWrite with a new file.
+func MultiRefWriteToFileV1(p string, refToImage map[name.Reference]v1.Image) error {
+	w, err := os.Create(p)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	return MultiRefWriteV1(refToImage, w)
+}
+
+// WriteV1 is a wrapper to write a single image in V1 format and tag to a tarball.
+func WriteV1(ref name.Reference, img v1.Image, w io.Writer) error {
+	return MultiRefWriteV1(map[name.Reference]v1.Image{ref: img}, w)
+}
+
+// MultiWriteV1 writes the contents of each image to the provided reader, in the V1 image tarball format.
+// The contents are written in the following format:
+// One manifest.json file at the top level containing information about several images.
+// One file for each layer, named after the layer's SHA.
+// One file for the config blob, named after its SHA.
+func MultiWriteV1(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
+	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))
+	for i, d := range tagToImage {
+		refToImage[i] = d
+	}
+	return MultiRefWriteV1(refToImage, w)
+}
+
+// v1Layer represents a layer with metadata needed by the v1 image spec https://github.com/moby/moby/blob/master/image/spec/v1.md.
+type v1Layer struct {
+	// config is the layer metadata.
+	config *v1.ConfigFile
+	// layer is the v1.Layer object this v1Layer represents.
+	layer v1.Layer
+}
+
+func (l *v1Layer) json() ([]byte, error) {
+	return json.Marshal(l.config)
+}
+
+func (l *v1Layer) version() []byte {
+	return []byte("1.0")
+}
+
+func v1LayerID(layer v1.Layer, parentID string, rawConfig []byte) (string, error) {
+	d, err := layer.Digest()
+	if err != nil {
+		return "", err
+	}
+	s := fmt.Sprintf("%s %s", d.Hex, parentID)
+	if len(rawConfig) != 0 {
+		s = fmt.Sprintf("%s %s", s, string(rawConfig))
+	}
+	rawDigest := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(rawDigest[:]), nil
+}
+
+func newV1Layer(layer v1.Layer, parent *v1Layer, history v1.History) (*v1Layer, error) {
+	parentID := ""
+	if parent != nil {
+		parentID = parent.config.ID
+	}
+	id, err := v1LayerID(layer, parentID, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to generate v1 layer ID")
+	}
+	result := &v1Layer{
+		layer: layer,
+		config: &v1.ConfigFile{
+			ID:      id,
+			Parent:  parentID,
+			Created: history.Created,
+			Author:  history.Author,
+			ContainerConfig: v1.Config{
+				Cmd: []string{history.CreatedBy},
+			},
+			Throwaway: history.EmptyLayer,
+		},
+	}
+	return result, nil
+}
+
+func newTopV1Layer(layer v1.Layer, parent *v1Layer, history v1.History, imgConfig *v1.ConfigFile, rawConfig []byte) (*v1Layer, error) {
+	result, err := newV1Layer(layer, parent, history)
+	if err != nil {
+		return nil, err
+	}
+	id, err := v1LayerID(layer, result.config.Parent, rawConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to generate v1 layer ID for top layer")
+	}
+	result.config.ID = id
+	result.config.Architecture = imgConfig.Architecture
+	result.config.Container = imgConfig.Container
+	result.config.DockerVersion = imgConfig.DockerVersion
+	result.config.OS = imgConfig.OS
+	result.config.Config = imgConfig.Config
+	result.config.ContainerConfig = imgConfig.ContainerConfig
+	result.config.Created = imgConfig.Created
+	return result, nil
+}
+
+func addTags(repos repositoriesTarDescriptor, tags []string, topLayerID string) error {
+	for _, t := range tags {
+		base, tag := name.SplitTag(t)
+		tagToID, ok := repos[base]
+		if !ok {
+			tagToID = make(map[string]string)
+			repos[base] = tagToID
+		}
+		tagToID[tag] = topLayerID
+	}
+	return nil
+}
+
+// MultiRefWriteV1 writes the contents of each image to the provided reader, in the V1 image tarball format.
+// The contents are written in the following format:
+// One manifest.json file at the top level containing information about several images.
+// One file for each layer, named after the layer's SHA.
+// One file for the config blob, named after its SHA.
+func MultiRefWriteV1(refToImage map[name.Reference]v1.Image, w io.Writer) error {
+	tf := tar.NewWriter(w)
+	defer tf.Close()
+
+	imageToTags := dedupRefToImage(refToImage)
+	var td tarDescriptor
+	repos := make(repositoriesTarDescriptor)
+
+	for img, tags := range imageToTags {
+		// Write the config.
+		cfgName, err := img.ConfigName()
+		if err != nil {
+			return err
+		}
+		cfgBlob, err := img.RawConfigFile()
+		if err != nil {
+			return err
+		}
+		if err := writeTarEntry(tf, cfgName.Hex, bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
+			return err
+		}
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			return err
+		}
+
+		// Store foreign layer info.
+		layerSources := make(map[v1.Hash]v1.Descriptor)
+
+		// Write the layers.
+		layers, err := img.Layers()
+		if err != nil {
+			return err
+		}
+		layerFiles := make([]string, len(layers))
+		var prev *v1Layer
+		for i, l := range layers {
+			d, err := l.Digest()
+			if err != nil {
+				return err
+			}
+
+			// Add to LayerSources if it's a foreign layer.
+			desc, err := partial.BlobDescriptor(img, d)
+			if err != nil {
+				return err
+			}
+			if !desc.MediaType.IsDistributable() {
+				diffid, err := partial.BlobToDiffID(img, d)
+				if err != nil {
+					return err
+				}
+				layerSources[diffid] = desc
+			}
+			var cur *v1Layer
+			if i < (len(layers) - 1) {
+				cur, err = newV1Layer(l, prev, cfg.History[i])
+			} else {
+				cur, err = newTopV1Layer(l, prev, cfg.History[i], cfg, cfgBlob)
+			}
+			if err != nil {
+				return err
+			}
+			layerFiles[i] = fmt.Sprintf("%s/layer.tar", cur.config.ID)
+			u, err := l.Uncompressed()
+			if err != nil {
+				return err
+			}
+			defer u.Close()
+			// Reads the entire uncompressed blob into memory! Can be avoided
+			// for some layer implementations where the uncompressed blob is
+			// stored on disk and the layer can just stat the file.
+			uncompressedBlob, err := ioutil.ReadAll(u)
+			if err != nil {
+				return err
+			}
+			if err := writeTarEntry(tf, layerFiles[i], bytes.NewReader(uncompressedBlob), int64(len(uncompressedBlob))); err != nil {
+				return err
+			}
+			j, err := cur.json()
+			if err != nil {
+				return err
+			}
+			if err := writeTarEntry(tf, fmt.Sprintf("%s/json", cur.config.ID), bytes.NewReader(j), int64(len(j))); err != nil {
+				return err
+			}
+			v := cur.version()
+			if err := writeTarEntry(tf, fmt.Sprintf("%s/VERSION", cur.config.ID), bytes.NewReader(v), int64(len(v))); err != nil {
+				return err
+			}
+			prev = cur
+		}
+
+		// Generate the tar descriptor and write it.
+		sitd := singleImageTarDescriptor{
+			Config:       cfgName.Hex,
+			RepoTags:     tags,
+			Layers:       layerFiles,
+			LayerSources: layerSources,
+		}
+
+		td = append(td, sitd)
+		// prev should be the top layer here. Use it to add the image tags
+		// to the tarball repositories file.
+		if err := addTags(repos, tags, prev.config.ID); err != nil {
+			return errors.Wrapf(err, "unable to add image tags to the repositories file")
+		}
+	}
+
+	tdBytes, err := json.Marshal(td)
+	if err != nil {
+		return err
+	}
+	if err := writeTarEntry(tf, "manifest.json", bytes.NewReader(tdBytes), int64(len(tdBytes))); err != nil {
+		return err
+	}
+	reposBytes, err := json.Marshal(&repos)
+	if err != nil {
+		return err
+	}
+	if err := writeTarEntry(tf, "repositories", bytes.NewReader(reposBytes), int64(len(reposBytes))); err != nil {
+		return err
+	}
+	return nil
 }
 
 func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]string {

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -200,7 +200,7 @@ func MultiWriteToFileV1(p string, tagToImage map[name.Tag]v1.Image) error {
 	for i, d := range tagToImage {
 		refToImage[i] = d
 	}
-	return MultiRefWriteToFile(p, refToImage)
+	return MultiRefWriteToFileV1(p, refToImage)
 }
 
 // MultiRefWriteToFileV1 writes in the V1 image tarball format to a tarball, on disk.


### PR DESCRIPTION
Fixes #526 
Add functions that can generate docker image tarballs in the v1 format. This is what `docker save` generates by default in version `18.09.3` today.