### PR TITLE
add download progress option for v1.tarball

### DIFF
--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -63,6 +63,7 @@ func Save(img v1.Image, src, path string) error {
 		tag = d.Repository.Tag(iWasADigestTag)
 	}
 
+	// no progress channel (for now)
 	return tarball.WriteToFile(path, tag, img)
 }
 

--- a/pkg/v1/progress.go
+++ b/pkg/v1/progress.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// Update representation of an update of transfer progress. Some functions
+// in this module can take a channel to which updates will be sent while a
+// transfer is in progress.
+type Update struct {
+	Total    int64
+	Complete int64
+	Error    error
+}

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -31,41 +32,41 @@ import (
 
 // WriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.Write with a new file.
-func WriteToFile(p string, ref name.Reference, img v1.Image) error {
+func WriteToFile(p string, ref name.Reference, img v1.Image, opts ...WriteOption) error {
 	w, err := os.Create(p)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 
-	return Write(ref, img, w)
+	return Write(ref, img, w, opts...)
 }
 
 // MultiWriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.MultiWrite with a new file.
-func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image) error {
+func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image, opts ...WriteOption) error {
 	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))
 	for i, d := range tagToImage {
 		refToImage[i] = d
 	}
-	return MultiRefWriteToFile(p, refToImage)
+	return MultiRefWriteToFile(p, refToImage, opts...)
 }
 
 // MultiRefWriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.MultiRefWrite with a new file.
-func MultiRefWriteToFile(p string, refToImage map[name.Reference]v1.Image) error {
+func MultiRefWriteToFile(p string, refToImage map[name.Reference]v1.Image, opts ...WriteOption) error {
 	w, err := os.Create(p)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 
-	return MultiRefWrite(refToImage, w)
+	return MultiRefWrite(refToImage, w, opts...)
 }
 
 // Write is a wrapper to write a single image and tag to a tarball.
-func Write(ref name.Reference, img v1.Image, w io.Writer) error {
-	return MultiRefWrite(map[name.Reference]v1.Image{ref: img}, w)
+func Write(ref name.Reference, img v1.Image, w io.Writer, opts ...WriteOption) error {
+	return MultiRefWrite(map[name.Reference]v1.Image{ref: img}, w, opts...)
 }
 
 // MultiWrite writes the contents of each image to the provided reader, in the compressed format.
@@ -73,12 +74,12 @@ func Write(ref name.Reference, img v1.Image, w io.Writer) error {
 // One manifest.json file at the top level containing information about several images.
 // One file for each layer, named after the layer's SHA.
 // One file for the config blob, named after its SHA.
-func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
+func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer, opts ...WriteOption) error {
 	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))
 	for i, d := range tagToImage {
 		refToImage[i] = d
 	}
-	return MultiRefWrite(refToImage, w)
+	return MultiRefWrite(refToImage, w, opts...)
 }
 
 // MultiRefWrite writes the contents of each image to the provided reader, in the compressed format.
@@ -86,45 +87,128 @@ func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer) error {
 // One manifest.json file at the top level containing information about several images.
 // One file for each layer, named after the layer's SHA.
 // One file for the config blob, named after its SHA.
-func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
-	tf := tar.NewWriter(w)
-	defer tf.Close()
-
-	m, err := processImages(refToImage, tf)
-	if err != nil {
-		return err
+func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer, opts ...WriteOption) error {
+	// process options
+	o := &writeOptions{
+		updates: nil,
+	}
+	for _, option := range opts {
+		if err := option(o); err != nil {
+			return err
+		}
 	}
 
+	m, err := calculateManifest(refToImage)
+	if err != nil {
+		return fmt.Errorf("error calculating manifest: %v", err)
+	}
 	mBytes, err := json.Marshal(m)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not marshall manifest to bytes: %v", err)
 	}
-	return writeTarEntry(tf, "manifest.json", bytes.NewReader(mBytes), int64(len(mBytes)))
+
+	size, err := calculateTarballSize(refToImage, mBytes)
+	if err != nil {
+		return fmt.Errorf("error calculating tarball size: %v", err)
+	}
+
+	return writeImagesToTar(refToImage, mBytes, size, w, o)
 }
 
