### PR TITLE
Preserve tag when writing to a tagged and digested image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 This is a golang library for working with container registries.
 It's largely based on the [Python library of the same name](https://github.com/google/containerregistry).
 
+When copying a schema v2 image, this library preserves the image's repository digest.
+
 The following diagram shows the main types that this library handles.
 ![OCI image representation](images/ociimage.jpeg)
 

--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -32,7 +32,7 @@ func Copy(src, dst string) error {
 		return fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
-	dstRef, err := name.ParseReference(dst)
+	dstRef, err := name.ParseWriteReference(dst)
 	if err != nil {
 		return fmt.Errorf("parsing reference for %q: %v", dst, err)
 	}

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -66,16 +66,8 @@ func checkDigest(name string) error {
 
 // NewDigest returns a new Digest representing the given name.
 func NewDigest(name string, opts ...Option) (Digest, error) {
-	// Split on "@"
-	parts := strings.Split(name, digestDelim)
-	if len(parts) != 2 {
-		return Digest{}, NewErrBadName("a digest must contain exactly one '@' separator (e.g. registry/repository@digest) saw: %s", name)
-	}
-	base := parts[0]
-	digest := parts[1]
-
-	// Always check that the digest is valid.
-	if err := checkDigest(digest); err != nil {
+	base, digest, err := splitDigest(name)
+	if err != nil {
 		return Digest{}, err
 	}
 
@@ -93,4 +85,20 @@ func NewDigest(name string, opts ...Option) (Digest, error) {
 		digest:     digest,
 		original:   name,
 	}, nil
+}
+
+func splitDigest(name string) (string, string, error) {
+	// Split on "@"
+	parts := strings.Split(name, digestDelim)
+	if len(parts) != 2 {
+		return "", "", NewErrBadName("a digest must contain exactly one '@' separator (e.g. registry/repository@digest) saw: %s", name)
+	}
+	base, digest := parts[0], parts[1]
+
+	// Always check that the digest is valid.
+	if err := checkDigest(digest); err != nil {
+		return "", "", err
+	}
+
+	return base, digest, nil
 }

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -37,6 +37,7 @@ type Reference interface {
 }
 
 // ParseReference parses the string as a reference, either by tag or digest.
+// If there is both a tag and a digest, the tag is discarded.
 func ParseReference(s string, opts ...Option) (Reference, error) {
 	if t, err := NewTag(s, opts...); err == nil {
 		return t, nil
@@ -46,4 +47,15 @@ func ParseReference(s string, opts ...Option) (Reference, error) {
 	}
 	return nil, NewErrBadName("could not parse reference: " + s)
 
+}
+
+// ParseWriteReference parses the string as a reference, either by tag or digest.
+// If there is both a tag and a digest, the digest is discarded.
+func ParseWriteReference(s string, opts ...Option) (Reference, error) {
+	if base, _, err := splitDigest(s); err == nil {
+		if t, err := NewTag(base, opts...); err == nil && t.explicitTag() {
+			return t, nil
+		}
+	}
+	return ParseReference(s, opts...)
 }

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,36 @@ func TestParseReference(t *testing.T) {
 		if err != nil {
 			t.Errorf("ParseReference(%q); %v", name, err)
 		}
+		dig, err := NewDigest(name, StrictValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+	}
+
+	for _, name := range goodWeakValidationTagDigestNames {
+		ref, err := ParseReference(name, WeakValidation)
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", name, err)
+		}
+
+		dig, err := NewDigest(name, WeakValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+	}
+
+	for _, name := range goodStrictValidationTagDigestNames {
+		ref, err := ParseReference(name, StrictValidation)
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", name, err)
+		}
+
 		dig, err := NewDigest(name, StrictValidation)
 		if err != nil {
 			t.Errorf("NewDigest(%q); %v", name, err)
@@ -84,6 +115,108 @@ func TestParseReference(t *testing.T) {
 	for _, name := range badTagNames {
 		if _, err := ParseReference(name, WeakValidation); err == nil {
 			t.Errorf("ParseReference(%q); expected error, got none", name)
+		}
+	}
+}
+
+func TestParseWriteReference(t *testing.T) {
+	for _, name := range goodWeakValidationDigestNames {
+		ref, err := ParseWriteReference(name, WeakValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		dig, err := NewDigest(name, WeakValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseWriteReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+	}
+
+	for _, name := range goodStrictValidationDigestNames {
+		ref, err := ParseWriteReference(name, StrictValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		dig, err := NewDigest(name, StrictValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseWriteReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+	}
+
+	for _, name := range badDigestNames {
+		if _, err := ParseWriteReference(name, WeakValidation); err == nil {
+			t.Errorf("ParseWriteReference(%q); expected error, got none", name)
+		}
+	}
+
+	for _, name := range goodWeakValidationTagNames {
+		ref, err := ParseWriteReference(name, WeakValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		tag, err := NewTag(name, WeakValidation)
+		if err != nil {
+			t.Errorf("NewTag(%q); %v", name, err)
+		}
+		if ref != tag {
+			t.Errorf("ParseWriteReference(%q) != NewTag(%q); got %v, want %v", name, name, ref, tag)
+		}
+	}
+
+	for _, name := range goodStrictValidationTagNames {
+		ref, err := ParseWriteReference(name, StrictValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		tag, err := NewTag(name, StrictValidation)
+		if err != nil {
+			t.Errorf("NewTag(%q); %v", name, err)
+		}
+		if ref != tag {
+			t.Errorf("ParseWriteReference(%q) != NewTag(%q); got %v, want %v", name, name, ref, tag)
+		}
+	}
+
+	for _, name := range goodStrictValidationTagDigestNames {
+		ref, err := ParseWriteReference(name, StrictValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		base := strings.Split(name, digestDelim)[0]
+
+		tag, err := NewTag(base, StrictValidation)
+		if err != nil {
+			t.Errorf("NewTag(%q); %v", base, err)
+		}
+		if ref != tag {
+			t.Errorf("ParseWriteReference(%q) != NewTag(%q); got %v, want %v", name, base, ref, tag)
+		}
+	}
+
+	for _, name := range goodWeakValidationTagDigestNames {
+		ref, err := ParseWriteReference(name, WeakValidation)
+		if err != nil {
+			t.Errorf("ParseWriteReference(%q); %v", name, err)
+		}
+		base := strings.Split(name, digestDelim)[0]
+
+		tag, err := NewTag(base, WeakValidation)
+		if err != nil {
+			t.Errorf("NewTag(%q); %v", base, err)
+		}
+		if ref != tag {
+			t.Errorf("ParseWriteReference(%q) != NewTag(%q); got %v, want %v", name, base, ref, tag)
+		}
+	}
+
+	for _, name := range badTagNames {
+		if _, err := ParseWriteReference(name, WeakValidation); err == nil {
+			t.Errorf("ParseWriteReference(%q); expected error, got none", name)
 		}
 	}
 }

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -45,9 +45,14 @@ func (t Tag) Identifier() string {
 	return t.TagStr()
 }
 
+// explicitTag returns true if and only if a tag was explicitly specified.
+func (t Tag) explicitTag() bool {
+	return t.tag != ""
+}
+
 // TagStr returns the tag component of the Tag.
 func (t Tag) TagStr() string {
-	if t.tag != "" {
+	if t.explicitTag() {
 		return t.tag
 	}
 	return defaultTag


### PR DESCRIPTION
This is a less integrated solution which essentially fixes the problem for crane and leaves it up to users of the library to opt in.

Fixes https://github.com/google/go-containerregistry/issues/540