### PR TITLE
Add tests to pkg/v1/{partial,remote,transport}

### DIFF
--- a/pkg/legacy/tarball/write_test.go
+++ b/pkg/legacy/tarball/write_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/internal/compare"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -65,24 +65,12 @@ func TestWrite(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}
-
-		tarManifest, err := tarImage.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-		randManifest, err := randImage.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-
-		if diff := cmp.Diff(randManifest, tarManifest); diff != "" {
-			t.Errorf("Manifests not equal. (-rand +tar) %s", diff)
-		}
-
 		if err := validate.Image(tarImage); err != nil {
 			t.Errorf("validate.Image: %v", err)
 		}
-		assertLayersAreIdentical(t, randImage, tarImage)
+		if err := compare.Images(randImage, tarImage); err != nil {
+			t.Errorf("compare.Images: %v", err)
+		}
 	}
 
 	// Try loading a different tag, it should error.
@@ -149,25 +137,12 @@ func TestMultiWriteSameImage(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}
-
-		tarManifest, err := tarImage.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-		randManifest, err := randImage.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-
-		if diff := cmp.Diff(randManifest, tarManifest); diff != "" {
-			t.Errorf("Manifests not equal. (-rand +tar) %s", diff)
-		}
-
 		if err := validate.Image(tarImage); err != nil {
 			t.Errorf("validate.Image: %v", err)
 		}
-
-		assertLayersAreIdentical(t, randImage, tarImage)
+		if err := compare.Images(randImage, tarImage); err != nil {
+			t.Errorf("compare.Images: %v", err)
+		}
 	}
 }
 
@@ -237,24 +212,12 @@ func TestMultiWriteDifferentImages(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error reading tarball: %v", err)
 		}
-
-		tarManifest, err := tarImage.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-		randManifest, err := img.Manifest()
-		if err != nil {
-			t.Fatalf("Unexpected error reading tarball: %v", err)
-		}
-
-		if diff := cmp.Diff(randManifest, tarManifest); diff != "" {
-			t.Errorf("Manifests not equal. (-rand +tar) %s", diff)
-		}
-
 		if err := validate.Image(tarImage); err != nil {
 			t.Errorf("validate.Image: %v", err)
 		}
-		assertLayersAreIdentical(t, img, tarImage)
+		if err := compare.Images(img, tarImage); err != nil {
+			t.Errorf("compare.Images: %v", err)
+		}
 	}
 }
 
@@ -437,56 +400,4 @@ func TestMultiWriteMismatchedHistory(t *testing.T) {
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("Got unexpected error when writing image with mismatched history & layer, got %v, want substring %q", err, want)
 	}
-}
-
-func assertLayersAreIdentical(t *testing.T, a, b v1.Image) {
-	t.Helper()
-
-	aLayers, err := a.Layers()
-	if err != nil {
-		t.Fatalf("error getting layers to compare: %v", err)
-	}
-
-	bLayers, err := b.Layers()
-	if err != nil {
-		t.Fatalf("error getting layers to compare: %v", err)
-	}
-
-	if diff := cmp.Diff(getDigests(t, aLayers), getDigests(t, bLayers)); diff != "" {
-		t.Fatalf("layers digests are not identical (-rand +tar) %s", diff)
-	}
-
-	if diff := cmp.Diff(getDiffIDs(t, aLayers), getDiffIDs(t, bLayers)); diff != "" {
-		t.Fatalf("layers digests are not identical (-rand +tar) %s", diff)
-	}
-}
-
-func getDigests(t *testing.T, layers []v1.Layer) []v1.Hash {
-	t.Helper()
-
-	digests := make([]v1.Hash, 0, len(layers))
-	for _, layer := range layers {
-		digest, err := layer.Digest()
-		if err != nil {
-			t.Fatalf("error getting digests: %s", err)
-		}
-		digests = append(digests, digest)
-	}
-
-	return digests
-}
-
-func getDiffIDs(t *testing.T, layers []v1.Layer) []v1.Hash {
-	t.Helper()
-
-	diffIDs := make([]v1.Hash, 0, len(layers))
-	for _, layer := range layers {
-		diffID, err := layer.DiffID()
-		if err != nil {
-			t.Fatalf("error getting diffID: %s", err)
-		}
-		diffIDs = append(diffIDs, diffID)
-	}
-
-	return diffIDs
 }

--- a/pkg/v1/partial/uncompressed.go
+++ b/pkg/v1/partial/uncompressed.go
@@ -188,6 +188,7 @@ func (i *uncompressedImageExtender) Manifest() (*v1.Manifest, error) {
 			m.Layers[i] = *desc
 			continue
 		}
