### PR TITLE
Adds WithAuth functional option to pkg/crane to allow for alternate m…

### DIFF
--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -56,7 +56,7 @@ func Insecure(o *options) {
 }
 
 // WithAuth is a functional option for overriding the default authentication
-// mechanism for GCR operations.
+// mechanism for remote operations.
 func WithAuth(a authn.Authenticator) Option {
 	return func (o *options) {
 		o.remote = append(o.remote, remote.WithAuth(a))

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -59,6 +59,6 @@ func Insecure(o *options) {
 // mechanism for remote operations.
 func WithAuth(a authn.Authenticator) Option {
 	return func (o *options) {
-		o.remote = append(o.remote, remote.WithAuth(a))
+		o.remote = []remote.Option{remote.WithAuth(a)}
 	}
 }

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
+var defaultRemoteOption = remote.WithAuthFromKeychain(authn.DefaultKeychain)
+
 type options struct {
 	name   []name.Option
 	remote []remote.Option
@@ -30,7 +32,7 @@ type options struct {
 func makeOptions(opts ...Option) options {
 	opt := options{
 		remote: []remote.Option{
-			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+			defaultRemoteOption,
 		},
 	}
 	for _, o := range opts {
@@ -59,6 +61,10 @@ func Insecure(o *options) {
 // mechanism for remote operations.
 func WithAuth(a authn.Authenticator) Option {
 	return func (o *options) {
-		o.remote = []remote.Option{remote.WithAuth(a)}
+		if &o.remote[0] == &defaultRemoteOption {
+			o.remote[0] = remote.WithAuth(a)
+		} else {
+			o.remote = append(o.remote, remote.WithAuth(a))
+		}
 	}
 }

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -22,8 +22,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-var defaultRemoteOption = remote.WithAuthFromKeychain(authn.DefaultKeychain)
-
 type options struct {
 	name   []name.Option
 	remote []remote.Option
@@ -32,7 +30,7 @@ type options struct {
 func makeOptions(opts ...Option) options {
 	opt := options{
 		remote: []remote.Option{
-			defaultRemoteOption,
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 		},
 	}
 	for _, o := range opts {
@@ -61,10 +59,6 @@ func Insecure(o *options) {
 // mechanism for remote operations.
 func WithAuth(a authn.Authenticator) Option {
 	return func (o *options) {
-		if &o.remote[0] == &defaultRemoteOption {
-			o.remote[0] = remote.WithAuth(a)
-		} else {
-			o.remote = append(o.remote, remote.WithAuth(a))
-		}
+		o.remote = []remote.Option{remote.WithAuth(a)}
 	}
 }

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -54,3 +54,11 @@ func WithTransport(t http.RoundTripper) Option {
 func Insecure(o *options) {
 	o.name = append(o.name, name.Insecure)
 }
+
+// WithAuth is a functional option for overriding the default authentication
+// mechanism for GCR operations.
+func WithAuth(a authn.Authenticator) Option {
+	return func (o *options) {
+		o.remote = append(o.remote, remote.WithAuth(a))
+	}
+}


### PR DESCRIPTION
To allow for alternate methods of authenticating with GCR when consuming as a library.

Use case: In a Slack bot deployed to a GKE cluster, I am using crane as a library to validate that a given image/tag combination exists in a private GCR registry. I am handling the access control to GCR already per-node pool via node pool service accounts, so it makes sense to be able to leverage that instead of trying to mount a Docker config into a pod.