### PR TITLE
Inline NewDockerKeyring

### DIFF
--- a/pkg/authn/k8schain/k8schain.go
+++ b/pkg/authn/k8schain/k8schain.go
@@ -38,9 +38,6 @@ type Options struct {
 	ImagePullSecrets []string
 }
 
-// origKeyRing is a variable so that testing can adjust it.
-var origKeyRing = credentialprovider.NewDockerKeyring()
-
 // New returns a new authn.Keychain suitable for resolving image references as
 // scoped by the provided Options.  It speaks to Kubernetes through the provided
 // client interface.
@@ -85,7 +82,7 @@ func New(client kubernetes.Interface, opt Options) (authn.Keychain, error) {
 	}
 
 	// Third, extend the default keyring with the pull secrets.
-	kr, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, origKeyRing)
+	kr, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, credentialprovider.NewDockerKeyring())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- This allows for credential providers to load flags before Keyring initialization
- Tests no longer appear to adjust origKeyRing


As an example, the Azure credential helper requires the [azure-container-registry-config](https://github.com/kubernetes/kubernetes/blob/387e6931e5fd63e8a7e353fa01b02a2ab218149c/pkg/credentialprovider/azure/azure_credentials.go#L40) flag to be set in order for the credential provider to report that it is [enabled](https://github.com/kubernetes/kubernetes/blob/387e6931e5fd63e8a7e353fa01b02a2ab218149c/pkg/credentialprovider/azure/azure_credentials.go#L156). Inlining `NewDockerKeyring`allows the "azure-container-registry-config" flag to be processed ahed of time and the Azure provider to be included. 