### PR TITLE
Implement pkg/internal/compare, use it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	golang.org/x/tools v0.0.0-20191002161851-3769738f410b // indirect
+	golang.org/x/tools v0.0.0-20191003162220-c56b4b191e2d // indirect
 	google.golang.org/appengine v1.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	golang.org/x/tools v0.0.0-20191001184121-329c8d646ebe // indirect
+	golang.org/x/tools v0.0.0-20191002161851-3769738f410b // indirect
 	google.golang.org/appengine v1.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ golang.org/x/tools v0.0.0-20191001184121-329c8d646ebe h1:hFr8KcN0dM0/dqbUW0KZYN+
 golang.org/x/tools v0.0.0-20191001184121-329c8d646ebe/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191002161851-3769738f410b h1:H3xgcuTEMnlg2n7BT6mWCOGuMchcPTaZ/uCC9GuV05M=
 golang.org/x/tools v0.0.0-20191002161851-3769738f410b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191003162220-c56b4b191e2d h1:xzbfnqkhzcf2qHVgbBaXlaj+JlFOxT6P/oe2+yVuwBE=
+golang.org/x/tools v0.0.0-20191003162220-c56b4b191e2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ golang.org/x/tools v0.0.0-20190926165942-a8d5d34286bd h1:L7bTtbmMojUZYEAt0OrTU0Z
 golang.org/x/tools v0.0.0-20190926165942-a8d5d34286bd/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191001184121-329c8d646ebe h1:hFr8KcN0dM0/dqbUW0KZYN+YXJeZBpBWIG9ZkMuX1vQ=
 golang.org/x/tools v0.0.0-20191001184121-329c8d646ebe/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191002161851-3769738f410b h1:H3xgcuTEMnlg2n7BT6mWCOGuMchcPTaZ/uCC9GuV05M=
+golang.org/x/tools v0.0.0-20191002161851-3769738f410b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/internal/compare/doc.go
+++ b/pkg/internal/compare/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package compare provides methods for comparing images, indexes, and layers.
+package compare

