### PR TITLE
Use Println to avoid spurious MISSING warnings

### DIFF
--- a/pkg/v1/remote/transport/logger.go
+++ b/pkg/v1/remote/transport/logger.go
@@ -23,7 +23,7 @@ func (t *logTransport) RoundTrip(in *http.Request) (out *http.Response, err erro
 	logs.Debug.Printf("--> %s %s", in.Method, in.URL)
 	b, err := httputil.DumpRequestOut(in, true)
 	if err == nil {
-		logs.Debug.Printf(string(b))
+		logs.Debug.Println(string(b))
 	}
 	out, err = t.inner.RoundTrip(in)
 	if err != nil {
@@ -37,7 +37,7 @@ func (t *logTransport) RoundTrip(in *http.Request) (out *http.Response, err erro
 		logs.Debug.Printf(msg)
 		b, err := httputil.DumpResponse(out, true)
 		if err == nil {
-			logs.Debug.Printf(string(b))
+			logs.Debug.Println(string(b))
 		}
 	}
 	return


### PR DESCRIPTION
Using Printf with the output of the httputil dumpers caused strange
output because the url-encoded scopes included percent characters.

We are just printing a string, so we can use Println instead of Printf.

See https://github.com/bazelbuild/rules_docker/issues/1193#issuecomment-543392322