+		// TODO: This is unreachable.
 		sz, err := l.Size()
 		if err != nil {
 			return nil, err

--- a/pkg/v1/partial/uncompressed_test.go
+++ b/pkg/v1/partial/uncompressed_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partial_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/internal/compare"
+	legacy "github.com/google/go-containerregistry/pkg/legacy/tarball"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
+)
+
+// legacy/tarball.Write + tarball.Image leverages a lot of uncompressed partials.
+//
+// This is cribbed from pkg/legacy/tarball just to get intra-package coverage.
+func TestLegacyWrite(t *testing.T) {
+	// Make a tempfile for tarball writes.
+	fp, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("Error creating temp file.")
+	}
+	t.Log(fp.Name())
+	defer fp.Close()
+	defer os.Remove(fp.Name())
+
+	// Make a random image
+	randImage, err := random.Image(256, 8)
+	if err != nil {
+		t.Fatalf("Error creating random image: %v", err)
+	}
+	tag, err := name.NewTag("gcr.io/foo/bar:latest", name.StrictValidation)
+	if err != nil {
+		t.Fatalf("Error creating test tag: %v", err)
+	}
+	o, err := os.Create(fp.Name())
+	if err != nil {
+		t.Fatalf("Error creating %q to write image tarball: %v", fp.Name(), err)
+	}
+	defer o.Close()
+	if err := legacy.Write(tag, randImage, o); err != nil {
+		t.Fatalf("Unexpected error writing tarball: %v", err)
+	}
+
+	// Make sure the image is valid and can be loaded.
+	// Load it both by nil and by its name.
+	for _, it := range []*name.Tag{nil, &tag} {
+		tarImage, err := tarball.ImageFromPath(fp.Name(), it)
+		if err != nil {
+			t.Fatalf("Unexpected error reading tarball: %v", err)
+		}
+		if err := validate.Image(tarImage); err != nil {
+			t.Errorf("validate.Image: %v", err)
+		}
+		if err := compare.Images(randImage, tarImage); err != nil {
+			t.Errorf("compare.Images: %v", err)
+		}
+	}
+
+	// Try loading a different tag, it should error.
+	fakeTag, err := name.NewTag("gcr.io/notthistag:latest", name.StrictValidation)
+	if err != nil {
+		t.Fatalf("Error generating tag: %v", err)
+	}
+	if _, err := tarball.ImageFromPath(fp.Name(), &fakeTag); err == nil {
+		t.Errorf("Expected error loading tag %v from image", fakeTag)
+	}
+}
+
+type uncompressedImage struct {
+	img v1.Image
+}
+
+func (i *uncompressedImage) RawConfigFile() ([]byte, error) {
+	return i.img.RawConfigFile()
+}
+
+func (i *uncompressedImage) MediaType() (types.MediaType, error) {
+	return i.img.MediaType()
+}
+
+func (i *uncompressedImage) LayerByDiffID(h v1.Hash) (partial.UncompressedLayer, error) {
+	return i.img.LayerByDiffID(h)
+}
+
+func TestUncompressed(t *testing.T) {
+	rnd, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	core := &uncompressedImage{rnd}
+
+	img, err := partial.UncompressedToImage(core)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validate.Image(img); err != nil {
+		t.Fatalf("validate.Image: %v", err)
+	}
+}

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -33,7 +33,7 @@ type bearerTransport struct {
 	// Basic credentials that we exchange for bearer tokens.
 	basic authn.Authenticator
 	// Holds the bearer response from the token service.
-	bearer *authn.Bearer
+	bearer authn.AuthConfig
 	// Registry to which we send bearer tokens.
 	registry name.Registry
 	// See https://tools.ietf.org/html/rfc6750#section-3
@@ -61,11 +61,7 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		// the registry with which we are interacting.
 		// In case of redirect http.Client can use an empty Host, check URL too.
 		if matchesHost(bt.registry, in, bt.scheme) {
-			auth, err := bt.bearer.Authorization()
-			if err != nil {
-				return nil, err
-			}
-			hdr := fmt.Sprintf("Bearer %s", auth.RegistryToken)
+			hdr := fmt.Sprintf("Bearer %s", bt.bearer.RegistryToken)
 			in.Header.Set("Authorization", hdr)
 		}
 		return bt.inner.RoundTrip(in)
@@ -134,9 +130,8 @@ func (bt *bearerTransport) refresh() error {
 	}
 
 	// Find a token to turn into a Bearer authenticator
-	var bearer authn.Bearer
 	if response.Token != "" {
-		bearer = authn.Bearer{Token: response.Token}
+		bt.bearer.RegistryToken = response.Token
 	} else {
 		return fmt.Errorf("no token in bearer response:\n%s", content)
 	}
@@ -148,8 +143,6 @@ func (bt *bearerTransport) refresh() error {
 		})
 	}
 
-	// Replace our old bearer authenticator (if we had one) with our newly refreshed authenticator.
-	bt.bearer = &bearer
 	return nil
 }
 


### PR DESCRIPTION
This also drops a bunch of test code from legacy/tarball that the `compare` package takes care of.