### PR TITLE
Add better usage

### DIFF
--- a/cmd/crane/cmd/config.go
+++ b/cmd/crane/cmd/config.go
@@ -27,7 +27,7 @@ func init() { Root.AddCommand(NewCmdConfig()) }
 // NewCmdConfig creates a new cobra.Command for the config subcommand.
 func NewCmdConfig() *cobra.Command {
 	return &cobra.Command{
-		Use:   "config",
+		Use:   "config IMAGE",
 		Short: "Get the config of an image",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -26,7 +26,7 @@ func init() { Root.AddCommand(NewCmdCopy()) }
 // NewCmdCopy creates a new cobra.Command for the copy subcommand.
 func NewCmdCopy() *cobra.Command {
 	return &cobra.Command{
-		Use:     "copy",
+		Use:     "copy SRC DST",
 		Aliases: []string{"cp"},
 		Short:   "Efficiently copy a remote image from src to dst",
 		Args:    cobra.ExactArgs(2),

--- a/cmd/crane/cmd/delete.go
+++ b/cmd/crane/cmd/delete.go
@@ -26,7 +26,7 @@ func init() { Root.AddCommand(NewCmdDelete()) }
 // NewCmdDelete creates a new cobra.Command for the delete subcommand.
 func NewCmdDelete() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete",
+		Use:   "delete IMAGE",
 		Short: "Delete an image reference from its registry",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -27,7 +27,7 @@ func init() { Root.AddCommand(NewCmdDigest()) }
 // NewCmdDigest creates a new cobra.Command for the digest subcommand.
 func NewCmdDigest() *cobra.Command {
 	return &cobra.Command{
-		Use:   "digest",
+		Use:   "digest IMAGE",
 		Short: "Get the digest of an image",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -27,7 +27,7 @@ func init() { Root.AddCommand(NewCmdExport()) }
 // NewCmdExport creates a new cobra.Command for the export subcommand.
 func NewCmdExport() *cobra.Command {
 	return &cobra.Command{
-		Use:   "export IMAGE OUTPUT",
+		Use:   "export IMAGE TARBALL",
 		Short: "Export contents of a remote image as a tarball",
 		Example: `  # Write tarball to stdout
   crane export ubuntu -

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -27,7 +27,7 @@ func init() { Root.AddCommand(NewCmdList()) }
 // NewCmdList creates a new cobra.Command for the ls subcommand.
 func NewCmdList() *cobra.Command {
 	return &cobra.Command{
-		Use:   "ls",
+		Use:   "ls REPO",
 		Short: "List the tags in a repo",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/manifest.go
+++ b/cmd/crane/cmd/manifest.go
@@ -27,7 +27,7 @@ func init() { Root.AddCommand(NewCmdManifest()) }
 // NewCmdManifest creates a new cobra.Command for the manifest subcommand.
 func NewCmdManifest() *cobra.Command {
 	return &cobra.Command{
-		Use:   "manifest",
+		Use:   "manifest IMAGE",
 		Short: "Get the manifest of an image",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -28,7 +28,7 @@ func init() { Root.AddCommand(NewCmdPull()) }
 func NewCmdPull() *cobra.Command {
 	var cachePath string
 	pull := &cobra.Command{
-		Use:   "pull",
+		Use:   "pull IMAGE TARBALL",
 		Short: "Pull a remote image by reference and store its contents in a tarball",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -26,7 +26,7 @@ func init() { Root.AddCommand(NewCmdPush()) }
 // NewCmdPush creates a new cobra.Command for the push subcommand.
 func NewCmdPush() *cobra.Command {
 	return &cobra.Command{
-		Use:   "push",
+		Use:   "push TARBALL IMAGE",
 		Short: "Push image contents as a tarball to a remote registry",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {


### PR DESCRIPTION
```
$ crane pull ubuntu
Error: accepts 2 arg(s), received 1
Usage:
  crane pull IMAGE TARBALL [flags]

Flags:
  -c, --cache_path string   Path to cache image layers
  -h, --help                help for pull

Global Flags:
  -v, --verbose   Enable debug logs

accepts 2 arg(s), received 1
```

Fixes https://github.com/google/go-containerregistry/issues/433