### PR TITLE
Publish debug images

### DIFF
--- a/.ko/debug/.ko.yaml
+++ b/.ko/debug/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/base:debug

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,7 @@ steps:
   entrypoint: /workspace/gopath/bin/ko
   dir: gopath/src
   args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/crane', '-t', 'latest', '-t', '$COMMIT_SHA']
+
 - name: golang
   env:
   - 'GOPATH=/workspace/gopath'
@@ -22,6 +23,27 @@ steps:
   entrypoint: /workspace/gopath/bin/ko
   dir: gopath/src
   args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/gcrane', '-t', 'latest', '-t', '$COMMIT_SHA']
+
+# Use the ko binary to build the crane and gcrane builder *debug* images.
+- name: golang
+  env:
+  - 'GOPATH=/workspace/gopath'
+  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
+  - 'KO_CONFIG_PATH=/workspace/.ko/debug/'
+  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
+  entrypoint: /workspace/gopath/bin/ko
+  dir: gopath/src
+  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/crane', '-t', 'debug']
+
+- name: golang
+  env:
+  - 'GOPATH=/workspace/gopath'
+  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
+  - 'KO_CONFIG_PATH=/workspace/.ko/debug/'
+  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
+  entrypoint: /workspace/gopath/bin/ko
+  dir: gopath/src
+  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/gcrane', '-t', 'debug']
 
 # Use the crane builder to get the digest for crane and gcrane.
 - name: gcr.io/$PROJECT_ID/crane


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/605

```
$ docker run -it --entrypoint "/busybox/sh" gcr.io/jonjohnson/crane:debug@sha256:3c4b1ba2483c8ef840db25beabbb4df1fb17634e471daf559157317b01033e32
Unable to find image 'gcr.io/jonjohnson/crane:debug@sha256:3c4b1ba2483c8ef840db25beabbb4df1fb17634e471daf559157317b01033e32' locally
sha256:3c4b1ba2483c8ef840db25beabbb4df1fb17634e471daf559157317b01033e32: Pulling from jonjohnson/crane
9ff2acc3204b: Already exists 
69e2f037cdb3: Already exists 
0ab175cd7cdc: Already exists 
72164b581b02: Already exists 
b707ebaa82ab: Pull complete 
Digest: sha256:3c4b1ba2483c8ef840db25beabbb4df1fb17634e471daf559157317b01033e32
Status: Downloaded newer image for gcr.io/jonjohnson/crane@sha256:3c4b1ba2483c8ef840db25beabbb4df1fb17634e471daf559157317b01033e32
/ # ls /ko-app
crane
/ # /ko-app/crane
Usage:
  crane [flags]
  crane [command]

Available Commands:
  append      Append contents of a tarball to a remote image
  catalog     List the repos in a registry
  config      Get the config of an image
  copy        Efficiently copy a remote image from src to dst
  delete      Delete an image reference from its registry
  digest      Get the digest of an image
  export      Export contents of a remote image as a tarball
  help        Help about any command
  ls          List the tags in a repo
  manifest    Get the manifest of an image
  pull        Pull a remote image by reference and store its contents in a tarball
  push        Push image contents as a tarball to a remote registry
  rebase      Rebase an image onto a new base image
  validate    Validate that an image is well-formed
  version     Print the version

Flags:
  -h, --help      help for crane
  -v, --verbose   Enable debug logs

Use "crane [command] --help" for more information about a command.
```

These should get published to gcr.io/go-containerregstry/{crane,gcrane}:debug once this merges.