-// processImages writes the images to the provider tar.Writer. Returns the manifest
-// for the written images as Manifest.`If the tar.Writer is nil, will just return
-// the Manifest.
-func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Manifest, error) {
+// writeImagesToTar writes the images to the tarball
+func writeImagesToTar(refToImage map[name.Reference]v1.Image, m []byte, size int64, w io.Writer, o *writeOptions) (err error) {
+	if w == nil {
+		return errors.New("must pass valid writer")
+	}
 	imageToTags := dedupRefToImage(refToImage)
-	var m Manifest
+
+	tw := w
+
+	// we only calculate the sizes and use a progressWriter if we were provided
+	// an option with a progress channel
+	if o != nil && o.updates != nil {
+		tw = &progressWriter{
+			w:       w,
+			updates: o.updates,
+			size:    size,
+		}
+	}
+
+	tf := tar.NewWriter(tw)
+	defer tf.Close()
 
 	seenLayerDigests := make(map[string]struct{})
 
-	for img, tags := range imageToTags {
+	for img := range imageToTags {
 		// Write the config.
 		cfgName, err := img.ConfigName()
 		if err != nil {
-			return nil, err
+			return err
 		}
-		if tf != nil {
-			cfgBlob, err := img.RawConfigFile()
+		cfgBlob, err := img.RawConfigFile()
+		if err != nil {
+			return err
+		}
+		if err := writeTarEntry(tf, cfgName.String(), bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
+			return err
+		}
+
+		// Write the layers.
+		layers, err := img.Layers()
+		if err != nil {
+			return err
+		}
+		layerFiles := make([]string, len(layers))
+		for i, l := range layers {
+			d, err := l.Digest()
 			if err != nil {
-				return nil, err
+				return err
 			}
-			if err := writeTarEntry(tf, cfgName.String(), bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
-				return nil, err
+			// Munge the file name to appease ancient technology.
+			//
+			// tar assumes anything with a colon is a remote tape drive:
+			// https://www.gnu.org/software/tar/manual/html_section/tar_45.html
+			// Drop the algorithm prefix, e.g. "sha256:"
+			hex := d.Hex
+
+			// gunzip expects certain file extensions:
+			// https://www.gnu.org/software/gzip/manual/html_node/Overview.html
+			layerFiles[i] = fmt.Sprintf("%s.tar.gz", hex)
+
+			if _, ok := seenLayerDigests[hex]; ok {
+				continue
 			}
+			seenLayerDigests[hex] = struct{}{}
+
+			r, err := l.Compressed()
+			if err != nil {
+				return err
+			}
+			blobSize, err := l.Size()
+			if err != nil {
+				return err
+			}
+
+			if err := writeTarEntry(tf, layerFiles[i], r, blobSize); err != nil {
+				return err
+			}
+		}
+	}
+	if err := writeTarEntry(tf, "manifest.json", bytes.NewReader(m), int64(len(m))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// calculateManifest calculates the manifest and optionally the size of the tar file
+func calculateManifest(refToImage map[name.Reference]v1.Image) (m Manifest, err error) {
+	imageToTags := dedupRefToImage(refToImage)
+
+	for img, tags := range imageToTags {
+		cfgName, err := img.ConfigName()
+		if err != nil {
+			return nil, err
 		}
 
 		// Store foreign layer info.
@@ -152,11 +236,6 @@ func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Mani
 			// https://www.gnu.org/software/gzip/manual/html_node/Overview.html
 			layerFiles[i] = fmt.Sprintf("%s.tar.gz", hex)
 
-			if _, ok := seenLayerDigests[hex]; ok {
-				continue
-			}
-			seenLayerDigests[hex] = struct{}{}
-
 			// Add to LayerSources if it's a foreign layer.
 			desc, err := partial.BlobDescriptor(img, d)
 			if err != nil {
@@ -168,21 +247,6 @@ func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Mani
 					return nil, err
 				}
 				layerSources[diffid] = *desc
-			}
-
-			if tf != nil {
-				r, err := l.Compressed()
-				if err != nil {
-					return nil, err
-				}
-				blobSize, err := l.Size()
-				if err != nil {
-					return nil, err
-				}
-
-				if err := writeTarEntry(tf, layerFiles[i], r, blobSize); err != nil {
-					return nil, err
-				}
 			}
 		}
 
@@ -201,6 +265,32 @@ func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Mani
 	})
 
 	return m, nil
+}
+
+// calculateTarballSize calculates the size of the tar file
+func calculateTarballSize(refToImage map[name.Reference]v1.Image, m []byte) (size int64, err error) {
+	imageToTags := dedupRefToImage(refToImage)
+
+	for img, name := range imageToTags {
+		manifest, err := img.Manifest()
+		if err != nil {
+			return size, fmt.Errorf("unable to get manifest for img %s: %v", name, err)
+		}
+		size += CalculateTarFileSize(manifest.Config.Size)
+		for _, l := range manifest.Layers {
+			size += CalculateTarFileSize(l.Size)
+		}
+	}
+	// add the manifest
+	mBytes, err := json.Marshal(m)
+	if err != nil {
+		return size, err
+	}
+	size += CalculateTarFileSize(int64(len(mBytes)))
+
+	// add the two padding blocks that indicate end of a tar file
+	size += 1024
+	return size, nil
 }
 
 func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]string {
@@ -241,5 +331,56 @@ func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 // ComputeManifest get the manifest.json that will be written to the tarball
 // for multiple references
 func ComputeManifest(refToImage map[name.Reference]v1.Image) (Manifest, error) {
-	return processImages(refToImage, nil)
+	return calculateManifest(refToImage)
+}
+
+// WriteOption a function option to pass to Write()
+type WriteOption func(*writeOptions) error
+type writeOptions struct {
+	updates chan<- v1.Update
+}
+
+// WithProgress create a WriteOption for passing to Write() that enables
+// a channel to receive updates as they are downloaded and written to disk.
+func WithProgress(updates chan<- v1.Update) WriteOption {
+	return func(o *writeOptions) error {
+		o.updates = updates
+		return nil
+	}
+}
+
+// progressWriter is a writer which will send the download progress
+type progressWriter struct {
+	w              io.Writer
+	updates        chan<- v1.Update
+	size, complete int64
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.w.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	pw.complete += int64(n)
+
+	pw.updates <- v1.Update{
+		Total:    pw.size,
+		Complete: pw.complete,
+	}
+
+	return n, err
+}
+
+// CalculateTarFileSize calculate the size a file will take up in a tar archive,
+// given the input data. Provided by rounding up to nearest whole block (512)
+// and adding header 512
+func CalculateTarFileSize(in int64) (out int64) {
+	// doing this manually, because math.Round() works with float64
+	out += in
+	if remainder := out % 512; remainder != 0 {
+		out += (512 - remainder)
+	}
+	out += 512
+	return out
 }

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
@@ -483,4 +484,69 @@ func getLayersFilenames(hashes []string) []string {
 		filenames = append(filenames, fmt.Sprintf("%s.tar.gz", h))
 	}
 	return filenames
+}
+
+func ExampleWithProgress() {
+	/* calculations for this test:
+	The image we are using is docker.io/library/alpine:3.10
+	its size on disk is 2800640
+	The filesizes inside are:
+	-rw-r--r--  0 0      0        1509 Jan  1  1970 sha256:be4e4bea2c2e15b403bb321562e78ea84b501fb41497472e91ecb41504e8a27c
+	-rw-r--r--  0 0      0     2795580 Jan  1  1970 21c83c5242199776c232920ddb58cfa2a46b17e42ed831ca9001c8dbc532d22d.tar.gz
+	-rw-r--r--  0 0      0         216 Jan  1  1970 manifest.json
+	when rounding each to a 512-byte block, plus the header, we get:
+	1509    ->    1536 + 512 = 2048
+	2795580 -> 2796032 + 512 = 2796544
+	216     ->     512 + 512 = 1024
+	add in 2 blocks of all 0x00 to indicate end of archive
+	                         = 1024
+	                        -------
+	Total:                  2800640
+	*/
+	// buffered channel to make the example test easier
+	c := make(chan v1.Update, 200)
+	// Make a tempfile for tarball writes.
+	fp, err := ioutil.TempFile("", "")
+	if err != nil {
+		fmt.Printf("error creating temp file: %v\n", err)
+		return
+	}
+	defer fp.Close()
+	defer os.Remove(fp.Name())
+
+	tag, err := name.NewDigest("docker.io/library/alpine@sha256:f0e9534a598e501320957059cb2a23774b4d4072e37c7b2cf7e95b241f019e35", name.StrictValidation)
+	if err != nil {
+		fmt.Printf("error creating test tag: %v\n", err)
+		return
+	}
+	desc, err := remote.Get(tag)
+	if err != nil {
+		fmt.Printf("error getting manifest: %v", err)
+		return
+	}
+	img, err := desc.Image()
+	if err != nil {
+		fmt.Printf("error image: %v", err)
+		return
+	}
+	errchan := make(chan error)
+	go func() {
+		if err := tarball.WriteToFile(fp.Name(), tag, img, tarball.WithProgress(c)); err != nil {
+			fmt.Printf("error writing tarball: %v\n", err)
+			errchan <- err
+		}
+		errchan <- nil
+	}()
+	var update v1.Update
+	for {
+		select {
+		case update = <-c:
+			fmt.Fprintf(os.Stderr, "receive update: %#v\n", update)
+		case err = <-errchan:
+			fmt.Fprintf(os.Stderr, "receive error message: %v\n", err)
+			fmt.Printf("%d/%d", update.Complete, update.Total)
+			// Output: 2800640/2800640
+			return
+		}
+	}
 }


### PR DESCRIPTION
Initial implementation of download progress, per [the discussion here](https://github.com/google/go-containerregistry/issues/670#issuecomment-584952872) with @jonjohnsonjr .

This only does it for `v1.tarball`; it still will need to be added to `legacy.tarball` and `v1.layout`. I also have given it zero testing. The goal is to have a basis for discussion.

I chose to change the calls to `Write/MultiWrite/MultiWriteRef` rather than entirely new funcs because:

* it would create an over-proliferation of functions and be very messy
* you always can pass in `nil` to a channel arg if you don't want it (which is what I did for almost all consumers
* with go modules, versioning of consumers is easy, so breaking changes on a new commit is not a big deal.

