### PR TITLE
Preserve Descriptor in remote where possible

### DIFF
--- a/pkg/legacy/tarball/write.go
+++ b/pkg/legacy/tarball/write.go
@@ -158,7 +158,7 @@ func updateLayerSources(layerSources map[v1.Hash]v1.Descriptor, layer v1.Layer, 
 		if err != nil {
 			return err
 		}
-		layerSources[diffid] = desc
+		layerSources[diffid] = *desc
 	}
 	return nil
 }

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -201,22 +201,22 @@ func BlobSize(i WithManifest, h v1.Hash) (int64, error) {
 }
 
 // BlobDescriptor is a helper for implementing v1.Image
-func BlobDescriptor(i WithManifest, h v1.Hash) (v1.Descriptor, error) {
+func BlobDescriptor(i WithManifest, h v1.Hash) (*v1.Descriptor, error) {
 	m, err := i.Manifest()
 	if err != nil {
-		return v1.Descriptor{}, err
+		return nil, err
 	}
 
 	if m.Config.Digest == h {
-		return m.Config, nil
+		return &m.Config, nil
 	}
 
 	for _, l := range m.Layers {
 		if l.Digest == h {
-			return l, nil
+			return &l, nil
 		}
 	}
-	return v1.Descriptor{}, fmt.Errorf("blob %v not found", h)
+	return nil, fmt.Errorf("blob %v not found", h)
 }
 
 // WithManifestAndConfigFile defines the subset of v1.Image used by these helper methods

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -77,14 +77,12 @@ func (d *Descriptor) RawManifest() ([]byte, error) {
 // querying what kind of artifact a reference represents.
 func Get(ref name.Reference, options ...Option) (*Descriptor, error) {
 	acceptable := []types.MediaType{
-		types.DockerManifestSchema2,
-		types.OCIManifestSchema1,
-		types.DockerManifestList,
-		types.OCIImageIndex,
 		// Just to look at them.
 		types.DockerManifestSchema1,
 		types.DockerManifestSchema1Signed,
 	}
+	acceptable = append(acceptable, acceptableImageMediaTypes...)
+	acceptable = append(acceptable, acceptableIndexMediaTypes...)
 	return get(ref, acceptable, options...)
 }
 
@@ -174,8 +172,9 @@ func (d *Descriptor) remoteImage() *remoteImage {
 			Ref:    d.Ref,
 			Client: d.Client,
 		},
-		manifest:  d.Manifest,
-		mediaType: d.MediaType,
+		manifest:   d.Manifest,
+		mediaType:  d.MediaType,
+		descriptor: &d.Descriptor,
 	}
 }
 
@@ -185,8 +184,9 @@ func (d *Descriptor) remoteIndex() *remoteIndex {
 			Ref:    d.Ref,
 			Client: d.Client,
 		},
-		manifest:  d.Manifest,
-		mediaType: d.MediaType,
+		manifest:   d.Manifest,
+		mediaType:  d.MediaType,
+		descriptor: &d.Descriptor,
 	}
 }
 

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -29,6 +29,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/v1util"
 )
 
+var acceptableImageMediaTypes = []types.MediaType{
+	types.DockerManifestSchema2,
+	types.OCIManifestSchema1,
+}
+
 // remoteImage accesses an image from a remote registry
 type remoteImage struct {
 	fetcher
@@ -37,6 +42,7 @@ type remoteImage struct {
 	configLock   sync.Mutex // Protects config
 	config       []byte
 	mediaType    types.MediaType
+	descriptor   *v1.Descriptor
 }
 
 var _ partial.CompressedImageCore = (*remoteImage)(nil)
@@ -68,15 +74,14 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
 	// do type-checking via remote.Descriptor. I've left this here for tests that
 	// directly instantiate a remoteImage.
-	acceptable := []types.MediaType{
-		types.DockerManifestSchema2,
-		types.OCIManifestSchema1,
-	}
-	manifest, desc, err := r.fetchManifest(r.Ref, acceptable)
+	manifest, desc, err := r.fetchManifest(r.Ref, acceptableImageMediaTypes)
 	if err != nil {
 		return nil, err
 	}
 
+	if r.descriptor == nil {
+		r.descriptor = desc
+	}
 	r.mediaType = desc.MediaType
 	r.manifest = manifest
 	return r.manifest, nil
@@ -105,6 +110,15 @@ func (r *remoteImage) RawConfigFile() ([]byte, error) {
 		return nil, err
 	}
 	return r.config, nil
+}
+
+// Descriptor retains the original descriptor from an index manifest.
+// See partial.Descriptor.
+func (r *remoteImage) Descriptor() (*v1.Descriptor, error) {
+	// kind of a hack, but RawManifest does appropriate locking/memoization
+	// and makes sure r.descriptor is populated.
+	_, err := r.RawManifest()
+	return r.descriptor, err
 }
 
 // remoteImageLayer implements partial.CompressedLayer
