### PR TITLE
Enable pass options to name package in case of fat image

### DIFF
--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -120,7 +120,7 @@ func get(ref name.Reference, acceptable []types.MediaType, options ...Option) (*
 // a child image with the appropriate platform.
 //
 // See WithPlatform to set the desired platform.
-func (d *Descriptor) Image() (v1.Image, error) {
+func (d *Descriptor) Image(opts ...name.Option) (v1.Image, error) {
 	switch d.MediaType {
 	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
 		// We don't care to support schema 1 images:
@@ -128,7 +128,7 @@ func (d *Descriptor) Image() (v1.Image, error) {
 		return nil, newErrSchema1(d.MediaType)
 	case types.OCIImageIndex, types.DockerManifestList:
 		// We want an image but the registry has an index, resolve it to an image.
-		return d.remoteIndex().imageByPlatform(d.platform)
+		return d.remoteIndex().imageByPlatform(d.platform, opts...)
 	case types.OCIManifestSchema1, types.DockerManifestSchema2:
 		// These are expected. Enumerated here to allow a default case.
 	default:

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -48,7 +48,11 @@ func Image(ref name.Reference, options ...Option) (v1.Image, error) {
 		return nil, err
 	}
 
-	return desc.Image()
+	nameOpts, err := makeNameOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+	return desc.Image(nameOpts...)
 }
 
 func (r *remoteImage) MediaType() (types.MediaType, error) {

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -113,8 +113,8 @@ func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
 	return desc.ImageIndex()
 }
 
-func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
-	desc, err := r.childByPlatform(platform)
+func (r *remoteIndex) imageByPlatform(platform v1.Platform, opts ...name.Option) (v1.Image, error) {
+	desc, err := r.childByPlatform(platform, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
 //
 // But first we'd need to migrate to:
 //   github.com/opencontainers/image-spec/specs-go/v1
-func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error) {
+func (r *remoteIndex) childByPlatform(platform v1.Platform, opts ...name.Option) (*Descriptor, error) {
 	index, err := r.IndexManifest()
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error)
 		}
 
 		if matchesPlatform(p, platform) {
-			return r.childDescriptor(childDesc, platform)
+			return r.childDescriptor(childDesc, platform, opts...)
 		}
 	}
 	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.Architecture, platform.OS, r.Ref)
@@ -162,13 +162,13 @@ func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {
 	return nil, fmt.Errorf("no child with digest %s in index %s", h, r.Ref)
 }
 
-func (r *remoteIndex) childRef(h v1.Hash) (name.Reference, error) {
-	return name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+func (r *remoteIndex) childRef(h v1.Hash, opts ...name.Option) (name.Reference, error) {
+	return name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), append(opts, name.StrictValidation)...)
 }
 
 // Convert one of this index's child's v1.Descriptor into a remote.Descriptor, with the given platform option.
-func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform) (*Descriptor, error) {
-	ref, err := r.childRef(child.Digest)
+func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform, opts ...name.Option) (*Descriptor, error) {
+	ref, err := r.childRef(child.Digest, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
@@ -31,6 +32,7 @@ type options struct {
 	keychain  authn.Keychain
 	transport http.RoundTripper
 	platform  v1.Platform
+	nameOpts  []name.Option
 }
 
 func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
@@ -61,6 +63,17 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 	o.transport = transport.NewRetry(o.transport)
 
 	return o, nil
+}
+
+func makeNameOptions(opts ...Option) ([]name.Option, error) {
+	o := &options{}
+	for _, option := range opts {
+		if err := option(o); err != nil {
+			return nil, err
+		}
+	}
+
+	return o.nameOpts, nil
 }
 
 // WithTransport is a functional option for overriding the default transport
@@ -104,6 +117,15 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 func WithPlatform(p v1.Platform) Option {
 	return func(o *options) error {
 		o.platform = p
+		return nil
+	}
+}
+
+// WithNameOptions is options to pass to the name package when a child image
+// of a fat image is fetched.
+func WithNameOptionsForChildren(opts ...name.Option) Option {
+	return func(o *options) error {
+		o.nameOpts = opts
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes: #563

Currently, we can't specify options(i.e. insecure options) of name package to
child images referenced by a fat image by index.
This commit solves this issue by enabling to pass options to name packages even
for references of child images of a fat image.

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>