--- a/pkg/internal/compare/image.go
+++ b/pkg/internal/compare/image.go
@@ -99,7 +99,7 @@ func Images(a, b v1.Image) error {
 	for i := 0; i < len(layerss[0]); i++ {
 		if err := Layers(layerss[0][i], layerss[1][i]); err != nil {
 			// Wrap the error in newlines to delineate layer errors.
-			errs = append(errs, fmt.Sprintf("\n%v\n", err))
+			errs = append(errs, fmt.Sprintf("Layers[%d]: %v\n", i, err))
 		}
 	}
 

--- a/pkg/internal/compare/image.go
+++ b/pkg/internal/compare/image.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+// Images compares the given images to each other and returns an error if they
+// differ.
 func Images(imgs ...v1.Image) error {
 	if len(imgs) < 2 {
 		return fmt.Errorf("comparing %d images makes no sense", len(imgs))

--- a/pkg/internal/compare/image.go
+++ b/pkg/internal/compare/image.go
@@ -26,11 +26,7 @@ import (
 
 // Images compares the given images to each other and returns an error if they
 // differ.
-func Images(imgs ...v1.Image) error {
-	if len(imgs) < 2 {
-		return fmt.Errorf("comparing %d images makes no sense", len(imgs))
-	}
-
+func Images(a, b v1.Image) error {
 	digests := []v1.Hash{}
 	manifests := []*v1.Manifest{}
 	cns := []v1.Hash{}
@@ -40,7 +36,7 @@ func Images(imgs ...v1.Image) error {
 
 	errs := []string{}
 
-	for i, img := range imgs {
+	for i, img := range []v1.Image{a, b} {
 		layers, err := img.Layers()
 		if err != nil {
 			return err
@@ -103,12 +99,11 @@ func Images(imgs ...v1.Image) error {
 			if len(layerss[j]) > i {
 				layers = append(layers, layerss[j][i])
 			} else {
-				// If we have fewer layers than the first image, report an error,
-				// even though something else will catch it, we don't have to panic.
-				errs = append(errs, fmt.Sprintf("len(image[%d].Layers()) < len(image[0].Layers())", j))
+				// If we have fewer layers than the first image, abort with an error so we don't panic.
+				return fmt.Errorf("len(image[%d].Layers()) < len(image[0].Layers())", j)
 			}
 		}
-		if err := Layers(layers...); err != nil {
+		if err := Layers(layers[0], layers[1]); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/pkg/internal/compare/image.go
+++ b/pkg/internal/compare/image.go
@@ -1,0 +1,119 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func Images(imgs ...v1.Image) error {
+	if len(imgs) < 2 {
+		return fmt.Errorf("comparing %d images makes no sense", len(imgs))
+	}
+
+	digests := []v1.Hash{}
+	manifests := []*v1.Manifest{}
+	cns := []v1.Hash{}
+	sizes := []int64{}
+	mts := []types.MediaType{}
+	layerss := [][]v1.Layer{}
+
+	errs := []string{}
+
+	for i, img := range imgs {
+		layers, err := img.Layers()
+		if err != nil {
+			return err
+		}
+		layerss = append(layerss, layers)
+
+		digest, err := img.Digest()
+		if err != nil {
+			return err
+		}
+		digests = append(digests, digest)
+
+		manifest, err := img.Manifest()
+		if err != nil {
+			return err
+		}
+		manifests = append(manifests, manifest)
+
+		cn, err := img.ConfigName()
+		if err != nil {
+			return err
+		}
+		cns = append(cns, cn)
+
+		size, err := img.Size()
+		if err != nil {
+			return err
+		}
+		sizes = append(sizes, size)
+
+		mt, err := img.MediaType()
+		if err != nil {
+			return err
+		}
+		mts = append(mts, mt)
+
+		if i > 0 {
+			if want, got := digests[i-1], digests[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].Digest() != image[%d].Digest(); %s != %s", i-1, i, want, got))
+			}
+			if want, got := cns[i-1], cns[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].ConfigName() != image[%d].ConfigName(); %s != %s", i-1, i, want, got))
+			}
+			if want, got := manifests[i-1], manifests[i]; !reflect.DeepEqual(want, got) {
+				errs = append(errs, fmt.Sprintf("image[%d].Manifest() != image[%d].Manifest(); %v != %v", i-1, i, want, got))
+			}
+			if want, got := sizes[i-1], sizes[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].Size() != image[%d].Size(); %d != %d", i-1, i, want, got))
+			}
+			if want, got := mts[i-1], mts[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].MediaType() != image[%d].MediaType(); %s != %s", i-1, i, want, got))
+			}
+		}
+	}
+
+	// Compare layers all at once.
+	for i := 0; i < len(layerss[0]); i++ {
+		layers := []v1.Layer{}
+		for j := 0; j < len(layerss); j++ {
+			if len(layerss[j]) > i {
+				layers = append(layers, layerss[j][i])
+			} else {
+				// If we have fewer layers than the first image, report an error,
+				// even though something else will catch it, we don't have to panic.
+				errs = append(errs, fmt.Sprintf("len(image[%d].Layers()) < len(image[0].Layers())", j))
+			}
+		}
+		if err := Layers(layers...); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n\n"))
+	}
+
+	return nil
+}

--- a/pkg/internal/compare/image.go
+++ b/pkg/internal/compare/image.go
@@ -93,13 +93,13 @@ func Images(a, b v1.Image) error {
 	if len(layerss[0]) != len(layerss[1]) {
 		// If we have fewer layers than the first image, abort with an error so we don't panic.
 		return errors.New("len(a.Layers()) != len(b.Layers())")
-	} else {
-		// Compare each layer.
-		for i := 0; i < len(layerss[0]); i++ {
-			if err := Layers(layerss[0][i], layerss[1][i]); err != nil {
-				// Wrap the error in newlines to delineate layer errors.
-				errs = append(errs, fmt.Sprintf("\n%v\n", err))
-			}
+	}
+
+	// Compare each layer.
+	for i := 0; i < len(layerss[0]); i++ {
+		if err := Layers(layerss[0][i], layerss[1][i]); err != nil {
+			// Wrap the error in newlines to delineate layer errors.
+			errs = append(errs, fmt.Sprintf("\n%v\n", err))
 		}
 	}
 

--- a/pkg/internal/compare/image_test.go
+++ b/pkg/internal/compare/image_test.go
@@ -41,7 +41,7 @@ func TestEqualImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Images(a, a); err != nil {
+	if err := Images(a, a, a); err != nil {
 		t.Errorf("got err: %v", err)
 	}
 }

--- a/pkg/internal/compare/image_test.go
+++ b/pkg/internal/compare/image_test.go
@@ -41,13 +41,7 @@ func TestEqualImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Images(a, a, a); err != nil {
+	if err := Images(a, a); err != nil {
 		t.Errorf("got err: %v", err)
-	}
-}
-
-func TestSanityCheckImages(t *testing.T) {
-	if err := Images(); err == nil {
-		t.Errorf("comparing nothing makes no sense")
 	}
 }

--- a/pkg/internal/compare/image_test.go
+++ b/pkg/internal/compare/image_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func TestDifferentImages(t *testing.T) {
+	a, err := random.Image(100, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := random.Image(100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Images(a, b); err == nil {
+		t.Errorf("got nil err, should have something")
+	}
+}
+
+func TestEqualImages(t *testing.T) {
+	a, err := random.Image(100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Images(a, a); err != nil {
+		t.Errorf("got err: %v", err)
+	}
+}
+
+func TestSanityCheckImages(t *testing.T) {
+	if err := Images(); err == nil {
+		t.Errorf("comparing nothing makes no sense")
+	}
+}

--- a/pkg/internal/compare/index.go
+++ b/pkg/internal/compare/index.go
@@ -34,7 +34,7 @@ func Indexes(a, b v1.ImageIndex) error {
 
 	errs := []string{}
 
-	for i, idx := range []v1.ImageIndex{a, b} {
+	for _, idx := range []v1.ImageIndex{a, b} {
 		digest, err := idx.Digest()
 		if err != nil {
 			return err
@@ -58,27 +58,25 @@ func Indexes(a, b v1.ImageIndex) error {
 			return err
 		}
 		mts = append(mts, mt)
+	}
 
-		if i > 0 {
-			if want, got := digests[i-1], digests[i]; want != got {
-				errs = append(errs, fmt.Sprintf("image[%d].Digest() != image[%d].Digest(); %s != %s", i-1, i, want, got))
-			}
-			if want, got := manifests[i-1], manifests[i]; !reflect.DeepEqual(want, got) {
-				errs = append(errs, fmt.Sprintf("image[%d].Manifest() != image[%d].Manifest(); %v != %v", i-1, i, want, got))
-			}
-			if want, got := sizes[i-1], sizes[i]; want != got {
-				errs = append(errs, fmt.Sprintf("image[%d].Size() != image[%d].Size(); %d != %d", i-1, i, want, got))
-			}
-			if want, got := mts[i-1], mts[i]; want != got {
-				errs = append(errs, fmt.Sprintf("image[%d].MediaType() != image[%d].MediaType(); %s != %s", i-1, i, want, got))
-			}
-		}
+	if want, got := digests[0], digests[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.Digest() != b.Digest(); %s != %s", want, got))
+	}
+	if want, got := manifests[0], manifests[1]; !reflect.DeepEqual(want, got) {
+		errs = append(errs, fmt.Sprintf("a.Manifest() != b.Manifest(); %v != %v", want, got))
+	}
+	if want, got := sizes[0], sizes[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.Size() != b.Size(); %d != %d", want, got))
+	}
+	if want, got := mts[0], mts[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.MediaType() != b.MediaType(); %s != %s", want, got))
 	}
 
 	// TODO(jonjohnsonjr): Iterate over Manifest and compare Image and ImageIndex results.
 
 	if len(errs) != 0 {
-		return errors.New(strings.Join(errs, "\n\n"))
+		return errors.New("Indexes differ:\n" + strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/pkg/internal/compare/index.go
+++ b/pkg/internal/compare/index.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+// Indexes compares the given indexes to each other and returns an error if
+// they differ.
 func Indexes(idxs ...v1.ImageIndex) error {
 	if len(idxs) < 2 {
 		return fmt.Errorf("comparing %d indexes makes no sense", len(idxs))

--- a/pkg/internal/compare/index.go
+++ b/pkg/internal/compare/index.go
@@ -26,11 +26,7 @@ import (
 
 // Indexes compares the given indexes to each other and returns an error if
 // they differ.
-func Indexes(idxs ...v1.ImageIndex) error {
-	if len(idxs) < 2 {
-		return fmt.Errorf("comparing %d indexes makes no sense", len(idxs))
-	}
-
+func Indexes(a, b v1.ImageIndex) error {
 	digests := []v1.Hash{}
 	manifests := []*v1.IndexManifest{}
 	sizes := []int64{}
@@ -38,7 +34,7 @@ func Indexes(idxs ...v1.ImageIndex) error {
 
 	errs := []string{}
 
-	for i, idx := range idxs {
+	for i, idx := range []v1.ImageIndex{a, b} {
 		digest, err := idx.Digest()
 		if err != nil {
 			return err

--- a/pkg/internal/compare/index.go
+++ b/pkg/internal/compare/index.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func Indexes(idxs ...v1.ImageIndex) error {
+	if len(idxs) < 2 {
+		return fmt.Errorf("comparing %d indexes makes no sense", len(idxs))
+	}
+
+	digests := []v1.Hash{}
+	manifests := []*v1.IndexManifest{}
+	sizes := []int64{}
+	mts := []types.MediaType{}
+
+	errs := []string{}
+
+	for i, idx := range idxs {
+		digest, err := idx.Digest()
+		if err != nil {
+			return err
+		}
+		digests = append(digests, digest)
+
+		manifest, err := idx.IndexManifest()
+		if err != nil {
+			return err
+		}
+		manifests = append(manifests, manifest)
+
+		size, err := idx.Size()
+		if err != nil {
+			return err
+		}
+		sizes = append(sizes, size)
+
+		mt, err := idx.MediaType()
+		if err != nil {
+			return err
+		}
+		mts = append(mts, mt)
+
+		if i > 0 {
+			if want, got := digests[i-1], digests[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].Digest() != image[%d].Digest(); %s != %s", i-1, i, want, got))
+			}
+			if want, got := manifests[i-1], manifests[i]; !reflect.DeepEqual(want, got) {
+				errs = append(errs, fmt.Sprintf("image[%d].Manifest() != image[%d].Manifest(); %v != %v", i-1, i, want, got))
+			}
+			if want, got := sizes[i-1], sizes[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].Size() != image[%d].Size(); %d != %d", i-1, i, want, got))
+			}
+			if want, got := mts[i-1], mts[i]; want != got {
+				errs = append(errs, fmt.Sprintf("image[%d].MediaType() != image[%d].MediaType(); %s != %s", i-1, i, want, got))
+			}
+		}
+	}
+
+	// TODO(jonjohnsonjr): Iterate over Manifest and compare Image and ImageIndex results.
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n\n"))
+	}
+
+	return nil
+}

--- a/pkg/internal/compare/index_test.go
+++ b/pkg/internal/compare/index_test.go
@@ -41,7 +41,7 @@ func TestEqualIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Indexes(a, a); err != nil {
+	if err := Indexes(a, a, a); err != nil {
 		t.Errorf("got err: %v", err)
 	}
 }

--- a/pkg/internal/compare/index_test.go
+++ b/pkg/internal/compare/index_test.go
@@ -41,13 +41,7 @@ func TestEqualIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Indexes(a, a, a); err != nil {
+	if err := Indexes(a, a); err != nil {
 		t.Errorf("got err: %v", err)
-	}
-}
-
-func TestSanityCheckIndexes(t *testing.T) {
-	if err := Indexes(); err == nil {
-		t.Errorf("comparing nothing makes no sense")
 	}
 }

--- a/pkg/internal/compare/index_test.go
+++ b/pkg/internal/compare/index_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func TestDifferentIndexes(t *testing.T) {
+	a, err := random.Index(100, 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := random.Index(100, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Indexes(a, b); err == nil {
+		t.Errorf("got nil err, should have something")
+	}
+}
+
+func TestEqualIndexes(t *testing.T) {
+	a, err := random.Index(100, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Indexes(a, a); err != nil {
+		t.Errorf("got err: %v", err)
+	}
+}
+
+func TestSanityCheckIndexes(t *testing.T) {
+	if err := Indexes(); err == nil {
+		t.Errorf("comparing nothing makes no sense")
+	}
+}

--- a/pkg/internal/compare/layer.go
+++ b/pkg/internal/compare/layer.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// Layers compares the layers given to each other. Note that this does not compare
+// the actual contents (by calling Compressed or Uncompressed).
+func Layers(layers ...v1.Layer) error {
+	if len(layers) < 2 {
+		return fmt.Errorf("comparing %d layers makes no sense", len(layers))
+	}
+
+	digests := []v1.Hash{}
+	diffids := []v1.Hash{}
+	sizes := []int64{}
+	mts := []types.MediaType{}
+	errs := []string{}
+
+	for i, layer := range layers {
+		digest, err := layer.Digest()
+		if err != nil {
+			return err
+		}
+		digests = append(digests, digest)
+
+		diffid, err := layer.DiffID()
+		if err != nil {
+			return err
+		}
+		diffids = append(diffids, diffid)
+
+		size, err := layer.Size()
+		if err != nil {
+			return err
+		}
+		sizes = append(sizes, size)
+
+		mt, err := layer.MediaType()
+		if err != nil {
+			return err
+		}
+		mts = append(mts, mt)
+
+		if i > 0 {
+			if want, got := digests[i-1], digests[i]; want != got {
+				errs = append(errs, fmt.Sprintf("layer[%d].Digest() != layer[%d].Digest(); %s != %s", i-1, i, want, got))
+			}
+			if want, got := diffids[i-1], diffids[i]; want != got {
+				errs = append(errs, fmt.Sprintf("layer[%d].DiffID() != layer[%d].DiffID(); %s != %s", i-1, i, want, got))
+			}
+			if want, got := sizes[i-1], sizes[i]; want != got {
+				errs = append(errs, fmt.Sprintf("layer[%d].Size() != layer[%d].Size(); %d != %d", i-1, i, want, got))
+			}
+			if want, got := mts[i-1], mts[i]; want != got {
+				errs = append(errs, fmt.Sprintf("layer[%d].MediaType() != layer[%d].MediaType(); %s != %s", i-1, i, want, got))
+			}
+		}
+	}
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n\n"))
+	}
+
+	return nil
+}

--- a/pkg/internal/compare/layer.go
+++ b/pkg/internal/compare/layer.go
@@ -23,8 +23,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-// Layers compares the layers given to each other. Note that this does not compare
-// the actual contents (by calling Compressed or Uncompressed).
+// Layers compares the given layers to each other and returns an error if they
+// differ.  Note that this does not compare the actual contents (by calling
+// Compressed or Uncompressed).
 func Layers(layers ...v1.Layer) error {
 	if len(layers) < 2 {
 		return fmt.Errorf("comparing %d layers makes no sense", len(layers))

--- a/pkg/internal/compare/layer.go
+++ b/pkg/internal/compare/layer.go
@@ -26,18 +26,14 @@ import (
 // Layers compares the given layers to each other and returns an error if they
 // differ.  Note that this does not compare the actual contents (by calling
 // Compressed or Uncompressed).
-func Layers(layers ...v1.Layer) error {
-	if len(layers) < 2 {
-		return fmt.Errorf("comparing %d layers makes no sense", len(layers))
-	}
-
+func Layers(a, b v1.Layer) error {
 	digests := []v1.Hash{}
 	diffids := []v1.Hash{}
 	sizes := []int64{}
 	mts := []types.MediaType{}
 	errs := []string{}
 
-	for i, layer := range layers {
+	for i, layer := range []v1.Layer{a, b} {
 		digest, err := layer.Digest()
 		if err != nil {
 			return err

--- a/pkg/internal/compare/layer.go
+++ b/pkg/internal/compare/layer.go
@@ -33,7 +33,7 @@ func Layers(a, b v1.Layer) error {
 	mts := []types.MediaType{}
 	errs := []string{}
 
-	for i, layer := range []v1.Layer{a, b} {
+	for _, layer := range []v1.Layer{a, b} {
 		digest, err := layer.Digest()
 		if err != nil {
 			return err
@@ -57,25 +57,23 @@ func Layers(a, b v1.Layer) error {
 			return err
 		}
 		mts = append(mts, mt)
+	}
 
-		if i > 0 {
-			if want, got := digests[i-1], digests[i]; want != got {
-				errs = append(errs, fmt.Sprintf("layer[%d].Digest() != layer[%d].Digest(); %s != %s", i-1, i, want, got))
-			}
-			if want, got := diffids[i-1], diffids[i]; want != got {
-				errs = append(errs, fmt.Sprintf("layer[%d].DiffID() != layer[%d].DiffID(); %s != %s", i-1, i, want, got))
-			}
-			if want, got := sizes[i-1], sizes[i]; want != got {
-				errs = append(errs, fmt.Sprintf("layer[%d].Size() != layer[%d].Size(); %d != %d", i-1, i, want, got))
-			}
-			if want, got := mts[i-1], mts[i]; want != got {
-				errs = append(errs, fmt.Sprintf("layer[%d].MediaType() != layer[%d].MediaType(); %s != %s", i-1, i, want, got))
-			}
-		}
+	if want, got := digests[0], digests[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.Digest() != b.Digest(); %s != %s", want, got))
+	}
+	if want, got := diffids[0], diffids[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.DiffID() != b.DiffID(); %s != %s", want, got))
+	}
+	if want, got := sizes[0], sizes[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.Size() != b.Size(); %d != %d", want, got))
+	}
+	if want, got := mts[0], mts[1]; want != got {
+		errs = append(errs, fmt.Sprintf("a.MediaType() != b.MediaType(); %s != %s", want, got))
 	}
 
 	if len(errs) != 0 {
-		return errors.New(strings.Join(errs, "\n\n"))
+		return errors.New("Layers differ:\n" + strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/pkg/internal/compare/layer_test.go
+++ b/pkg/internal/compare/layer_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestDifferentLayers(t *testing.T) {
+	a, err := random.Layer(100, types.DockerLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := random.Layer(100, types.OCILayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Layers(a, b); err == nil {
+		t.Errorf("got nil err, should have something")
+	}
+}
+
+func TestEqualLayers(t *testing.T) {
+	a, err := random.Layer(100, types.DockerLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Layers(a, a); err != nil {
+		t.Errorf("got err: %v", err)
+	}
+}
+
+func TestSanityCheckLayers(t *testing.T) {
+	if err := Layers(); err == nil {
+		t.Errorf("comparing nothing makes no sense")
+	}
+}

--- a/pkg/internal/compare/layer_test.go
+++ b/pkg/internal/compare/layer_test.go
@@ -42,7 +42,7 @@ func TestEqualLayers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Layers(a, a); err != nil {
+	if err := Layers(a, a, a); err != nil {
 		t.Errorf("got err: %v", err)
 	}
 }

--- a/pkg/internal/compare/layer_test.go
+++ b/pkg/internal/compare/layer_test.go
@@ -42,13 +42,7 @@ func TestEqualLayers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Layers(a, a, a); err != nil {
+	if err := Layers(a, a); err != nil {
 		t.Errorf("got err: %v", err)
-	}
-}
-
-func TestSanityCheckLayers(t *testing.T) {
-	if err := Layers(); err == nil {
-		t.Errorf("comparing nothing makes no sense")
 	}
 }

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"io"
 	"os"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/internal/compare"
 	"github.com/google/go-containerregistry/pkg/name"
 
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -43,7 +43,7 @@ func init() {
 }
 
 func TestImage(t *testing.T) {
-	testImage, err := tarball.ImageFromPath(imagePath, nil)
+	img, err := tarball.ImageFromPath(imagePath, nil)
 	if err != nil {
 		t.Fatalf("error loading test image: %s", err)
 	}
@@ -60,21 +60,12 @@ func TestImage(t *testing.T) {
 		} else {
 			bufferedOption = WithUnbufferedOpener()
 		}
-		daemonImage, err := Image(tag, bufferedOption)
+		dmn, err := Image(tag, bufferedOption)
 		if err != nil {
 			t.Errorf("Error loading daemon image: %s", err)
 		}
-
-		dmfst, err := daemonImage.Manifest()
-		if err != nil {
-			t.Errorf("Error getting daemon manifest: %s", err)
-		}
-		tmfst, err := testImage.Manifest()
-		if err != nil {
-			t.Errorf("Error getting test manifest: %s", err)
-		}
-		if !reflect.DeepEqual(dmfst, tmfst) {
-			t.Errorf("%v != %v", testImage, daemonImage)
+		if err := compare.Images(img, dmn); err != nil {
+			t.Errorf("compare.Images: %v", err)
 		}
 	}
 

--- a/pkg/v1/tarball/layer_test.go
+++ b/pkg/v1/tarball/layer_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/internal/compare"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 func TestLayerFromFile(t *testing.T) {
@@ -41,6 +42,13 @@ func TestLayerFromFile(t *testing.T) {
 
 	if err := compare.Layers(tarLayer, tarGzLayer); err != nil {
 		t.Errorf("compare.Layers: %v", err)
+	}
+
+	if err := validate.Layer(tarLayer); err != nil {
+		t.Errorf("validate.Layer(tarLayer): %v", err)
+	}
+	if err := validate.Layer(tarGzLayer); err != nil {
+		t.Errorf("validate.Layer(tarGzLayer): %v", err)
 	}
 }
 


### PR DESCRIPTION
This drops a lot of testing boilerplate.

This is under pkg/internal for now because I'm not sure if I love the interface.