### PR TITLE
Use Link header for pagination

### DIFF
--- a/pkg/crane/catalog.go
+++ b/pkg/crane/catalog.go
@@ -15,6 +15,8 @@
 package crane
 
 import (
+	"context"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -27,5 +29,5 @@ func Catalog(src string) (res []string, err error) {
 		return nil, err
 	}
 
-	return remote.Catalog(reg, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Catalog(context.TODO(), reg, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 }

--- a/pkg/crane/catalog.go
+++ b/pkg/crane/catalog.go
@@ -27,23 +27,5 @@ func Catalog(src string) (res []string, err error) {
 		return nil, err
 	}
 
-	n := 100
-	last := ""
-	for {
-		page, err := remote.CatalogPage(reg, last, n, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-		if err != nil {
-			return nil, err
-		}
-
-		if len(page) > 0 {
-			last = page[len(page)-1]
-			res = append(res, page...)
-		}
-
-		if len(page) < n {
-			break
-		}
-	}
-
-	return res, nil
+	return remote.Catalog(reg, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 }

--- a/pkg/internal/retry/retry.go
+++ b/pkg/internal/retry/retry.go
@@ -17,6 +17,7 @@
 package retry
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/internal/retry/wait"
@@ -35,6 +36,9 @@ type temporary interface {
 
 // IsTemporary returns true if err implements Temporary() and it returns true.
 func IsTemporary(err error) bool {
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		return false
+	}
 	if te, ok := err.(temporary); ok && te.Temporary() {
 		return true
 	}

--- a/pkg/internal/retry/retry.go
+++ b/pkg/internal/retry/retry.go
@@ -36,7 +36,7 @@ type temporary interface {
 
 // IsTemporary returns true if err implements Temporary() and it returns true.
 func IsTemporary(err error) bool {
-	if err == context.Canceled || err == context.DeadlineExceeded {
+	if err == context.DeadlineExceeded {
 		return false
 	}
 	if te, ok := err.(temporary); ok && te.Temporary() {

--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -106,10 +106,10 @@ func Catalog(ctx context.Context, target name.Registry, options ...Option) ([]st
 		}
 
 		req, err := http.NewRequest("GET", uri.String(), nil)
-		req = req.WithContext(ctx)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -84,9 +84,10 @@ func Catalog(ctx context.Context, target name.Registry, options ...Option) ([]st
 	}
 
 	uri := &url.URL{
-		Scheme: target.Scheme(),
-		Host:   target.RegistryStr(),
-		Path:   "/v2/_catalog",
+		Scheme:   target.Scheme(),
+		Host:     target.RegistryStr(),
+		Path:     "/v2/_catalog",
+		RawQuery: "n=10000",
 	}
 
 	client := http.Client{Transport: tr}

--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -105,7 +105,8 @@ func Catalog(ctx context.Context, target name.Registry, options ...Option) ([]st
 		default:
 		}
 
-		req, err := http.NewRequestWithContext(ctx, "GET", uri.String(), nil)
+		req, err := http.NewRequest("GET", uri.String(), nil)
+		req = req.WithContext(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -69,10 +69,10 @@ func ListWithContext(ctx context.Context, repo name.Repository, options ...Optio
 		}
 
 		req, err := http.NewRequest("GET", uri.String(), nil)
-		req = req.WithContext(ctx)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -68,7 +68,8 @@ func ListWithContext(ctx context.Context, repo name.Repository, options ...Optio
 		default:
 		}
 
-		req, err := http.NewRequestWithContext(ctx, "GET", uri.String(), nil)
+		req, err := http.NewRequest("GET", uri.String(), nil)
+		req = req.WithContext(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -31,7 +31,7 @@ type tags struct {
 	Tags []string `json:"tags"`
 }
 
-// List wraps ListWithContext using the backround context
+// List wraps ListWithContext using the background context.
 func List(repo name.Repository, options ...Option) ([]string, error) {
 	return ListWithContext(context.Background(), repo, options...)
 }

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -50,9 +50,10 @@ func ListWithContext(ctx context.Context, repo name.Repository, options ...Optio
 	}
 
 	uri := &url.URL{
-		Scheme: repo.Registry.Scheme(),
-		Host:   repo.Registry.RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
+		Scheme:   repo.Registry.Scheme(),
+		Host:     repo.Registry.RegistryStr(),
+		Path:     fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
+		RawQuery: "n=10000",
 	}
 
 	client := http.Client{Transport: tr}

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -107,10 +107,11 @@ func TestTimeoutContext(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond*20))
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "GET", slowServer.URL, nil)
+	req, err := http.NewRequest("GET", slowServer.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req = req.WithContext(ctx)
 
 	result := make(chan error)
 

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -15,8 +15,11 @@
 package transport
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/internal/retry"
 )
@@ -90,5 +93,38 @@ func TestRetryDefaults(t *testing.T) {
 
 	if rt.predicate == nil {
 		t.Fatal("default predicate not set")
+	}
+}
+
+func TestTimeoutContext(t *testing.T) {
+	tr := NewRetry(http.DefaultTransport)
+
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// hanging request
+		time.Sleep(time.Second * 1)
+	}))
+	defer func() { go func() { slowServer.Close() }() }()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond*20))
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", slowServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := make(chan error)
+
+	go func() {
+		_, err := tr.RoundTrip(req)
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		if err != context.DeadlineExceeded {
+			t.Fatalf("got: %v, want: %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatalf("deadline was not recognized by transport")
 	}
 }


### PR DESCRIPTION
* Adds support for pagination on /v2/repo/tags/list
* Apply same logic for catalog /v2/_catalog

Instead of setting the url parameters `n` and `last` manually the logic only relies on the `Link` header as described in https://docs.docker.com/registry/spec/api/#pagination.

#549 