@@ -190,6 +204,12 @@ func (rl *remoteImageLayer) ConfigFile() (*v1.ConfigFile, error) {
 // available in our ConfigFile.
 func (rl *remoteImageLayer) DiffID() (v1.Hash, error) {
 	return partial.BlobToDiffID(rl, rl.digest)
+}
+
+// Descriptor retains the original descriptor from an image manifest.
+// See partial.Descriptor.
+func (rl *remoteImageLayer) Descriptor() (*v1.Descriptor, error) {
+	return partial.BlobDescriptor(rl, rl.digest)
 }
 
 // LayerByDigest implements partial.CompressedLayer

--- a/pkg/v1/remote/mount.go
+++ b/pkg/v1/remote/mount.go
@@ -17,6 +17,7 @@ package remote
 import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 )
 
 // MountableLayer wraps a v1.Layer in a shim that enables the layer to be
@@ -25,6 +26,12 @@ type MountableLayer struct {
 	v1.Layer
 
 	Reference name.Reference
+}
+
+// Descriptor retains the original descriptor from an image manifest.
+// See partial.Descriptor.
+func (ml *MountableLayer) Descriptor() (*v1.Descriptor, error) {
+	return partial.Descriptor(ml.Layer)
 }
 
 // mountableImage wraps the v1.Layer references returned by the embedded v1.Image
@@ -74,4 +81,10 @@ func (mi *mountableImage) LayerByDiffID(d v1.Hash) (v1.Layer, error) {
 		Layer:     l,
 		Reference: mi.Reference,
 	}, nil
+}
+
+// Descriptor retains the original descriptor from an index manifest.
+// See partial.Descriptor.
+func (mi *mountableImage) Descriptor() (*v1.Descriptor, error) {
+	return partial.Descriptor(mi.Image)
 }

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -1359,6 +1359,9 @@ func TestNestedIndex(t *testing.T) {
 	}
 	parent := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 		Add: child,
+		Descriptor: v1.Descriptor{
+			URLs: []string{"example.com/url"},
+		},
 	})
 
 	if err := WriteIndex(srcRef, parent); err != nil {
@@ -1371,6 +1374,29 @@ func TestNestedIndex(t *testing.T) {
 
 	if err := validate.Index(pulled); err != nil {
 		t.Fatalf("validate.Index: %v", err)
+	}
+
+	digest, err := child.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pulledChild, err := pulled.ImageIndex(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desc, err := partial.Descriptor(pulledChild)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(desc.URLs) != 1 {
+		t.Fatalf("expected url for pulledChild")
+	}
+
+	if want, got := "example.com/url", desc.URLs[0]; want != got {
+		t.Errorf("pulledChild.urls[0] = %s != %s", got, want)
 	}
 }
 

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -146,7 +146,7 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 				if err != nil {
 					return err
 				}
-				layerSources[diffid] = desc
+				layerSources[diffid] = *desc
 			}
 
 			r, err := l.Compressed()


### PR DESCRIPTION
Fixes #683 

If we resolve an index to an image, we can potentially lose a lot of
information, e.g. annotations or anything in the platform that's not in
the config, which only has os/arch.

If we return a layer from an image, we can look up the original
descriptor from that image to return as well, which might include
annotations or urls. Previously, the Mountable wrapping made this not
work.