### PR TITLE
Add "crane auth" command

### DIFF
--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -1,0 +1,151 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdAuth()) }
+
+// NewCmdAuth creates a new cobra.Command for the auth subcommand.
+func NewCmdAuth() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Log in or access credentials",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Usage()
+		},
+	}
+	cmd.AddCommand(NewCmdAuthGet(), NewCmdAuthLogin())
+	return cmd
+}
+
+// NewCmdAuthGet creates a new `crane auth get` command.
+func NewCmdAuthGet() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get",
+		Short: "Implements a credential helper",
+		Example: `  # Read configured credentials for reg.example.com
+  echo "reg.example.com" | crane auth get
+  {"username":"AzureDiamond","password":"hunter2"}`,
+		Args: cobra.NoArgs,
+		Run: func(_ *cobra.Command, args []string) {
+			b, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				log.Fatal(err)
+			}
+			reg, err := name.NewRegistry(strings.TrimSpace(string(b)))
+			if err != nil {
+				log.Fatal(err)
+			}
+			auther, err := authn.DefaultKeychain.Resolve(reg)
+			if err != nil {
+				log.Fatal(err)
+			}
+			auth, err := auther.Authorization()
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err := json.NewEncoder(os.Stdout).Encode(auth); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+// NewCmdAuthLogin creates a new `crane auth login` command.
+func NewCmdAuthLogin() *cobra.Command {
+	var opts loginOptions
+
+	cmd := &cobra.Command{
+		Use:   "login [OPTIONS] [SERVER]",
+		Short: "Log in to a registry",
+		Example: `  # Log in to reg.example.com
+  crane auth login reg.example.com -u AzureDiamond -p hunter2`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			reg, err := name.NewRegistry(args[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			opts.serverAddress = reg.Name()
+
+			if err := login(opts); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVarP(&opts.user, "username", "u", "", "Username")
+	flags.StringVarP(&opts.password, "password", "p", "", "Password")
+	flags.BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "Take the password from stdin")
+
+	return cmd
+}
+
+type loginOptions struct {
+	serverAddress string
+	user          string
+	password      string
+	passwordStdin bool
+}
+
+func login(opts loginOptions) error {
+	if opts.passwordStdin {
+		contents, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		opts.password = strings.TrimSuffix(string(contents), "\n")
+		opts.password = strings.TrimSuffix(opts.password, "\r")
+	}
+	if opts.user == "" && opts.password == "" {
+		return errors.New("username and password required")
+	}
+	cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))
+	if err != nil {
+		return err
+	}
+	creds := cf.GetCredentialsStore(opts.serverAddress)
+	if opts.serverAddress == name.DefaultRegistry {
+		opts.serverAddress = authn.DefaultAuthKey
+	}
+	if err := creds.Store(types.AuthConfig{
+		ServerAddress: opts.serverAddress,
+		Username:      opts.user,
+		Password:      opts.password,
+	}); err != nil {
+		return err
+	}
+
+	return cf.Save()
+}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -21,6 +21,7 @@ crane [flags]
 ### SEE ALSO
 
 * [crane append](crane_append.md)	 - Append contents of a tarball to a remote image
