### PR TITLE
Add verbose flag to gcrane

### DIFF
--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -68,7 +68,7 @@ func NewCmdCopy() *cobra.Command {
 	recursive := false
 	jobs := 1
 	cmd := &cobra.Command{
-		Use:     "copy",
+		Use:     "copy SRC DST",
 		Aliases: []string{"cp"},
 		Short:   "Efficiently copy a remote image from src to dst",
 		Args:    cobra.ExactArgs(2),

--- a/pkg/gcrane/list.go
+++ b/pkg/gcrane/list.go
@@ -29,7 +29,7 @@ func init() { Root.AddCommand(NewCmdList()) }
 func NewCmdList() *cobra.Command {
 	recursive := false
 	cmd := &cobra.Command{
-		Use:   "ls",
+		Use:   "ls REPO",
 		Short: "List the contents of a repo",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {

--- a/pkg/gcrane/root.go
+++ b/pkg/gcrane/root.go
@@ -12,12 +12,30 @@
 
 package gcrane
 
-import "github.com/spf13/cobra"
+import (
+	"os"
 
-// Root is the top-level cobra.Command for gcrane.
-var Root = &cobra.Command{
-	Use:               "gcrane",
-	Short:             "gcrane is a tool for managing container images on gcr.io",
-	Run:               func(cmd *cobra.Command, _ []string) { cmd.Usage() },
-	DisableAutoGenTag: true,
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	Root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
 }
+
+var (
+	verbose = false
+
+	// Root is the top-level cobra.Command for gcrane.
+	Root = &cobra.Command{
+		Use:               "gcrane",
+		Short:             "gcrane is a tool for managing container images on gcr.io",
+		Run:               func(cmd *cobra.Command, _ []string) { cmd.Usage() },
+		DisableAutoGenTag: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if verbose {
+				logs.Debug.SetOutput(os.Stderr)
+			}
+		},
+	}
+)

--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -110,6 +110,13 @@ func (tsa *tokenSourceAuth) Authorization() (*authn.AuthConfig, error) {
 		return nil, err
 	}
 
+	if logs.Enabled(logs.Debug) {
+		b, err := json.Marshal(token)
+		if err == nil {
+			logs.Debug.Printf("google.Keychain: %s", string(b))
+		}
+	}
+
 	return &authn.AuthConfig{
 		RegistryToken: token.AccessToken,
 	}, nil

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -15,6 +15,7 @@
 package google
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/oauth2"
 )
@@ -117,6 +119,10 @@ func TestGcloudErrors(t *testing.T) {
 }
 
 func TestGcloudSuccess(t *testing.T) {
+	// Stupid coverage to make sure it doesn't panic.
+	var b bytes.Buffer
+	logs.Debug.SetOutput(&b)
+
 	GetGcloudCmd = newGcloudCmdMock("success")
 
 	auth, err := NewGcloudAuthenticator()

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
@@ -49,6 +50,13 @@ func newLister(repo name.Repository, options ...ListerOption) (*lister, error) {
 		if err := option(l); err != nil {
 			return nil, err
 		}
+	}
+
+	// Wrap the transport in something that logs requests and responses.
+	// It's expensive to generate the dumps, so skip it if we're writing
+	// to nothing.
+	if logs.Enabled(logs.Debug) {
+		l.transport = transport.NewLogger(l.transport)
 	}
 
 	// Wrap the transport in something that can retry network flakes.

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -15,6 +15,7 @@
 package google
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -131,6 +133,10 @@ func (r *recorder) walk(repo name.Repository, tags *Tags, err error) error {
 }
 
 func TestWalk(t *testing.T) {
+	// Stupid coverage to make sure it doesn't panic.
+	var b bytes.Buffer
+	logs.Debug.SetOutput(&b)
+
 	cases := []struct {
 		name         string
 		responseBody []byte


### PR DESCRIPTION
Also ensure consistent `Use` field between duplicated commands, since
this is used to dedupe them in gcrane.