### PR TITLE
Add crane.Option and make --insecure global

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -18,7 +18,6 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -27,17 +26,12 @@ func init() { Root.AddCommand(NewCmdAppend()) }
 // NewCmdAppend creates a new cobra.Command for the append subcommand.
 func NewCmdAppend() *cobra.Command {
 	var baseRef, newTag, newLayer, outFile string
-	var insecure bool
 
 	appendCmd := &cobra.Command{
 		Use:   "append",
 		Short: "Append contents of a tarball to a remote image",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, args []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
 			base, err := crane.Pull(baseRef, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", baseRef, err)
@@ -63,7 +57,6 @@ func NewCmdAppend() *cobra.Command {
 	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
 	appendCmd.Flags().StringVarP(&newLayer, "new_layer", "f", "", "Path to tarball to append to image")
 	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
-	appendCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 
 	appendCmd.MarkFlagRequired("base")
 	appendCmd.MarkFlagRequired("new_tag")

--- a/cmd/crane/cmd/config.go
+++ b/cmd/crane/cmd/config.go
@@ -31,7 +31,7 @@ func NewCmdConfig() *cobra.Command {
 		Short: "Get the config of an image",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			cfg, err := crane.Config(args[0])
+			cfg, err := crane.Config(args[0], options...)
 			if err != nil {
 				log.Fatalf("fetching config: %v", err)
 			}

--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -32,7 +32,7 @@ func NewCmdCopy() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
 			src, dst := args[0], args[1]
-			if err := crane.Copy(src, dst); err != nil {
+			if err := crane.Copy(src, dst, options...); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/crane/cmd/delete.go
+++ b/cmd/crane/cmd/delete.go
@@ -31,7 +31,7 @@ func NewCmdDelete() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			ref := args[0]
-			if err := crane.Delete(ref); err != nil {
+			if err := crane.Delete(ref, options...); err != nil {
 				log.Fatalf("deleting %s: %v", ref, err)
 			}
 		},

--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -31,7 +31,7 @@ func NewCmdDigest() *cobra.Command {
 		Short: "Get the digest of an image",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			digest, err := crane.Digest(args[0])
+			digest, err := crane.Digest(args[0], options...)
 			if err != nil {
 				log.Fatalf("computing digest: %v", err)
 			}

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +26,7 @@ func init() { Root.AddCommand(NewCmdExport()) }
 
 // NewCmdExport creates a new cobra.Command for the export subcommand.
 func NewCmdExport() *cobra.Command {
-	var insecure bool
-
-	exportCmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "export IMAGE TARBALL",
 		Short: "Export contents of a remote image as a tarball",
 		Example: `  # Write tarball to stdout
@@ -39,10 +36,6 @@ func NewCmdExport() *cobra.Command {
   crane export ubuntu ubuntu.tar`,
 		Args: cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
 			src, dst := args[0], args[1]
 
 			f, err := openFile(dst)
@@ -61,8 +54,6 @@ func NewCmdExport() *cobra.Command {
 			}
 		},
 	}
-	exportCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
-	return exportCmd
 }
 
 func openFile(s string) (*os.File, error) {

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -32,7 +32,7 @@ func NewCmdList() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			repo := args[0]
-			tags, err := crane.ListTags(repo)
+			tags, err := crane.ListTags(repo, options...)
 			if err != nil {
 				log.Fatalf("reading tags for %s: %v", repo, err)
 			}

--- a/cmd/crane/cmd/manifest.go
+++ b/cmd/crane/cmd/manifest.go
@@ -32,7 +32,7 @@ func NewCmdManifest() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			src := args[0]
-			manifest, err := crane.Manifest(src)
+			manifest, err := crane.Manifest(src, options...)
 			if err != nil {
 				log.Fatalf("fetching manifest %s: %v", src, err)
 			}

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -18,7 +18,6 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/spf13/cobra"
 )
@@ -28,17 +27,12 @@ func init() { Root.AddCommand(NewCmdPull()) }
 // NewCmdPull creates a new cobra.Command for the pull subcommand.
 func NewCmdPull() *cobra.Command {
 	var cachePath string
-	var insecure bool
 
-	pull := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "pull IMAGE TARBALL",
 		Short: "Pull a remote image by reference and store its contents in a tarball",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
 			src, path := args[0], args[1]
 			img, err := crane.Pull(src, options...)
 			if err != nil {
@@ -52,7 +46,7 @@ func NewCmdPull() *cobra.Command {
 			}
 		},
 	}
-	pull.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
-	pull.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
-	return pull
+	cmd.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
+
+	return cmd
 }

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -18,7 +18,6 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -26,17 +25,11 @@ func init() { Root.AddCommand(NewCmdPush()) }
 
 // NewCmdPush creates a new cobra.Command for the push subcommand.
 func NewCmdPush() *cobra.Command {
-	var insecure bool
-
-	pushCmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "push TARBALL IMAGE",
 		Short: "Push image contents as a tarball to a remote registry",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
 			path, tag := args[0], args[1]
 			img, err := crane.Load(path)
 			if err != nil {
@@ -48,8 +41,4 @@ func NewCmdPush() *cobra.Command {
 			}
 		},
 	}
-
-	pushCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be pushed without TLS")
-
-	return pushCmd
 }

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -19,7 +19,6 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/spf13/cobra"
 )
@@ -29,17 +28,12 @@ func init() { Root.AddCommand(NewCmdRebase()) }
 // NewCmdRebase creates a new cobra.Command for the rebase subcommand.
 func NewCmdRebase() *cobra.Command {
 	var orig, oldBase, newBase, rebased string
-	var insecure bool
 
 	rebaseCmd := &cobra.Command{
 		Use:   "rebase",
 		Short: "Rebase an image onto a new base image",
 		Args:  cobra.NoArgs,
 		Run: func(*cobra.Command, []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
 			origImg, err := crane.Pull(orig, options...)
 			if err != nil {
 				log.Fatalf("pulling %s: %v", orig, err)
@@ -75,7 +69,6 @@ func NewCmdRebase() *cobra.Command {
 	rebaseCmd.Flags().StringVarP(&oldBase, "old_base", "", "", "Old base image to remove")
 	rebaseCmd.Flags().StringVarP(&newBase, "new_base", "", "", "New base image to insert")
 	rebaseCmd.Flags().StringVarP(&rebased, "rebased", "", "", "Tag to apply to rebased image")
-	rebaseCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 
 	rebaseCmd.MarkFlagRequired("original")
 	rebaseCmd.MarkFlagRequired("old_base")

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -15,16 +15,22 @@ package cmd
 import (
 	"os"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	Root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
+	Root.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow image references to be fetched without TLS")
 }
 
 var (
-	verbose = false
+	verbose  = false
+	insecure = false
+
+	// Crane options for this invocation.
+	options = []crane.Option{}
 
 	// Root is the top-level cobra.Command for crane.
 	Root = &cobra.Command{
@@ -35,6 +41,9 @@ var (
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if verbose {
 				logs.Debug.SetOutput(os.Stderr)
+			}
+			if insecure {
+				options = append(options, crane.Insecure)
 			}
 		},
 	}

--- a/cmd/crane/cmd/tag.go
+++ b/cmd/crane/cmd/tag.go
@@ -42,7 +42,7 @@ crane tag ubuntu v1`,
 		Args: cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
 			img, tag := args[0], args[1]
-			if err := crane.Tag(img, tag); err != nil {
+			if err := crane.Tag(img, tag, options...); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/crane/cmd/validate.go
+++ b/cmd/crane/cmd/validate.go
@@ -19,7 +19,6 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
@@ -31,18 +30,13 @@ func init() { Root.AddCommand(NewCmdValidate()) }
 // NewCmdValidate creates a new cobra.Command for the validate subcommand.
 func NewCmdValidate() *cobra.Command {
 	var tarballPath, remoteRef string
-	var insecure bool
 
 	validateCmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate that an image is well-formed",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, args []string) {
-			options := []name.Option{}
-			if insecure {
-				options = append(options, name.Insecure)
-			}
-			for flag, maker := range map[string]func(string, ...name.Option) (v1.Image, error){
+			for flag, maker := range map[string]func(string, ...crane.Option) (v1.Image, error){
 				tarballPath: makeTarball,
 				remoteRef:   crane.Pull,
 			} {
@@ -64,11 +58,10 @@ func NewCmdValidate() *cobra.Command {
 	}
 	validateCmd.Flags().StringVar(&tarballPath, "tarball", "", "Path to tarball to validate")
 	validateCmd.Flags().StringVar(&remoteRef, "remote", "", "Name of remote image to validate")
-	validateCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Allow image references to be fetched without TLS")
 
 	return validateCmd
 }
 
-func makeTarball(path string, opts ...name.Option) (v1.Image, error) {
+func makeTarball(path string, opts ...crane.Option) (v1.Image, error) {
 	return tarball.ImageFromPath(path, nil)
 }

--- a/pkg/crane/catalog.go
+++ b/pkg/crane/catalog.go
@@ -17,17 +17,17 @@ package crane
 import (
 	"context"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // Catalog returns the repositories in a registry's catalog.
-func Catalog(src string) (res []string, err error) {
-	reg, err := name.NewRegistry(src)
+func Catalog(src string, opt ...Option) (res []string, err error) {
+	o := makeOptions(opt...)
+	reg, err := name.NewRegistry(src, o.name...)
 	if err != nil {
 		return nil, err
 	}
 
-	return remote.Catalog(context.TODO(), reg, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Catalog(context.TODO(), reg, o.remote...)
 }

--- a/pkg/crane/config.go
+++ b/pkg/crane/config.go
@@ -15,8 +15,8 @@
 package crane
 
 // Config returns the config file for the remote image ref.
-func Config(ref string) ([]byte, error) {
-	i, _, err := getImage(ref)
+func Config(ref string, opt ...Option) ([]byte, error) {
+	i, _, err := getImage(ref, opt...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -109,7 +109,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Make sure what we copied is equivalent.
-	copied, err := crane.Pull(dst)
+	copied, err := crane.Pull(dst, crane.Insecure, crane.WithTransport(http.DefaultTransport))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/crane/delete.go
+++ b/pkg/crane/delete.go
@@ -17,17 +17,17 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // Delete deletes the remote reference at src.
-func Delete(src string) error {
-	ref, err := name.ParseReference(src)
+func Delete(src string, opt ...Option) error {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(src, o.name...)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %v", src, err)
 	}
 
-	return remote.Delete(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Delete(ref, o.remote...)
 }

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -15,8 +15,8 @@
 package crane
 
 // Digest returns the sha256 hash of the remote image at ref.
-func Digest(ref string) (string, error) {
-	desc, err := getManifest(ref)
+func Digest(ref string, opt ...Option) (string, error) {
+	desc, err := getManifest(ref, opt...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -17,28 +17,29 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-func getImage(r string) (v1.Image, name.Reference, error) {
-	ref, err := name.ParseReference(r)
+func getImage(r string, opt ...Option) (v1.Image, name.Reference, error) {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(r, o.name...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing reference %q: %v", r, err)
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref, o.remote...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading image %q: %v", ref, err)
 	}
 	return img, ref, nil
 }
 
-func getManifest(r string) (*remote.Descriptor, error) {
-	ref, err := name.ParseReference(r)
+func getManifest(r string, opt ...Option) (*remote.Descriptor, error) {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(r, o.name...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing reference %q: %v", r, err)
 	}
-	return remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Get(ref, o.remote...)
 }

--- a/pkg/crane/list.go
+++ b/pkg/crane/list.go
@@ -17,17 +17,17 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // ListTags returns the tags in repository src.
-func ListTags(src string) ([]string, error) {
-	repo, err := name.NewRepository(src)
+func ListTags(src string, opt ...Option) ([]string, error) {
+	o := makeOptions(opt...)
+	repo, err := name.NewRepository(src, o.name...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing repo %q: %v", src, err)
 	}
 
-	return remote.List(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.List(repo, o.remote...)
 }

--- a/pkg/crane/manifest.go
+++ b/pkg/crane/manifest.go
@@ -15,8 +15,8 @@
 package crane
 
 // Manifest returns the manifest for the remote image or index ref.
-func Manifest(ref string) ([]byte, error) {
-	desc, err := getManifest(ref)
+func Manifest(ref string, opt ...Option) ([]byte, error) {
+	desc, err := getManifest(ref, opt...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crane
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type options struct {
+	name   []name.Option
+	remote []remote.Option
+}
+
+func makeOptions(opts ...Option) options {
+	opt := options{
+		remote: []remote.Option{
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		},
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// Option is a functional option for crane.
+type Option func(*options)
+
+// WithTransport is a functional option for overriding the default transport
+// for remote operations.
+func WithTransport(t http.RoundTripper) Option {
+	return func(o *options) {
+		o.remote = append(o.remote, remote.WithTransport(t))
+	}
+}
+
+// Insecure is an Option that allows image references to be fetched without TLS.
+func Insecure(o *options) {
+	o.name = append(o.name, name.Insecure)
+}

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -17,7 +17,6 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -30,13 +29,14 @@ import (
 const iWasADigestTag = "i-was-a-digest"
 
 // Pull returns a v1.Image of the remote image src.
-func Pull(src string, opts ...name.Option) (v1.Image, error) {
-	ref, err := name.ParseReference(src, opts...)
+func Pull(src string, opt ...Option) (v1.Image, error) {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(src, o.name...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing tag %q: %v", src, err)
 	}
 
-	return remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Image(ref, o.remote...)
 }
 
 // Save writes the v1.Image img as a tarball at path with tag src.

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -17,7 +17,6 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -31,11 +30,11 @@ func Load(path string) (v1.Image, error) {
 }
 
 // Push pushes the v1.Image img to a registry as dst.
-func Push(img v1.Image, dst string, options ...name.Option) error {
-	tag, err := name.NewTag(dst, options...)
+func Push(img v1.Image, dst string, opt ...Option) error {
+	o := makeOptions(opt...)
+	tag, err := name.NewTag(dst, o.name...)
 	if err != nil {
 		return fmt.Errorf("parsing tag %q: %v", dst, err)
 	}
-
-	return remote.Write(tag, img, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Write(tag, img, o.remote...)
 }

--- a/pkg/crane/tag.go
+++ b/pkg/crane/tag.go
@@ -17,23 +17,23 @@ package crane
 import (
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // Tag adds tag to the remote img.
-func Tag(img, tag string) error {
-	ref, err := name.ParseReference(img)
+func Tag(img, tag string, opt ...Option) error {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(img, o.name...)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %v", img, err)
 	}
-	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	desc, err := remote.Get(ref, o.remote...)
 	if err != nil {
 		return fmt.Errorf("fetching %q: %v", img, err)
 	}
 
 	dst := ref.Context().Tag(tag)
 
-	return remote.Tag(dst, desc, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	return remote.Tag(dst, desc, o.remote...)
 }


### PR DESCRIPTION
I realized I want to be able to inject my own transport for crane, but
that's going to be impossible if we only accept name options, so this
wraps this options (again, sigh) in a way that lets us extend to other
packages.

This also drops -i as an option for insecure (breaking, but so briefly).