### PR TITLE
Add WithClient to daemon.Image

### DIFF
--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -14,6 +14,13 @@
 
 package daemon
 
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+)
+
 // WithBufferedOpener buffers the image.
 func WithBufferedOpener() ImageOption {
 	return func(i *imageOpener) error {
@@ -31,4 +38,23 @@ func WithUnbufferedOpener() ImageOption {
 func (i *imageOpener) setBuffered(buffer bool) error {
 	i.buffered = buffer
 	return nil
+}
+
+// WithClient is a functional option to allow injecting a docker client.
+//
+// By default, github.com/docker/docker/client.FromEnv is used.
+func WithClient(client Client) ImageOption {
+	return func(i *imageOpener) error {
+		i.client = client
+		return nil
+	}
+}
+
+// Client represents the subset of a docker client that the daemon
+// package uses.
+type Client interface {
+	NegotiateAPIVersion(ctx context.Context)
+	ImageSave(context.Context, []string) (io.ReadCloser, error)
+	ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error)
+	ImageTag(context.Context, string, string) error
 }


### PR DESCRIPTION
Fixes #139

Rather than wrapping the docker client options (as proposed in #139),
this just allows you to pass in an entire client implementation. This
makes testing a nicer, since we can pass in a MockImageSaver, and
callers can configure the client however they'd like without us having
to keep up with the docker client dependency.

By default, we'll still use the same options (client.FromEnv) to reach
the daemon (for compatibility).