### PR TITLE
Add tests for gcrane.Copy[Repository]

### DIFF
--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -126,12 +126,13 @@ func recursiveCopy(ctx context.Context, src, dst string, jobs int) error {
 	g, ctx := errgroup.WithContext(ctx)
 	walkFn := func(repo name.Repository, tags *google.Tags, err error) error {
 		if err != nil {
+			logs.Warn.Printf("failed walkFn for repo %s: %v", repo, err)
 			// If we hit an error when listing the repo, try re-listing with backoff.
 			if err := backoffErrors(GCRBackoff(), func() error {
 				tags, err = google.List(repo, google.WithAuthFromKeychain(google.Keychain))
 				return err
 			}); err != nil {
-				return fmt.Errorf("failed walkFn for repo %s: %v", repo, err)
+				return fmt.Errorf("failed List for repo %s: %v", repo, err)
 			}
 		}
 

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -17,28 +17,191 @@ package gcrane
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	ggcrtest "github.com/google/go-containerregistry/pkg/internal/httptest"
 	"github.com/google/go-containerregistry/pkg/internal/retry"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 func mustRepo(s string) name.Repository {
-	repo, err := name.NewRepository(s, name.WeakValidation)
+	repo, err := name.NewRepository(s)
 	if err != nil {
 		panic(err)
 	}
 	return repo
+}
+
+type fakeGCR struct {
+	h     http.Handler
+	repos map[string]google.Tags
+	t     *testing.T
+}
+
+func (gcr *fakeGCR) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	gcr.t.Logf("%s %s", r.Method, r.URL)
+	if strings.HasPrefix(r.URL.Path, "/v2/") && strings.HasSuffix(r.URL.Path, "/tags/list") {
+		repo := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/"), "/tags/list")
+		if tags, ok := gcr.repos[repo]; !ok {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			gcr.t.Logf("%+v", tags)
+			json.NewEncoder(w).Encode(tags)
+		}
+	} else {
+		gcr.h.ServeHTTP(w, r)
+	}
+}
+
+func newFakeGCR(stuff map[name.Reference]partial.Describable, t *testing.T) (*fakeGCR, error) {
+	h := registry.New()
+
+	repos := make(map[string]google.Tags)
+
+	for ref, thing := range stuff {
+		repo := ref.Context().RepositoryStr()
+		tags, ok := repos[repo]
+		if !ok {
+			tags = google.Tags{
+				Name:     repo,
+				Children: []string{},
+			}
+		}
+
+		// Populate the "child" field.
+		for parentPath := repo; parentPath != "."; parentPath = path.Dir(parentPath) {
+			child, parent := path.Base(parentPath), path.Dir(parentPath)
+			tags, ok := repos[parent]
+			if !ok {
+				tags = google.Tags{}
+			}
+			for _, c := range repos[parent].Children {
+				if c == child {
+					break
+				}
+			}
+			tags.Children = append(tags.Children, child)
+			repos[parent] = tags
+		}
+
+		// Populate the "manifests" and "tags" field.
+		d, err := thing.Digest()
+		if err != nil {
+			return nil, err
+		}
+		mt, err := thing.MediaType()
+		if err != nil {
+			return nil, err
+		}
+		if tags.Manifests == nil {
+			tags.Manifests = make(map[string]google.ManifestInfo)
+		}
+		mi, ok := tags.Manifests[d.String()]
+		if !ok {
+			mi = google.ManifestInfo{
+				MediaType: string(mt),
+				Tags:      []string{},
+			}
+		}
+		if tag, ok := ref.(name.Tag); ok {
+			tags.Tags = append(tags.Tags, tag.Identifier())
+			mi.Tags = append(mi.Tags, tag.Identifier())
+		}
+		tags.Manifests[d.String()] = mi
+		repos[repo] = tags
+	}
+
+	return &fakeGCR{h: h, t: t, repos: repos}, nil
+}
+
+func TestCopy(t *testing.T) {
+	logs.Warn.SetOutput(os.Stderr)
+	src := "gcr.io/test/gcrane"
+	dst := "gcr.io/test/gcrane/copy"
+
+	oneTag, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	twoTags, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noTags, err := random.Image(1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	latestRef, err := name.ParseReference(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneTagRef := latestRef.Context().Tag("bar")
+
+	d, err := noTags.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	noTagsRef := latestRef.Context().Digest(d.String())
+	fooRef := latestRef.Context().Tag("foo")
+
+	// Set up a fake GCR.
+	h, err := newFakeGCR(map[name.Reference]partial.Describable{
+		oneTagRef: oneTag,
+		latestRef: twoTags,
+		fooRef:    twoTags,
+		noTagsRef: noTags,
+	}, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := ggcrtest.NewTLSServer("gcr.io", h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Make sure we don't actually talk to GCR.
+	http.DefaultTransport = s.Client().Transport
+
+	if err := remote.Write(latestRef, twoTags); err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(fooRef, twoTags); err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(oneTagRef, oneTag); err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(noTagsRef, noTags); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Copy(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyRepository(context.Background(), src, dst); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRename(t *testing.T) {

--- a/pkg/internal/httptest/httptest.go
+++ b/pkg/internal/httptest/httptest.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// NewTLSServer returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain.
+// If you need a transport, Client().Transport is correctly configured.
+func NewTLSServer(domain string, handler http.Handler) (*httptest.Server, error) {
+	s := httptest.NewUnstartedServer(handler)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, nil
+}

--- a/pkg/registry/tls.go
+++ b/pkg/registry/tls.go
@@ -15,19 +15,9 @@
 package registry
 
 import (
-	"bytes"
-	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
-	"math/big"
-	"net"
-	"net/http"
 	"net/http/httptest"
-	"time"
+
+	ggcrtest "github.com/google/go-containerregistry/pkg/internal/httptest"
 )
 
 // TLS returns an httptest server, with an http client that has been configured to
@@ -35,70 +25,5 @@ import (
 // which should correspond to the domain the image is stored in.
 // If you need a transport, Client().Transport is correctly configured.
 func TLS(domain string) (*httptest.Server, error) {
-	s := httptest.NewUnstartedServer(New())
-
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now().Add(-1 * time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		IPAddresses: []net.IP{
-			net.IPv4(127, 0, 0, 1),
-			net.IPv6loopback,
-		},
-		DNSNames: []string{domain},
-
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	if err != nil {
-		return nil, err
-	}
-
-	pc := &bytes.Buffer{}
-	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
-		return nil, err
-	}
-
-	ek, err := x509.MarshalECPrivateKey(priv)
-	if err != nil {
-		return nil, err
-	}
-
-	pk := &bytes.Buffer{}
-	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
-		return nil, err
-	}
-
-	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
-	if err != nil {
-		return nil, err
-	}
-	s.TLS = &tls.Config{
-		Certificates: []tls.Certificate{c},
-	}
-	s.StartTLS()
-
-	certpool := x509.NewCertPool()
-	certpool.AddCert(s.Certificate())
-
-	t := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs: certpool,
-		},
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
-		},
-	}
-	s.Client().Transport = t
-
-	return s, nil
+	return ggcrtest.NewTLSServer(domain, New())
 }

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -121,6 +121,21 @@ func fromUnixMs(ms int64) time.Time {
 	return time.Unix(sec, ns)
 }
 
+func toUnixMs(t time.Time) string {
+	return strconv.FormatInt(t.UnixNano()/1000000, 10)
+}
+
+// MarshalJSON implements json.Marshaler
+func (m ManifestInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rawManifestInfo{
+		Size:      strconv.FormatUint(m.Size, 10),
+		MediaType: m.MediaType,
+		Created:   toUnixMs(m.Created),
+		Uploaded:  toUnixMs(m.Uploaded),
+		Tags:      m.Tags,
+	})
+}
+
 // UnmarshalJSON implements json.Unmarshaler
 func (m *ManifestInfo) UnmarshalJSON(data []byte) error {
 	raw := rawManifestInfo{}

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -16,6 +16,7 @@ package google
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +36,35 @@ func mustParseDuration(t *testing.T, d string) time.Duration {
 		t.Fatal(err)
 	}
 	return dur
+}
+
+func TestRoundtrip(t *testing.T) {
+	raw := rawManifestInfo{
+		Size:      "100",
+		MediaType: "hi",
+		Created:   "12345678",
+		Uploaded:  "23456789",
+		Tags:      []string{"latest"},
+	}
+
+	og, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed := ManifestInfo{}
+	if err := json.Unmarshal(og, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	roundtripped, err := json.Marshal(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(og, roundtripped); diff != "" {
+		t.Errorf("ManifestInfo can't roundtrip: (-want +got) = %s", diff)
+	}
 }
 
 func TestList(t *testing.T) {


### PR DESCRIPTION
I split off the useful parts of `registry.TLS` from pkg/registry, fixed up the marshalling/unmarshalling of `google.ManifestInfo` so that it would roundtrip through bytes, and implemented a fake GCR that returns an appropriate response when the client tries to list tags.