### PR TITLE
tarball: Fix lint failure

### DIFF
--- a/pkg/legacy/tarball/write.go
+++ b/pkg/legacy/tarball/write.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package tarball
 
 import (


### PR DESCRIPTION
Without this newline, lint + go think the license is a package comment