### PR TITLE
crane: Allow loading layerless images

### DIFF
--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -79,15 +79,17 @@ func Image(opener Opener, tag *name.Tag) (v1.Image, error) {
 	}
 
 	// Peek at the first layer and see if it's compressed.
-	compressed, err := img.areLayersCompressed()
-	if err != nil {
-		return nil, err
-	}
-	if compressed {
-		c := compressedImage{
-			image: img,
+	if len(img.imgDescriptor.Layers) > 0 {
+		compressed, err := img.areLayersCompressed()
+		if err != nil {
+			return nil, err
 		}
-		return partial.CompressedToImage(&c)
+		if compressed {
+			c := compressedImage{
+				image: img,
+			}
+			return partial.CompressedToImage(&c)
+		}
 	}
 
 	uc := uncompressedImage{


### PR DESCRIPTION
It fixes the following problem when pushing images:

`Dockerfile`:
```
FROM scratch
ENV foo=
```


Shell session reproducing the problem:
```
$ docker build -t 2opremio/flux:empty .
Sending build context to Docker daemon  10.75kB
Step 1/2 : FROM scratch
 ---> 
Step 2/2 : ENV foo=
 ---> Using cache
 ---> 3f8017fe3087
Successfully built 3f8017fe3087
Successfully tagged 2opremio/flux:empty

$ docker push 2opremio/flux:empty
The push refers to repository [docker.io/2opremio/flux]
empty: digest: sha256:3814b642f5c61a77247936fc05d926dcd96f98016cd8e5ec94b7ef18f6d44ce0 size: 314

$ crane push empty.tar 2opremio/flux:empty2
2020/01/20 15:28:43 loading empty.tar as tarball: 0 layers found in image
```

Note how Docker doesn't have a problem pushing the layerles image

With the fix in this PR:

```
$ crane push empty.tar 2opremio/flux:empty2
2020/01/20 15:30:02 existing blob: sha256:3f8017fe3087652f52e2b40a6438b81a6281efdb79c975945eb890597fde8a87
2020/01/20 15:30:02 2opremio/flux:empty2: digest: sha256:0405acdab970e8269aae3c707139d73470f82ff4633bc6e81f4b3bbc2e72a91f size: 265

$ crane pull 2opremio/flux:empty2 empty2.tar
```
