### PR TITLE
Make gcrane work with Artifact Registry

### DIFF
--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -160,7 +160,7 @@ func TestKeychainDockerHub(t *testing.T) {
 	}
 }
 
-func TestKeychainGCR(t *testing.T) {
+func TestKeychainGCRandAR(t *testing.T) {
 	cases := []string{
 		"gcr.io",
 		"us.gcr.io",
@@ -168,6 +168,10 @@ func TestKeychainGCR(t *testing.T) {
 		"eu.gcr.io",
 		"staging-k8s.gcr.io",
 		"global.gcr.io",
+		"us-docker.pkg.dev",
+		"asia-docker.pkg.dev",
+		"europe-docker.pkg.dev",
+		"us-central1-docker.pkg.dev",
 	}
 
 	// Env should fail.
@@ -184,18 +188,18 @@ func TestKeychainGCR(t *testing.T) {
 			GetGcloudCmd = newGcloudCmdMock("success")
 
 			if auth, err := Keychain.Resolve(mustRegistry(tc)); err != nil {
-				t.Errorf("expected success, got: %v", err)
+				t.Errorf("expected success for %v, got: %v", tc, err)
 			} else if auth == authn.Anonymous {
-				t.Errorf("expected not anonymous auth, got: %v", auth)
+				t.Errorf("expected not anonymous auth for %v, got: %v", tc, auth)
 			}
 
 			// Make gcloud fail to test that caching works.
 			GetGcloudCmd = newGcloudCmdMock("badoutput")
 
 			if auth, err := Keychain.Resolve(mustRegistry(tc)); err != nil {
-				t.Errorf("expected success, got: %v", err)
+				t.Errorf("expected success for %v, got: %v", tc, err)
 			} else if auth == authn.Anonymous {
-				t.Errorf("expected not anonymous auth, got: %v", auth)
+				t.Errorf("expected not anonymous auth for %v, got: %v", tc, auth)
 			}
 		})
 	}

--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -51,8 +51,8 @@ type googleKeychain struct {
 // In general, we don't worry about that here because we expect to use the same
 // gcloud configuration in the scope of this one process.
 func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
-	// Only authenticate GCR so it works with authn.NewMultiKeychain to fallback.
-	if !strings.HasSuffix(target.RegistryStr(), "gcr.io") {
+	// Only authenticate GCR and AR so it works with authn.NewMultiKeychain to fallback.
+	if !strings.HasSuffix(target.RegistryStr(), "gcr.io") && !strings.HasSuffix(target.RegistryStr(), "pkg.dev") {
 		return authn.Anonymous, nil
 	}
 

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -98,12 +98,14 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 	return &tags, nil
 }
 
+// Uploaded uses json.Number to work around GCR returning timeUploaded
+// as a string, while AR returns the same field as int64.
 type rawManifestInfo struct {
-	Size      string   `json:"imageSizeBytes"`
-	MediaType string   `json:"mediaType"`
-	Created   string   `json:"timeCreatedMs"`
-	Uploaded  string   `json:"timeUploadedMs"`
-	Tags      []string `json:"tag"`
+	Size      string      `json:"imageSizeBytes"`
+	MediaType string      `json:"mediaType"`
+	Created   string      `json:"timeCreatedMs"`
+	Uploaded  json.Number `json:"timeUploadedMs"`
+	Tags      []string    `json:"tag"`
 }
 
 // ManifestInfo is a Manifests entry is the output of List and Walk.
@@ -131,7 +133,7 @@ func (m ManifestInfo) MarshalJSON() ([]byte, error) {
 		Size:      strconv.FormatUint(m.Size, 10),
 		MediaType: m.MediaType,
 		Created:   toUnixMs(m.Created),
-		Uploaded:  toUnixMs(m.Uploaded),
+		Uploaded:  json.Number(toUnixMs(m.Uploaded)),
 		Tags:      m.Tags,
 	})
 }

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -67,6 +67,64 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
+// GCR returns timeUploaded as string
+func TestTimeUploadedMsAsString(t *testing.T) {
+	data := []byte(`
+		{
+			"imageSizeBytes": "100",
+			"mediaType": "hi",
+      		"tag": ["latest"],
+      		"timeCreatedMs": "12345678",
+      		"timeUploadedMs": "23456789"
+		}
+	`)
+
+	raw := rawManifestInfo{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRaw := rawManifestInfo{
+		Size:      "100",
+		MediaType: "hi",
+		Created:   "12345678",
+		Uploaded:  "23456789",
+		Tags:      []string{"latest"},
+	}
+
+	if diff := cmp.Diff(expectedRaw, raw); diff != "" {
+		t.Errorf("Can't unmarshal rawManifestInfo with string timeUploadedMs: (-want +got) = %s", diff)
+	}
+}
+
+// AR returns timeUploaded as int64, and timeCreatedMs is missing
+func TestTimeUploadedMsAsInt64(t *testing.T) {
+	data := []byte(`
+		{
+			"imageSizeBytes": "100",
+			"mediaType": "hi",
+      		"tag": ["latest"],
+      		"timeUploadedMs": 23456789
+		}
+	`)
+
+	raw := rawManifestInfo{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRaw := rawManifestInfo{
+		Size:      "100",
+		MediaType: "hi",
+		Uploaded:  "23456789",
+		Tags:      []string{"latest"},
+	}
+
+	if diff := cmp.Diff(expectedRaw, raw); diff != "" {
+		t.Errorf("Can't unmarshal rawManifestInfo with int64 timeUploadedMs: (-want +got) = %s", diff)
+	}
+}
+
 func TestList(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -73,9 +73,9 @@ func TestTimeUploadedMsAsString(t *testing.T) {
 		{
 			"imageSizeBytes": "100",
 			"mediaType": "hi",
-      		"tag": ["latest"],
-      		"timeCreatedMs": "12345678",
-      		"timeUploadedMs": "23456789"
+	  		"tag": ["latest"],
+	  		"timeCreatedMs": "12345678",
+	  		"timeUploadedMs": "23456789"
 		}
 	`)
 
@@ -103,8 +103,8 @@ func TestTimeUploadedMsAsInt64(t *testing.T) {
 		{
 			"imageSizeBytes": "100",
 			"mediaType": "hi",
-      		"tag": ["latest"],
-      		"timeUploadedMs": 23456789
+	  		"tag": ["latest"],
+	  		"timeUploadedMs": 23456789
 		}
 	`)
 


### PR DESCRIPTION
- Use googleKeychain to authenticate to pkg.dev registries

- Handle schema difference for the list operation. GCR returns
  timeUploadedMs as a string, while AR returns the same field
  as int64