### PR TITLE
Improve cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,28 +1,21 @@
 steps:
 # Build the ko binary.
-- name: gcr.io/cloud-builders/go:debian
-  env: ['PROJECT_ROOT=github.com/google/go-containerregistry']
+- name: golang
+  env: ['GOPATH=/workspace/gopath']
+  entrypoint: go
   args: ['get', 'github.com/google/ko/cmd/ko']
 
 # Use the ko binary to build the crane and gcrane builder images.
-- name: gcr.io/cloud-builders/go:debian
+- name: golang
   env: ['GOPATH=/workspace/gopath', 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID']
   entrypoint: /workspace/gopath/bin/ko
   dir: gopath/src
-  args: ['publish', '-P', 'github.com/google/go-containerregistry/cmd/crane']
-
-- name: gcr.io/cloud-builders/go:debian
+  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/crane', '-t', 'latest', '-t', '$COMMIT_SHA']
+- name: golang
   env: ['GOPATH=/workspace/gopath', 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID']
   entrypoint: /workspace/gopath/bin/ko
   dir: gopath/src
-  args: ['publish', '-P', 'github.com/google/go-containerregistry/cmd/gcrane']
-
-# Use the crane builder to retag crane and gcrane.
-- name: gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane
-  args: ['copy', 'gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane', 'gcr.io/$PROJECT_ID/crane']
-
-- name: gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/crane
-  args: ['copy', 'gcr.io/$PROJECT_ID/github.com/google/go-containerregistry/cmd/gcrane', 'gcr.io/$PROJECT_ID/gcrane']
+  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/gcrane', '-t', 'latest', '-t', '$COMMIT_SHA']
 
 # Use the crane builder to get the digest for crane and gcrane.
 - name: gcr.io/$PROJECT_ID/crane


### PR DESCRIPTION
Supercedes #580

* Tag pushed images with the commit SHA
* Remove unnecessary tag, and just tag with `ko`
* Use official `golang` image instead of `gcr.io/cloud-builders/go` which provides wonky stuff to support pre-modules Go packages, which go-containerregistry is not. (new since #580)

The new logic is:
1. `GOPATH=/workspace/gopath go get github.com/google/ko/cmd/ko`
1. `/workspace/gopath/bin/ko publish -B github.com/google/go-containerregistry/cmd/crane -t latest -t $COMMIT_SHA`
1. `/workspace/gopath/bin/ko publish -B github.com/google/go-containerregistry/cmd/gcrane -t latest -t $COMMIT_SHA`
1. (using just-built `crane` image) `crane digest gcr.io/$PROJECT_ID/crane`
1. (using just-built `gcrane` image) `gcrane digest gcr.io/$PROJECT_ID/gcrane`