### PR TITLE
Implement partial.UncompressedSize

### DIFF
--- a/pkg/legacy/tarball/write.go
+++ b/pkg/legacy/tarball/write.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/legacy"
@@ -250,34 +249,22 @@ func MultiWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 			}
 			layerFiles[i] = fmt.Sprintf("%s/layer.tar", cur.config.ID)
 
+			// If the v1.Layer implements UncompressedSize efficiently, use that
+			// for the tar header. Otherwise, this iterates over Uncompressed().
+			// NOTE: If using a streaming layer, this may consume the layer.
+			size, err := partial.UncompressedSize(l)
+			if err != nil {
+				return err
+			}
 			u, err := l.Uncompressed()
 			if err != nil {
 				return err
 			}
 			defer u.Close()
-
-			if partial.HasUncompressedSize(l) {
-				// If the v1.Layer implements UncompressedSize efficiently, use that
-				// for the tar header.
-				size, err := partial.UncompressedSize(l)
-				if err != nil {
-					return err
-				}
-				if err := writeTarEntry(tf, layerFiles[i], u, size); err != nil {
-					return err
-				}
-			} else {
-				// Reads the entire uncompressed blob into memory! Can be avoided
-				// for some layer implementations where the uncompressed blob is
-				// stored on disk and the layer can just stat the file.
-				uncompressedBlob, err := ioutil.ReadAll(u)
-				if err != nil {
-					return err
-				}
-				if err := writeTarEntry(tf, layerFiles[i], bytes.NewReader(uncompressedBlob), int64(len(uncompressedBlob))); err != nil {
-					return err
-				}
+			if err := writeTarEntry(tf, layerFiles[i], u, size); err != nil {
+				return err
 			}
+
 			j, err := cur.json()
 			if err != nil {
 				return err

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -129,12 +129,6 @@ func RawConfigFile(i WithConfigFile) ([]byte, error) {
 	return json.Marshal(cfg)
 }
 
-// WithUncompressedLayer defines the subset of v1.Image used by these helper methods
-type WithUncompressedLayer interface {
-	// UncompressedLayer is like UncompressedBlob, but takes the "diff id".
-	UncompressedLayer(v1.Hash) (io.ReadCloser, error)
-}
-
 // WithRawManifest defines the subset of v1.Image used by these helper methods
 type WithRawManifest interface {
 	// RawManifest returns the serialized bytes of this image's config file.

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -383,9 +383,6 @@ func UncompressedSize(l v1.Layer) (int64, error) {
 		return -1, err
 	}
 	defer rc.Close()
-	n, err := io.Copy(ioutil.Discard, rc)
-	if err != nil {
-		return -1, err
-	}
-	return n, nil
+
+	return io.Copy(ioutil.Discard, rc)
 }

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -359,7 +359,7 @@ func UncompressedSize(l v1.Layer) (int64, error) {
 	}
 
 	// Otherwise, try to unwrap any partial implementations to see
-	// if the wrapped struct implements CompressedSize.
+	// if the wrapped struct implements UncompressedSize.
 	if ule, ok := l.(*uncompressedLayerExtender); ok {
 		if wus, ok := ule.UncompressedLayer.(withUncompressedSize); ok {
 			return wus.UncompressedSize()
@@ -371,7 +371,7 @@ func UncompressedSize(l v1.Layer) (int64, error) {
 		}
 	}
 
-	// The layer doens't implement CompressedSize, we need to compute it.
+	// The layer doesn't implement UncompressedSize, we need to compute it.
 	rc, err := l.Uncompressed()
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
This allows access to an optional method that v1.Layers can implement to
cheaply get the size of the uncompressed contents of a layer. This is
useful in situations where you need to know the size of the contents
before writing them (e.g. pkg/legacy/tarball.Write).

I dropped the `ReadAll` call in the "slow path". This means that the `Uncompressed` bytes aren't buffered (yay), but if using a streaming layer, we might accidentally consume it. The only known uses of the legacy package _don't_ use streaming layers, so we can cross that bridge when we get to it.