### PR TITLE
Refactor pkg/gcrane quite a bit

### DIFF
--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"log"
 	"runtime"
 
@@ -35,7 +36,7 @@ func NewCmdCopy() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		Run: func(cc *cobra.Command, args []string) {
 			if recursive {
-				if err := gcrane.CopyRepository(args[0], args[1], gcrane.WithJobs(jobs)); err != nil {
+				if err := gcrane.CopyRepository(context.TODO(), args[0], args[1], gcrane.WithJobs(jobs)); err != nil {
 					log.Fatal(err)
 				}
 			} else {

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -34,7 +34,13 @@ func NewCmdCopy() *cobra.Command {
 		Short:   "Efficiently copy a remote image from src to dst",
 		Args:    cobra.ExactArgs(2),
 		Run: func(cc *cobra.Command, args []string) {
-			if err := gcrane.Copy(args[0], args[1], recursive, jobs); err != nil {
+			if recursive {
+				if err := gcrane.CopyRepository(args[0], args[1], gcrane.WithJobs(jobs)); err != nil {
+					log.Fatal(err)
+				}
+			} else {
+			}
+			if err := gcrane.Copy(args[0], args[1]); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2019 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -40,9 +40,9 @@ func NewCmdCopy() *cobra.Command {
 					log.Fatal(err)
 				}
 			} else {
-			}
-			if err := gcrane.Copy(args[0], args[1]); err != nil {
-				log.Fatal(err)
+				if err := gcrane.Copy(args[0], args[1]); err != nil {
+					log.Fatal(err)
+				}
 			}
 		},
 	}

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+	"runtime"
+
+	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdCopy()) }
+
+// NewCmdCopy creates a new cobra.Command for the copy subcommand.
+func NewCmdCopy() *cobra.Command {
+	recursive := false
+	jobs := 1
+	cmd := &cobra.Command{
+		Use:     "copy SRC DST",
+		Aliases: []string{"cp"},
+		Short:   "Efficiently copy a remote image from src to dst",
+		Args:    cobra.ExactArgs(2),
+		Run: func(cc *cobra.Command, args []string) {
+			if err := gcrane.Copy(args[0], args[1], recursive, jobs); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Whether to recurse through repos")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", runtime.GOMAXPROCS(0), "The maximum number of concurrent copies")
+
+	return cmd
+}

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -35,12 +35,16 @@ func NewCmdCopy() *cobra.Command {
 		Short:   "Efficiently copy a remote image from src to dst",
 		Args:    cobra.ExactArgs(2),
 		Run: func(cc *cobra.Command, args []string) {
+			src, dst := args[0], args[1]
 			if recursive {
-				if err := gcrane.CopyRepository(context.TODO(), args[0], args[1], gcrane.WithJobs(jobs)); err != nil {
+				// We should wire this up to signal handlers and make sure we
+				// respect the cancellation downstream.
+				ctx := context.TODO()
+				if err := gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs)); err != nil {
 					log.Fatal(err)
 				}
 			} else {
-				if err := gcrane.Copy(args[0], args[1]); err != nil {
+				if err := gcrane.Copy(src, dst); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/cmd/gcrane/cmd/list.go
+++ b/cmd/gcrane/cmd/list.go
@@ -12,29 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcrane
+package cmd
 
 import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/spf13/cobra"
 )
 
-func init() { Root.AddCommand(NewCmdGc()) }
+func init() { Root.AddCommand(NewCmdList()) }
 
-// NewCmdGc creates a new cobra.Command for the gc subcommand.
-func NewCmdGc() *cobra.Command {
+// NewCmdList creates a new cobra.Command for the ls subcommand.
+func NewCmdList() *cobra.Command {
 	recursive := false
 	cmd := &cobra.Command{
-		Use:   "gc",
-		Short: "List images that are not tagged",
+		Use:   "ls REPO",
+		Short: "List the contents of a repo",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			gc(args[0], recursive)
+			ls(args[0], recursive)
 		},
 	}
 
@@ -43,35 +42,52 @@ func NewCmdGc() *cobra.Command {
 	return cmd
 }
 
-func gc(root string, recursive bool) {
+func ls(root string, recursive bool) {
 	repo, err := name.NewRepository(root)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	auth := google.WithAuthFromKeychain(authn.DefaultKeychain)
-
 	if recursive {
-		if err := google.Walk(repo, printUntaggedImages, auth); err != nil {
+		if err := google.Walk(repo, printImages, google.WithAuthFromKeychain(google.Keychain)); err != nil {
 			log.Fatalln(err)
 		}
 		return
 	}
 
-	tags, err := google.List(repo, auth)
-	if err := printUntaggedImages(repo, tags, err); err != nil {
+	tags, err := google.List(repo, google.WithAuthFromKeychain(google.Keychain))
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if len(tags.Manifests) == 0 && len(tags.Children) == 0 {
+		// If we didn't see any GCR extensions, just list the tags like normal.
+		for _, tag := range tags.Tags {
+			fmt.Printf("%s:%s\n", repo, tag)
+		}
+		return
+	}
+
+	// Since we're not recursing, print the subdirectories too.
+	for _, child := range tags.Children {
+		fmt.Printf("%s/%s\n", repo, child)
+	}
+
+	if err := printImages(repo, tags, err); err != nil {
 		log.Fatalln(err)
 	}
 }
 
-func printUntaggedImages(repo name.Repository, tags *google.Tags, err error) error {
+func printImages(repo name.Repository, tags *google.Tags, err error) error {
 	if err != nil {
 		return err
 	}
 
 	for digest, manifest := range tags.Manifests {
-		if len(manifest.Tags) == 0 {
-			fmt.Printf("%s@%s\n", repo, digest)
+		fmt.Printf("%s@%s\n", repo, digest)
+
+		for _, tag := range manifest.Tags {
+			fmt.Printf("%s:%s\n", repo, tag)
 		}
 	}
 

--- a/cmd/gcrane/cmd/root.go
+++ b/cmd/gcrane/cmd/root.go
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcrane
+package cmd
 
 import (
 	"os"

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -19,7 +19,7 @@ import (
 	"os"
 
 	crane "github.com/google/go-containerregistry/cmd/crane/cmd"
-	"github.com/google/go-containerregistry/pkg/gcrane"
+	gcrane "github.com/google/go-containerregistry/cmd/gcrane/cmd"
 	"github.com/google/go-containerregistry/pkg/logs"
 )
 

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -57,15 +57,19 @@ func GCRBackoff() retry.Backoff {
 	}
 }
 
-func Copy(src, dst string, recursive bool, jobs int) error {
-	if recursive {
-		return recursiveCopy(src, dst, jobs)
-	}
-
+// Copy copies a remote image or index from src to dst.
+func Copy(src, dst string) error {
 	// This is a bit of a hack, but we want to use crane's copy
 	// logic with gcrane's google credentials magic.
 	authn.DefaultKeychain = authn.NewMultiKeychain(google.Keychain, authn.DefaultKeychain)
 	return crane.Copy(src, dst)
+}
+
+// CopyRepository copies everything from the src GCR repository to the
+// dst GCR repository.
+func CopyRepository(src, dst string, opts ...Option) error {
+	o := makeOptions(opts...)
+	return recursiveCopy(src, dst, o.jobs)
 }
 
 type task struct {

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -229,3 +229,7 @@ func TestRetryErrors(t *testing.T) {
 		t.Fatalf("backoffErrors should return internal err, got different status code: %v", te.StatusCode)
 	}
 }
+
+func TestFailures(t *testing.T) {
+	// TODO
+}

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gcrane
 
 import (

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -1,0 +1,33 @@
+package gcrane
+
+import (
+	"runtime"
+)
+
+// Option is a functional option for gcrane operations.
+type Option func(*options)
+
+type options struct {
+	jobs int
+}
+
+func makeOptions(opts ...Option) *options {
+	o := &options{
+		jobs: runtime.GOMAXPROCS(0),
+	}
+
+	for _, option := range opts {
+		option(o)
+	}
+
+	return o
+}
+
+// WithJobs sets the number of concurrent jobs to run.
+//
+// The default number of jobs is GOMAXPROCS.
+func WithJobs(jobs int) Option {
+	return func(o *options) {
+		o.jobs = jobs
+	}
+}


### PR DESCRIPTION
This mirrors a similar change we did for crane: https://github.com/google/go-containerregistry/pull/478

The only thing I'm really comfortable with exposing as a library at the moment is the copy stuff. This PR includes `gcrane.Copy` and `gcrane.CopyRepository` (feel free to bikeshed names).

The difference between `gcrane.Copy` and `crane.Copy` is that we'll use the google-specific credential magic for gcrane.

In order to make `CopyRepository` a bit more palatable, I've added the `WithJobs` (again, happy to bikeshed names) option to specify concurrency.

Some small differences in implementation that drop the code size quite a bit:
* https://github.com/google/go-containerregistry/pull/603 allows me to stop plumbing authenticators around.
* https://github.com/google/go-containerregistry/pull/608 allows me to drop the little wrapper struct.
* https://github.com/google/go-containerregistry/pull/594 allows me to drop all our `copyFoo` methods and just call into `crane.Copy`.

I've also added a few tests, but in order to do this "correctly", I really need to set up a fake GCR or better integration tests.