### PR TITLE
Separate credentialprovider into files with buildtag 🏷

### DIFF
--- a/pkg/authn/k8schain/k8schain.go
+++ b/pkg/authn/k8schain/k8schain.go
@@ -23,14 +23,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
-
-	// Credential providers
-	_ "k8s.io/kubernetes/pkg/credentialprovider/aws"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
-	// TODO(mattmoor): This doesn't seem to build, figure out why `dep ensure`
-	// is not working and add constraints.
-	// _ "k8s.io/kubernetes/pkg/credentialprovider/rancher"
 )
 
 // Options holds configuration data for guiding credential resolution.

--- a/pkg/authn/k8schain/k8schain_aws.go
+++ b/pkg/authn/k8schain/k8schain_aws.go
@@ -1,0 +1,21 @@
+// +build !disable_aws
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8schain
+
+import (
+	// aws credential provider
+	_ "k8s.io/kubernetes/pkg/credentialprovider/aws"
+)

--- a/pkg/authn/k8schain/k8schain_azure.go
+++ b/pkg/authn/k8schain/k8schain_azure.go
@@ -1,0 +1,21 @@
+// +build !disable_azure
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8schain
+
+import (
+	// azure credential provider
+	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
+)

--- a/pkg/authn/k8schain/k8schain_gcp.go
+++ b/pkg/authn/k8schain/k8schain_gcp.go
@@ -1,0 +1,21 @@
+// +build !disable_gcp
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8schain
+
+import (
+	// gcp credential provider
+	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+)


### PR DESCRIPTION
Each files for each provider (aws, azure, gcp, …) have a "negative"
build tag, this means by default, no behaviour change, they are all
compiled — but they can be disabled using `disable-…`.
This allows a library to depend on k8schain but not having those
automatic import, or at least choose the one to enable/disable.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>