### PR TITLE
Add --format flag to `crane pull`

### DIFF
--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -57,7 +57,7 @@ func NewCmdPull() *cobra.Command {
 					log.Fatalf("saving oci image layout %s: %v", path, err)
 				}
 			default:
-				log.Fatalf("unexpected --format: %q (valid values are: tarball, legacy, and oci)")
+				log.Fatalf("unexpected --format: %q (valid values are: tarball, legacy, and oci)", format)
 			}
 		},
 	}

--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -26,7 +27,7 @@ func init() { Root.AddCommand(NewCmdPull()) }
 
 // NewCmdPull creates a new cobra.Command for the pull subcommand.
 func NewCmdPull() *cobra.Command {
-	var cachePath string
+	var cachePath, format string
 
 	cmd := &cobra.Command{
 		Use:   "pull IMAGE TARBALL",
@@ -41,12 +42,27 @@ func NewCmdPull() *cobra.Command {
 			if cachePath != "" {
 				img = cache.Image(img, cache.NewFilesystemCache(cachePath))
 			}
-			if err := crane.Save(img, src, path); err != nil {
-				log.Fatalf("saving tarball %s: %v", path, err)
+
+			switch format {
+			case "tarball":
+				if err := crane.Save(img, src, path); err != nil {
+					log.Fatalf("saving tarball %s: %v", path, err)
+				}
+			case "legacy":
+				if err := crane.SaveLegacy(img, src, path); err != nil {
+					log.Fatalf("saving legacy tarball %s: %v", path, err)
+				}
+			case "oci":
+				if err := crane.SaveOCI(img, path); err != nil {
+					log.Fatalf("saving oci image layout %s: %v", path, err)
+				}
+			default:
+				log.Fatalf("unexpected --format: %q (valid values are: tarball, legacy, and oci)")
 			}
 		},
 	}
 	cmd.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
+	cmd.Flags().StringVar(&format, "format", "tarball", fmt.Sprintf("Format in which to save images (%q, %q, or %q)", "tarball", "legacy", "oci"))
 
 	return cmd
 }

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -14,6 +14,7 @@ crane pull IMAGE TARBALL [flags]
 
 ```
   -c, --cache_path string   Path to cache image layers
+      --format string       Format in which to save images ("tarball", "legacy", or "oci") (default "tarball")
   -h, --help                help for pull
 ```
 


### PR DESCRIPTION
Fixes #621

This adds the --format flag with values "tarball" (default), "legacy"
(for saving pkg/legacy/tarball images, for compatibility with some
software that assumes the old format), and "oci", which saves the image
as an OCI image layout.