### PR TITLE
Always wrap transports for scheme and useragent

### DIFF
--- a/pkg/v1/remote/transport/schemer.go
+++ b/pkg/v1/remote/transport/schemer.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type schemeTransport struct {
+	// Scheme we should use, determined by ping response.
+	scheme string
+
+	// Registry we're talking to.
+	registry name.Registry
+
+	// Wrapped by schemeTransport.
+	inner http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper
+func (st *schemeTransport) RoundTrip(in *http.Request) (*http.Response, error) {
+	// When we ping() the registry, we determine whether to use http or https
+	// based on which scheme was successful. That is only valid for the
+	// registry server and not e.g. a separate token server or blob storage,
+	// so we should only override the scheme if the host is the registry.
+	if matchesHost(st.registry, in, st.scheme) {
+		in.URL.Scheme = st.scheme
+	}
+	return st.inner.RoundTrip(in)
+}

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -22,10 +22,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-const (
-	transportName = "go-containerregistry"
-)
-
 // New returns a new RoundTripper based on the provided RoundTripper that has been
 // setup to authenticate with the remote registry "reg", in the capacity
 // laid out by the specified scopes.
@@ -47,6 +43,16 @@ func New(reg name.Registry, auth authn.Authenticator, t http.RoundTripper, scope
 	pr, err := ping(reg, t)
 	if err != nil {
 		return nil, err
+	}
+
+	// Wrap the given transport in transports that use an appropriate scheme,
+	// (based on the ping response) and set the user agent.
+	t = &useragentTransport{
+		inner: &schemeTransport{
+			scheme:   pr.scheme,
+			registry: reg,
+			inner:    t,
+		},
 	}
 
 	switch pr.challenge.Canonical() {

--- a/pkg/v1/remote/transport/useragent.go
+++ b/pkg/v1/remote/transport/useragent.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import "net/http"
+
+const (
+	transportName = "go-containerregistry"
+)
+
+type useragentTransport struct {
+	// Wrapped by useragentTransport.
+	inner http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper
+func (ut *useragentTransport) RoundTrip(in *http.Request) (*http.Response, error) {
+	in.Header.Set("User-Agent", transportName)
+	return ut.inner.RoundTrip(in)
+}


### PR DESCRIPTION
These were only set for the bearer transport, but we care about basic
and anonymous as well.

Context: https://github.com/GoogleContainerTools/kaniko/pull/817