+* [crane auth](crane_auth.md)	 - Log in or access credentials
 * [crane blob](crane_blob.md)	 - Read a blob from the registry
 * [crane catalog](crane_catalog.md)	 - List the repos in a registry
 * [crane config](crane_config.md)	 - Get the config of an image

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -1,0 +1,31 @@
+## crane auth
+
+Log in or access credentials
+
+### Synopsis
+
+Log in or access credentials
+
+```
+crane auth [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for auth
+```
+
+### Options inherited from parent commands
+
+```
+      --insecure   Allow image references to be fetched without TLS
+  -v, --verbose    Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane](crane.md)	 - Crane is a tool for managing container images
+* [crane auth get](crane_auth_get.md)	 - Implements a credential helper
+* [crane auth login](crane_auth_login.md)	 - Log in to a registry
+

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -1,0 +1,37 @@
+## crane auth get
+
+Implements a credential helper
+
+### Synopsis
+
+Implements a credential helper
+
+```
+crane auth get [flags]
+```
+
+### Examples
+
+```
+  # Read configured credentials for reg.example.com
+  echo "reg.example.com" | crane auth get
+  {"username":"AzureDiamond","password":"hunter2"}
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --insecure   Allow image references to be fetched without TLS
+  -v, --verbose    Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane auth](crane_auth.md)	 - Log in or access credentials
+

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -1,0 +1,39 @@
+## crane auth login
+
+Log in to a registry
+
+### Synopsis
+
+Log in to a registry
+
+```
+crane auth login [OPTIONS] [SERVER] [flags]
+```
+
+### Examples
+
+```
+  # Log in to reg.example.com
+  crane auth login reg.example.com -u AzureDiamond -p hunter2
+```
+
+### Options
+
+```
+  -h, --help              help for login
+  -p, --password string   Password
+      --password-stdin    Take the password from stdin
+  -u, --username string   Username
+```
+
+### Options inherited from parent commands
+
+```
+      --insecure   Allow image references to be fetched without TLS
+  -v, --verbose    Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane auth](crane_auth.md)	 - Log in or access credentials
+

--- a/go.mod
+++ b/go.mod
@@ -17,15 +17,15 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238
-	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
+	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
-	golang.org/x/tools v0.0.0-20200115165105-de0b1760071a // indirect
+	golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
-	k8s.io/code-generator v0.17.1
+	k8s.io/code-generator v0.17.2
 )

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,11 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jK
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
+golang.org/x/lint v0.0.0-20200130185559-910be7a94367 h1:0IiAsCRByjO2QjX7ZPkw5oU9x+n1YqRL802rjC0c3Aw=
+golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -429,7 +432,11 @@ golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921 h1:a2kzKBu/PCzjVEtbXNEyM2K
 golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115165105-de0b1760071a h1:bEJ3JL2YUH3tt9KX9dsy0WUF3WOrhjtNjK93o0svepY=
 golang.org/x/tools v0.0.0-20200115165105-de0b1760071a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 h1:a/Fd23DJvg1CaeDH0dYHahE+hCI0v9rFgxSNIThoUcM=
+golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
@@ -498,6 +505,8 @@ k8s.io/code-generator v0.0.0-20191121015212-c4c8f8345c7e h1:HB9Zu5ZUvJfNpLiTPhz+
 k8s.io/code-generator v0.0.0-20191121015212-c4c8f8345c7e/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
 k8s.io/code-generator v0.17.1 h1:e3B1UqRzRUWygp7WD+QTRT3ZUahPIaRKF0OFa7duQwI=
 k8s.io/code-generator v0.17.1/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
+k8s.io/code-generator v0.17.2 h1:pTwl3rLB1fUyxmvEzmVPMM0tBSdUehd7z+bDzpj4lPE=
+k8s.io/code-generator v0.17.2/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
 k8s.io/component-base v0.17.0 h1:BnDFcmBDq+RPpxXjmuYnZXb59XNN9CaFrX8ba9+3xrA=
 k8s.io/component-base v0.17.0/go.mod h1:rKuRAokNMY2nn2A6LP/MiwpoaMRHpfRnrPaUJJj1Yoc=
 k8s.io/csi-translation-lib v0.17.0/go.mod h1:HEF7MEz7pOLJCnxabi45IPkhSsE/KmxPQksuCrHKWls=

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -52,7 +52,9 @@ var (
 )
 
 const (
-	defaultAuthKey = "https://" + name.DefaultRegistry + "/v1/"
+	// DefaultAuthKey is the key used for dockerhub in config files, which
+	// is hardcoded for historical reasons.
+	DefaultAuthKey = "https://" + name.DefaultRegistry + "/v1/"
 )
 
 // Resolve implements Keychain.
@@ -67,7 +69,7 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	// https://github.com/moby/moby/blob/fc01c2b481097a6057bec3cd1ab2d7b4488c50c4/registry/config.go#L397-L404
 	key := target.RegistryStr()
 	if key == name.DefaultRegistry {
-		key = defaultAuthKey
+		key = DefaultAuthKey
 	}
 
 	cfg, err := cf.GetAuthConfig(key)

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -107,7 +107,7 @@ func TestVariousPaths(t *testing.T) {
 		},
 	}, {
 		target:  defaultRegistry,
-		content: fmt.Sprintf(`{"auths": {"%s": {"auth": %q}}}`, defaultAuthKey, encode("foo", "bar")),
+		content: fmt.Sprintf(`{"auths": {"%s": {"auth": %q}}}`, DefaultAuthKey, encode("foo", "bar")),
 		cfg: &AuthConfig{
 			Username: "foo",
 			Password: "bar",


### PR DESCRIPTION
Fixes #664 

Expose the rather complicated logic for resolving a config file to
credentials as "crane auth get" via the credential helper API.

Also expose a simple "crane auth login" command to make populating the
config file with basic auth simpler.