### PR TITLE
Re-read $DOCKER_CONFIG when we load the config file

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -15,6 +15,8 @@
 package authn
 
 import (
+	"os"
+
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -45,10 +47,6 @@ type defaultKeychain struct{}
 var (
 	// DefaultKeychain implements Keychain by interpreting the docker config file.
 	DefaultKeychain Keychain = &defaultKeychain{}
-
-	// This should generally just be "", but for testing it's nice to redirect
-	// to a temporary file. If it's "", docker/cli will handle defaulting for us.
-	configDir = ""
 )
 
 const (
@@ -57,7 +55,7 @@ const (
 
 // Resolve implements Keychain.
 func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
-	cf, err := config.Load(configDir)
+	cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -45,7 +45,7 @@ func setupConfigDir(t *testing.T) string {
 
 	fresh = fresh + 1
 	p := fmt.Sprintf("%s/%d", tmpdir, fresh)
-	configDir = p
+	os.Setenv("DOCKER_CONFIG", p)
 	if err := os.Mkdir(p, 0777); err != nil {
 		t.Fatalf("mkdir %q: %v", p, err)
 	}


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_docker/issues/1193#issuecomment-540712704

This broke because:
https://github.com/bazelbuild/rules_docker/blob/72fe2bb93e6d59c1f8823421a1b914a3058b90e2/container/go/cmd/pusher/pusher.go#L66

and 

https://github.com/docker/cli/blob/3e07fa728a3025cf4205e3dd071da703c34cf45f/cli/config/config.go#L25

don't work together. We used to parse the config file ourselves and read from the env every time we called into the keychain, but docker does this once on startup.