### PR TITLE
Add insecure flag to push and pull

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -18,6 +18,7 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -26,12 +27,18 @@ func init() { Root.AddCommand(NewCmdAppend()) }
 // NewCmdAppend creates a new cobra.Command for the append subcommand.
 func NewCmdAppend() *cobra.Command {
 	var baseRef, newTag, newLayer, outFile string
+	var insecure bool
+
 	appendCmd := &cobra.Command{
 		Use:   "append",
 		Short: "Append contents of a tarball to a remote image",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, args []string) {
-			base, err := crane.Pull(baseRef)
+			options := []name.Option{}
+			if insecure {
+				options = append(options, name.Insecure)
+			}
+			base, err := crane.Pull(baseRef, options)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", baseRef, err)
 			}
@@ -56,6 +63,7 @@ func NewCmdAppend() *cobra.Command {
 	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
 	appendCmd.Flags().StringVarP(&newLayer, "new_layer", "f", "", "Path to tarball to append to image")
 	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
+	appendCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 
 	appendCmd.MarkFlagRequired("base")
 	appendCmd.MarkFlagRequired("new_tag")

--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -53,7 +53,7 @@ func NewCmdAppend() *cobra.Command {
 					log.Fatalf("writing output %q: %v", outFile, err)
 				}
 			} else {
-				if err := crane.Push(img, newTag); err != nil {
+				if err := crane.Push(img, newTag, options); err != nil {
 					log.Fatalf("pushing image %s: %v", newTag, err)
 				}
 			}

--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -38,7 +38,7 @@ func NewCmdAppend() *cobra.Command {
 			if insecure {
 				options = append(options, name.Insecure)
 			}
-			base, err := crane.Pull(baseRef, options)
+			base, err := crane.Pull(baseRef, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", baseRef, err)
 			}
@@ -53,7 +53,7 @@ func NewCmdAppend() *cobra.Command {
 					log.Fatalf("writing output %q: %v", outFile, err)
 				}
 			} else {
-				if err := crane.Push(img, newTag, options); err != nil {
+				if err := crane.Push(img, newTag, options...); err != nil {
 					log.Fatalf("pushing image %s: %v", newTag, err)
 				}
 			}

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -51,7 +51,7 @@ func NewCmdExport() *cobra.Command {
 			}
 			defer f.Close()
 
-			img, err := crane.Pull(src, options)
+			img, err := crane.Pull(src, options...)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -40,7 +40,7 @@ func NewCmdPull() *cobra.Command {
 				options = append(options, name.Insecure)
 			}
 			src, path := args[0], args[1]
-			img, err := crane.Pull(src, options)
+			img, err := crane.Pull(src, options...)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -18,6 +18,7 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/spf13/cobra"
 )
@@ -27,13 +28,19 @@ func init() { Root.AddCommand(NewCmdPull()) }
 // NewCmdPull creates a new cobra.Command for the pull subcommand.
 func NewCmdPull() *cobra.Command {
 	var cachePath string
+	var insecure bool
+
 	pull := &cobra.Command{
 		Use:   "pull IMAGE TARBALL",
 		Short: "Pull a remote image by reference and store its contents in a tarball",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
+			options := []name.Option{}
+			if insecure {
+				options = append(options, name.Insecure)
+			}
 			src, path := args[0], args[1]
-			img, err := crane.Pull(src)
+			img, err := crane.Pull(src, options)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -46,5 +53,6 @@ func NewCmdPull() *cobra.Command {
 		},
 	}
 	pull.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
+	pull.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 	return pull
 }

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -18,6 +18,7 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -25,20 +26,30 @@ func init() { Root.AddCommand(NewCmdPush()) }
 
 // NewCmdPush creates a new cobra.Command for the push subcommand.
 func NewCmdPush() *cobra.Command {
-	return &cobra.Command{
+	var insecure bool
+
+	pushCmd := &cobra.Command{
 		Use:   "push TARBALL IMAGE",
 		Short: "Push image contents as a tarball to a remote registry",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
+			options := []name.Option{}
+			if insecure {
+				options = append(options, name.Insecure)
+			}
 			path, tag := args[0], args[1]
 			img, err := crane.Load(path)
 			if err != nil {
 				log.Fatalf("loading %s as tarball: %v", path, err)
 			}
 
-			if err := crane.Push(img, tag); err != nil {
+			if err := crane.Push(img, tag, options); err != nil {
 				log.Fatalf("pushing %s: %v", tag, err)
 			}
 		},
 	}
+
+	pushCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be pushed without TLS")
+
+	return pushCmd
 }

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -43,7 +43,7 @@ func NewCmdPush() *cobra.Command {
 				log.Fatalf("loading %s as tarball: %v", path, err)
 			}
 
-			if err := crane.Push(img, tag, options); err != nil {
+			if err := crane.Push(img, tag, options...); err != nil {
 				log.Fatalf("pushing %s: %v", tag, err)
 			}
 		},

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -60,7 +60,7 @@ func NewCmdRebase() *cobra.Command {
 				log.Fatalf("rebasing: %v", err)
 			}
 
-			if err := crane.Push(img, rebased); err != nil {
+			if err := crane.Push(img, rebased, options); err != nil {
 				log.Fatalf("pushing %s: %v", rebased, err)
 			}
 

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/spf13/cobra"
 )
@@ -28,22 +29,28 @@ func init() { Root.AddCommand(NewCmdRebase()) }
 // NewCmdRebase creates a new cobra.Command for the rebase subcommand.
 func NewCmdRebase() *cobra.Command {
 	var orig, oldBase, newBase, rebased string
+	var insecure bool
+
 	rebaseCmd := &cobra.Command{
 		Use:   "rebase",
 		Short: "Rebase an image onto a new base image",
 		Args:  cobra.NoArgs,
 		Run: func(*cobra.Command, []string) {
-			origImg, err := crane.Pull(orig)
+			options := []name.Option{}
+			if insecure {
+				options = append(options, name.Insecure)
+			}
+			origImg, err := crane.Pull(orig, options)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", orig, err)
 			}
 
-			oldBaseImg, err := crane.Pull(oldBase)
+			oldBaseImg, err := crane.Pull(oldBase, options)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", oldBase, err)
 			}
 
-			newBaseImg, err := crane.Pull(newBase)
+			newBaseImg, err := crane.Pull(newBase, options)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", newBase, err)
 			}
@@ -68,6 +75,7 @@ func NewCmdRebase() *cobra.Command {
 	rebaseCmd.Flags().StringVarP(&oldBase, "old_base", "", "", "Old base image to remove")
 	rebaseCmd.Flags().StringVarP(&newBase, "new_base", "", "", "New base image to insert")
 	rebaseCmd.Flags().StringVarP(&rebased, "rebased", "", "", "Tag to apply to rebased image")
+	rebaseCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 
 	rebaseCmd.MarkFlagRequired("original")
 	rebaseCmd.MarkFlagRequired("old_base")

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -40,17 +40,17 @@ func NewCmdRebase() *cobra.Command {
 			if insecure {
 				options = append(options, name.Insecure)
 			}
-			origImg, err := crane.Pull(orig, options)
+			origImg, err := crane.Pull(orig, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", orig, err)
 			}
 
-			oldBaseImg, err := crane.Pull(oldBase, options)
+			oldBaseImg, err := crane.Pull(oldBase, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", oldBase, err)
 			}
 
-			newBaseImg, err := crane.Pull(newBase, options)
+			newBaseImg, err := crane.Pull(newBase, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", newBase, err)
 			}
@@ -60,7 +60,7 @@ func NewCmdRebase() *cobra.Command {
 				log.Fatalf("rebasing: %v", err)
 			}
 
-			if err := crane.Push(img, rebased, options); err != nil {
+			if err := crane.Push(img, rebased, options...); err != nil {
 				log.Fatalf("pushing %s: %v", rebased, err)
 			}
 

--- a/cmd/crane/cmd/validate.go
+++ b/cmd/crane/cmd/validate.go
@@ -42,14 +42,14 @@ func NewCmdValidate() *cobra.Command {
 			if insecure {
 				options = append(options, name.Insecure)
 			}
-			for flag, maker := range map[string]func(string, []name.Option) (v1.Image, error){
+			for flag, maker := range map[string]func(string, ...name.Option) (v1.Image, error){
 				tarballPath: makeTarball,
 				remoteRef:   crane.Pull,
 			} {
 				if flag == "" {
 					continue
 				}
-				img, err := maker(flag, options)
+				img, err := maker(flag, options...)
 				if err != nil {
 					log.Fatalf("failed to read image %s: %v", flag, err)
 				}
@@ -69,6 +69,6 @@ func NewCmdValidate() *cobra.Command {
 	return validateCmd
 }
 
-func makeTarball(path string, options []name.Option) (v1.Image, error) {
+func makeTarball(path string, opts ...name.Option) (v1.Image, error) {
 	return tarball.ImageFromPath(path, nil)
 }

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -15,6 +15,7 @@ crane append [flags]
 ```
   -b, --base string        Name of base image to append to
   -h, --help               help for append
+  -i, --insecure           Allow image references to be fetched without TLS
   -f, --new_layer string   Path to tarball to append to image
   -t, --new_tag string     Tag to apply to resulting image
   -o, --output string      Path to new tarball of resulting image

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -23,7 +23,8 @@ crane export IMAGE TARBALL [flags]
 ### Options
 
 ```
-  -h, --help   help for export
+  -h, --help       help for export
+  -i, --insecure   Allow image references to be fetched without TLS
 ```
 
 ### Options inherited from parent commands

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -15,6 +15,7 @@ crane pull IMAGE TARBALL [flags]
 ```
   -c, --cache_path string   Path to cache image layers
   -h, --help                help for pull
+  -i, --insecure            Allow image references to be fetched without TLS
 ```
 
 ### Options inherited from parent commands

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -13,7 +13,8 @@ crane push TARBALL IMAGE [flags]
 ### Options
 
 ```
-  -h, --help   help for push
+  -h, --help       help for push
+  -i, --insecure   Allow image references to be pushed without TLS
 ```
 
 ### Options inherited from parent commands

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -14,6 +14,7 @@ crane rebase [flags]
 
 ```
   -h, --help              help for rebase
+  -i, --insecure          Allow image references to be fetched without TLS
       --new_base string   New base image to insert
       --old_base string   Old base image to remove
       --original string   Original image to rebase

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -14,6 +14,7 @@ crane validate [flags]
 
 ```
   -h, --help             help for validate
+  -i, --insecure         Allow image references to be fetched without TLS
       --remote string    Name of remote image to validate
       --tarball string   Path to tarball to validate
 ```

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -68,7 +68,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Load up the registry.
-	if err := crane.Push(img, src, nil); err != nil {
+	if err := crane.Push(img, src); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure we pull what we pushed.
-	pulled, err := crane.Pull(src, nil)
+	pulled, err := crane.Pull(src)
 	if err != nil {
 		t.Error(err)
 	}
@@ -109,7 +109,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure what we copied is equivalent.
-	copied, err := crane.Pull(dst, nil)
+	copied, err := crane.Pull(dst)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure what we tagged is equivalent.
-	tagged, err := crane.Pull(fmt.Sprintf("%s:%s", dst, "crane-tag"), nil)
+	tagged, err := crane.Pull(fmt.Sprintf("%s:%s", dst, "crane-tag"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestBadInputs(t *testing.T) {
 		desc string
 		err  error
 	}{
-		{"Push(_, invalid)", crane.Push(nil, invalid, nil)},
+		{"Push(_, invalid)", crane.Push(nil, invalid)},
 		{"Delete(invalid)", crane.Delete(invalid)},
 		{"Delete: 404", crane.Delete(valid404)},
 		{"Save(_, invalid)", crane.Save(nil, invalid, "")},
@@ -301,7 +301,7 @@ func TestBadInputs(t *testing.T) {
 		{"Tag(404, invalid)", crane.Tag(valid404, invalid)},
 		{"Tag(404, 404)", crane.Tag(valid404, valid404)},
 		// These return multiple values, which are hard to use as expressions.
-		{"Pull(invalid)", e(crane.Pull(invalid, nil))},
+		{"Pull(invalid)", e(crane.Pull(invalid))},
 		{"Digest(invalid)", e(crane.Digest(invalid))},
 		{"Manifet(invalid)", e(crane.Manifest(invalid))},
 		{"Config(invalid)", e(crane.Config(invalid))},

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -68,7 +68,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Load up the registry.
-	if err := crane.Push(img, src); err != nil {
+	if err := crane.Push(img, src, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -290,7 +290,7 @@ func TestBadInputs(t *testing.T) {
 		desc string
 		err  error
 	}{
-		{"Push(_, invalid)", crane.Push(nil, invalid)},
+		{"Push(_, invalid)", crane.Push(nil, invalid, nil)},
 		{"Delete(invalid)", crane.Delete(invalid)},
 		{"Delete: 404", crane.Delete(valid404)},
 		{"Save(_, invalid)", crane.Save(nil, invalid, "")},

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -95,7 +95,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure we pull what we pushed.
-	pulled, err := crane.Pull(src)
+	pulled, err := crane.Pull(src, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -109,7 +109,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure what we copied is equivalent.
-	copied, err := crane.Pull(dst)
+	copied, err := crane.Pull(dst, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure what we tagged is equivalent.
-	tagged, err := crane.Pull(fmt.Sprintf("%s:%s", dst, "crane-tag"))
+	tagged, err := crane.Pull(fmt.Sprintf("%s:%s", dst, "crane-tag"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestBadInputs(t *testing.T) {
 		{"Tag(404, invalid)", crane.Tag(valid404, invalid)},
 		{"Tag(404, 404)", crane.Tag(valid404, valid404)},
 		// These return multiple values, which are hard to use as expressions.
-		{"Pull(invalid)", e(crane.Pull(invalid))},
+		{"Pull(invalid)", e(crane.Pull(invalid, nil))},
 		{"Digest(invalid)", e(crane.Digest(invalid))},
 		{"Manifet(invalid)", e(crane.Manifest(invalid))},
 		{"Config(invalid)", e(crane.Config(invalid))},

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -30,7 +30,7 @@ import (
 const iWasADigestTag = "i-was-a-digest"
 
 // Pull returns a v1.Image of the remote image src.
-func Pull(src string, opts []name.Option) (v1.Image, error) {
+func Pull(src string, opts ...name.Option) (v1.Image, error) {
 	ref, err := name.ParseReference(src, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing tag %q: %v", src, err)

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -30,8 +30,8 @@ import (
 const iWasADigestTag = "i-was-a-digest"
 
 // Pull returns a v1.Image of the remote image src.
-func Pull(src string) (v1.Image, error) {
-	ref, err := name.ParseReference(src)
+func Pull(src string, opts []name.Option) (v1.Image, error) {
+	ref, err := name.ParseReference(src, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing tag %q: %v", src, err)
 	}

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -31,7 +31,7 @@ func Load(path string) (v1.Image, error) {
 }
 
 // Push pushes the v1.Image img to a registry as dst.
-func Push(img v1.Image, dst string, options []name.Option) error {
+func Push(img v1.Image, dst string, options ...name.Option) error {
 	tag, err := name.NewTag(dst, options...)
 	if err != nil {
 		return fmt.Errorf("parsing tag %q: %v", dst, err)

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -31,8 +31,8 @@ func Load(path string) (v1.Image, error) {
 }
 
 // Push pushes the v1.Image img to a registry as dst.
-func Push(img v1.Image, dst string) error {
-	tag, err := name.NewTag(dst)
+func Push(img v1.Image, dst string, options []name.Option) error {
+	tag, err := name.NewTag(dst, options...)
 	if err != nil {
 		return fmt.Errorf("parsing tag %q: %v", dst, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to push and pull from insecure registries to the crane cmd.
The flag also had to be added to a few other subcommands like export, append and etc.

**Which issue this PR fixes**:
fixes #633 


**Special notes for your reviewer**:
I wasn't sure if it's ok to change the handler map in the validate subcommand without any prior discussions, so I just added the options argument to `makeTarball` as a temporary fix so we don't have failing tests.
Let me know if it's ok to change the handler map and also what do you think is a good approach to change it.
https://github.com/google/go-containerregistry/pull/634/files#diff-67c9d71faf9a3b5faa49b6f666170f54R72