### PR TITLE
Preserve tag when writing to a tagged and digested image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 This is a golang library for working with container registries.
 It's largely based on the [Python library of the same name](https://github.com/google/containerregistry).
 
+When copying a schema v2 image, this library preserves the image's repository digest.
+
 The following diagram shows the main types that this library handles.
 ![OCI image representation](images/ociimage.jpeg)
 

--- a/pkg/internal/legacy/copy.go
+++ b/pkg/internal/legacy/copy.go
@@ -32,6 +32,7 @@ import (
 // CopySchema1 allows `[g]crane cp` to work with old images without adding
 // full support for schema 1 images to this package.
 func CopySchema1(desc *remote.Descriptor, srcRef, dstRef name.Reference, srcAuth, dstAuth authn.Authenticator) error {
+	dstRef = dstRef.WriteTarget()
 	m := schema1{}
 	if err := json.NewDecoder(bytes.NewReader(desc.Manifest)).Decode(&m); err != nil {
 		return err

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -34,6 +34,9 @@ type Reference interface {
 
 	// Scope is the scope needed to access this reference.
 	Scope(string) string
+
+	// WriteTarget has a tag rather than a digest when both are present.
+	WriteTarget() Reference
 }
 
 // ParseReference parses the string as a reference, either by tag or digest.

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -31,6 +31,7 @@ func TestParseReference(t *testing.T) {
 		if ref != dig {
 			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
 		}
+		checkRefIsWriteTarget(ref, t)
 	}
 
 	for _, name := range goodStrictValidationDigestNames {
@@ -45,6 +46,39 @@ func TestParseReference(t *testing.T) {
 		if ref != dig {
 			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
 		}
+		checkRefIsWriteTarget(ref, t)
+	}
+
+	for _, name := range goodWeakValidationTagDigestNames {
+		ref, err := ParseReference(name, WeakValidation)
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", name, err)
+		}
+
+		dig, err := NewDigest(name, WeakValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+		checkWriteTarget(ref, dig, t)
+	}
+
+	for _, name := range goodStrictValidationTagDigestNames {
+		ref, err := ParseReference(name, StrictValidation)
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", name, err)
+		}
+
+		dig, err := NewDigest(name, StrictValidation)
+		if err != nil {
+			t.Errorf("NewDigest(%q); %v", name, err)
+		}
+		if ref != dig {
+			t.Errorf("ParseReference(%q) != NewDigest(%q); got %v, want %v", name, name, ref, dig)
+		}
+		checkWriteTarget(ref, dig, t)
 	}
 
 	for _, name := range badDigestNames {
@@ -65,6 +99,7 @@ func TestParseReference(t *testing.T) {
 		if ref != tag {
 			t.Errorf("ParseReference(%q) != NewTag(%q); got %v, want %v", name, name, ref, tag)
 		}
+		checkRefIsWriteTarget(ref, t)
 	}
 
 	for _, name := range goodStrictValidationTagNames {
@@ -79,11 +114,24 @@ func TestParseReference(t *testing.T) {
 		if ref != tag {
 			t.Errorf("ParseReference(%q) != NewTag(%q); got %v, want %v", name, name, ref, tag)
 		}
+		checkRefIsWriteTarget(ref, t)
 	}
 
 	for _, name := range badTagNames {
 		if _, err := ParseReference(name, WeakValidation); err == nil {
 			t.Errorf("ParseReference(%q); expected error, got none", name)
 		}
+	}
+}
+
+func checkRefIsWriteTarget(ref Reference, t *testing.T) {
+	if ref != ref.WriteTarget() {
+		t.Errorf("ref != ref.WriteTarget(); r=%v, ref.WriteTarget()=%v", ref, ref.WriteTarget())
+	}
+}
+
+func checkWriteTarget(ref Reference, dig Digest, t *testing.T) {
+	if ref.String() != ref.WriteTarget().String()+"@"+dig.DigestStr() {
+		t.Errorf("ref.WriteTarget() is not the original ref with the digest removed; ref.String()=%v, ref.WriteTarget().String()=%v", ref.String(), ref.WriteTarget().String())
 	}
 }

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -28,8 +28,8 @@ const (
 // Tag stores a docker tag name in a structured form.
 type Tag struct {
 	Repository
-	tag      string
-	original string
+	tag         string
+	original    string
 }
 
 // Ensure Tag implements Reference
@@ -45,9 +45,14 @@ func (t Tag) Identifier() string {
 	return t.TagStr()
 }
 
+// explicitTag returns true if and only if a tag was explicitly specified.
+func (t Tag) explicitTag() bool {
+	return t.tag != ""
+}
+
 // TagStr returns the tag component of the Tag.
 func (t Tag) TagStr() string {
-	if t.tag != "" {
+	if t.explicitTag() {
 		return t.tag
 	}
 	return defaultTag
@@ -66,6 +71,11 @@ func (t Tag) String() string {
 // Scope returns the scope required to perform the given action on the tag.
 func (t Tag) Scope(action string) string {
 	return t.Repository.Scope(action)
+}
+
+// WriteTarget has a tag rather than a digest when both are present.
+func (t Tag) WriteTarget() Reference {
+	return t
 }
 
 func checkTag(name string) error {

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -42,6 +42,7 @@ type Taggable interface {
 
 // Write pushes the provided img to the specified image reference.
 func Write(ref name.Reference, img v1.Image, options ...Option) error {
+	ref = ref.WriteTarget()
 	ls, err := img.Layers()
 	if err != nil {
 		return err
@@ -434,6 +435,7 @@ func scopesForUploadingImage(ref name.Reference, layers []v1.Layer) []string {
 // WriteIndex will attempt to push all of the referenced manifests before
 // attempting to push the ImageIndex, to retain referential integrity.
 func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
+	ref = ref.WriteTarget()
 	index, err := ii.IndexManifest()
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a more integrated solution which fixes the problem for crane and all users of the library, without giving them the ability to opt out. Compare the less integrated solution https://github.com/google/go-containerregistry/pull/541.

Fixes https://github.com/google/go-containerregistry/issues/540