### PR TITLE
remote: Call Get() directly from remote.Image()

### DIFF
--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -43,15 +43,7 @@ var _ partial.CompressedImageCore = (*remoteImage)(nil)
 
 // Image provides access to a remote image reference.
 func Image(ref name.Reference, options ...Option) (v1.Image, error) {
-	acceptable := []types.MediaType{
-		types.DockerManifestSchema2,
-		types.OCIManifestSchema1,
-		// We resolve these to images later.
-		types.DockerManifestList,
-		types.OCIImageIndex,
-	}
-
-	desc, err := get(ref, acceptable, options...)
+	desc, err := Get(ref, options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The descriptor.Image() code handles docker v2schema1 images cleanly, but
the Image code resricts the list, causing certain repositories to return
ManifestUnknown for images that exist.

By using the Get function, we reduce code slightly and handle schema1
images with an error that doesn't appear to imply that the image does
not exist.