### PR TITLE
Add name.Repository helpers

### DIFF
--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -56,11 +56,7 @@ func Save(img v1.Image, src, path string) error {
 		if !ok {
 			return fmt.Errorf("ref wasn't a tag or digest")
 		}
-		s := fmt.Sprintf("%s:%s", d.Repository.Name(), iWasADigestTag)
-		tag, err = name.NewTag(s)
-		if err != nil {
-			return fmt.Errorf("parsing digest as tag (%s): %v", s, err)
-		}
+		tag = d.Repository.Tag(iWasADigestTag)
 	}
 
 	return tarball.WriteToFile(path, tag, img)

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -386,13 +386,9 @@ func (c *copier) copyImages(ctx context.Context, t task) error {
 
 	// Copy the rest of the tags.
 	for _, tag := range t.manifest.Tags[1:] {
-		dstImg := fmt.Sprintf("%s:%s", t.newRepo, tag)
-		t, err := name.NewTag(dstImg)
-		if err != nil {
-			return err
-		}
+		dstImg := t.newRepo.Tag(tag)
 
-		if err := remote.Tag(t, taggable, remote.WithAuth(c.dstAuth)); err != nil {
+		if err := remote.Tag(dstImg, taggable, remote.WithAuth(c.dstAuth)); err != nil {
 			return err
 		}
 	}

--- a/pkg/internal/legacy/copy.go
+++ b/pkg/internal/legacy/copy.go
@@ -38,23 +38,15 @@ func CopySchema1(desc *remote.Descriptor, srcRef, dstRef name.Reference, srcAuth
 	}
 
 	for _, layer := range m.FSLayers {
-		src := fmt.Sprintf("%s@%s", srcRef.Context(), layer.BlobSum)
-		blobSrc, err := name.NewDigest(src)
-		if err != nil {
-			return err
-		}
-		dst := fmt.Sprintf("%s@%s", dstRef.Context(), layer.BlobSum)
-		blobDst, err := name.NewDigest(dst)
+		src := srcRef.Context().Digest(layer.BlobSum)
+		dst := dstRef.Context().Digest(layer.BlobSum)
+
+		blob, err := remote.Layer(src, remote.WithAuth(srcAuth))
 		if err != nil {
 			return err
 		}
 
-		blob, err := remote.Layer(blobSrc, remote.WithAuth(srcAuth))
-		if err != nil {
-			return err
-		}
-
-		if err := remote.WriteLayer(blobDst, blob, remote.WithAuth(dstAuth)); err != nil {
+		if err := remote.WriteLayer(dst, blob, remote.WithAuth(dstAuth)); err != nil {
 			return err
 		}
 	}

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -100,6 +100,7 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 	return Repository{reg, repo}, nil
 }
 
+// Tag returns a Tag in this Repository.
 func (r Repository) Tag(identifier string) Tag {
 	t := Tag{
 		tag:        identifier,
@@ -109,6 +110,7 @@ func (r Repository) Tag(identifier string) Tag {
 	return t
 }
 
+// Digest returns a Digest in this Repository.
 func (r Repository) Digest(identifier string) Digest {
 	d := Digest{
 		digest:     identifier,

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -99,3 +99,21 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 	}
 	return Repository{reg, repo}, nil
 }
+
+func (r Repository) Tag(identifier string) Tag {
+	t := Tag{
+		tag:        identifier,
+		Repository: r,
+	}
+	t.original = t.Name()
+	return t
+}
+
+func (r Repository) Digest(identifier string) Digest {
+	d := Digest{
+		digest:     identifier,
+		Repository: r,
+	}
+	d.original = d.Name()
+	return d
+}

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -120,3 +120,18 @@ func TestRepositoryBadDefaulting(t *testing.T) {
 		t.Errorf("IsBadErrName == false: %v", err)
 	}
 }
+
+func TestRepositoryChildren(t *testing.T) {
+	repo, err := NewRepository("ubuntu", Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tag := repo.Tag("foo")
+	if got, want := tag.Scheme(), "http"; got != want {
+		t.Errorf("tag.Scheme(): got %s want %s", got, want)
+	}
+	digest := repo.Digest("badf00d")
+	if got, want := digest.Scheme(), "http"; got != want {
+		t.Errorf("digest.Scheme(): got %s want %s", got, want)
+	}
+}

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -122,7 +122,7 @@ func TestRepositoryBadDefaulting(t *testing.T) {
 }
 
 func TestRepositoryChildren(t *testing.T) {
-	repo, err := NewRepository("ubuntu", Insecure)
+	repo, err := NewRepository("example.com/repo", Insecure)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,8 +130,14 @@ func TestRepositoryChildren(t *testing.T) {
 	if got, want := tag.Scheme(), "http"; got != want {
 		t.Errorf("tag.Scheme(): got %s want %s", got, want)
 	}
+	if got, want := tag.String(), "example.com/repo:foo"; got != want {
+		t.Errorf("tag.String(): got %s want %s", got, want)
+	}
 	digest := repo.Digest("badf00d")
 	if got, want := digest.Scheme(), "http"; got != want {
 		t.Errorf("digest.Scheme(): got %s want %s", got, want)
+	}
+	if got, want := digest.String(), "example.com/repo@badf00d"; got != want {
+		t.Errorf("digest.String(): got %s want %s", got, want)
 	}
 }

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -162,13 +162,9 @@ func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {
 	return nil, fmt.Errorf("no child with digest %s in index %s", h, r.Ref)
 }
 
-func (r *remoteIndex) childRef(h v1.Hash) name.Reference {
-	return r.Ref.Context().Digest(h.String())
-}
-
 // Convert one of this index's child's v1.Descriptor into a remote.Descriptor, with the given platform option.
 func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform) (*Descriptor, error) {
-	ref := r.childRef(child.Digest)
+	ref := r.Ref.Context().Digest(child.Digest.String())
 	manifest, desc, err := r.fetchManifest(ref, []types.MediaType{child.MediaType})
 	if err != nil {
 		return nil, err

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -162,16 +162,13 @@ func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {
 	return nil, fmt.Errorf("no child with digest %s in index %s", h, r.Ref)
 }
 
-func (r *remoteIndex) childRef(h v1.Hash) (name.Reference, error) {
-	return name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+func (r *remoteIndex) childRef(h v1.Hash) name.Reference {
+	return r.Ref.Context().Digest(h.String())
 }
 
 // Convert one of this index's child's v1.Descriptor into a remote.Descriptor, with the given platform option.
 func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform) (*Descriptor, error) {
-	ref, err := r.childRef(child.Digest)
-	if err != nil {
-		return nil, err
-	}
+	ref := r.childRef(child.Digest)
 	manifest, desc, err := r.fetchManifest(ref, []types.MediaType{child.MediaType})
 	if err != nil {
 		return nil, err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -455,9 +455,6 @@ func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
 
 	for _, desc := range index.Manifests {
 		ref := ref.Context().Digest(desc.Digest.String())
-		if err != nil {
-			return err
-		}
 		exists, err := w.checkExistingManifest(desc.Digest, desc.MediaType)
 		if err != nil {
 			return err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -454,7 +454,7 @@ func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
 	}
 
 	for _, desc := range index.Manifests {
-		ref, err := name.ParseReference(fmt.Sprintf("%s@%s", ref.Context(), desc.Digest), name.StrictValidation)
+		ref := ref.Context().Digest(desc.Digest.String())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #563

These are useful for creating a child digest/tag from a repository, which is something we need to do in remote. Before, we were throwing away the insecure option, which this approach fixes.