### PR TITLE
crane append: multiple layers, empty base

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -18,6 +18,9 @@ import (
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/logs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/spf13/cobra"
 )
 
@@ -25,21 +28,35 @@ func init() { Root.AddCommand(NewCmdAppend()) }
 
 // NewCmdAppend creates a new cobra.Command for the append subcommand.
 func NewCmdAppend() *cobra.Command {
-	var baseRef, newTag, newLayer, outFile string
+	var (
+		baseRef, newTag, outFile string
+		newLayers                []string
+	)
 
 	appendCmd := &cobra.Command{
 		Use:   "append",
 		Short: "Append contents of a tarball to a remote image",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, args []string) {
-			base, err := crane.Pull(baseRef, options...)
-			if err != nil {
-				log.Fatalf("pulling %s: %v", baseRef, err)
+			var (
+				base v1.Image
+				err  error
+			)
+
+			if baseRef == "" {
+				logs.Warn.Printf("base unspecified, using empty image")
+				base = empty.Image
+
+			} else {
+				base, err = crane.Pull(baseRef, options...)
+				if err != nil {
+					log.Fatalf("pulling %s: %v", baseRef, err)
+				}
 			}
 
-			img, err := crane.Append(base, newLayer)
+			img, err := crane.Append(base, newLayers...)
 			if err != nil {
-				log.Fatalf("appending %s: %v", newLayer, err)
+				log.Fatalf("appending %v: %v", newLayers, err)
 			}
 
 			if outFile != "" {
@@ -55,10 +72,9 @@ func NewCmdAppend() *cobra.Command {
 	}
 	appendCmd.Flags().StringVarP(&baseRef, "base", "b", "", "Name of base image to append to")
 	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
-	appendCmd.Flags().StringVarP(&newLayer, "new_layer", "f", "", "Path to tarball to append to image")
+	appendCmd.Flags().StringSliceVarP(&newLayers, "new_layer", "f", []string{}, "Path to tarball to append to image")
 	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
 
-	appendCmd.MarkFlagRequired("base")
 	appendCmd.MarkFlagRequired("new_tag")
 	appendCmd.MarkFlagRequired("new_layer")
 	return appendCmd

--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -28,20 +28,16 @@ func init() { Root.AddCommand(NewCmdAppend()) }
 
 // NewCmdAppend creates a new cobra.Command for the append subcommand.
 func NewCmdAppend() *cobra.Command {
-	var (
-		baseRef, newTag, outFile string
-		newLayers                []string
-	)
+	var baseRef, newTag, outFile string
+	var newLayers []string
 
 	appendCmd := &cobra.Command{
 		Use:   "append",
 		Short: "Append contents of a tarball to a remote image",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, args []string) {
-			var (
-				base v1.Image
-				err  error
-			)
+			var base v1.Image
+			var err error
 
 			if baseRef == "" {
 				logs.Warn.Printf("base unspecified, using empty image")

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -13,11 +13,11 @@ crane append [flags]
 ### Options
 
 ```
-  -b, --base string        Name of base image to append to
-  -h, --help               help for append
-  -f, --new_layer string   Path to tarball to append to image
-  -t, --new_tag string     Tag to apply to resulting image
-  -o, --output string      Path to new tarball of resulting image
+  -b, --base string         Name of base image to append to
+  -h, --help                help for append
+  -f, --new_layer strings   Path to tarball to append to image
+  -t, --new_tag string      Tag to apply to resulting image
+  -o, --output string       Path to new tarball of resulting image
 ```
 
 ### Options inherited from parent commands

--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -23,11 +23,15 @@ import (
 )
 
 // Append reads a layer from path and appends it the the v1.Image base.
-func Append(base v1.Image, path string) (v1.Image, error) {
-	layer, err := tarball.LayerFromFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading tar %q: %v", path, err)
+func Append(base v1.Image, paths ...string) (v1.Image, error) {
+	layers := make([]v1.Layer, 0, len(paths))
+	for _, path := range paths {
+		layer, err := tarball.LayerFromFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading tar %q: %v", path, err)
+		}
+		layers = append(layers, layer)
 	}
 
-	return mutate.AppendLayers(base, layer)
+	return mutate.AppendLayers(base, layers...)
 }


### PR DESCRIPTION
Allow multiple layers to be appended (via multiple -f flags, a la
kubectl apply).

Make "base" optional, which then uses empty.Image as the base.