### PR TITLE
Compare mount targets by string

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -449,7 +449,7 @@ func scopesForUploadingImage(repo name.Repository, layers []v1.Layer) []string {
 		if ml, ok := l.(*MountableLayer); ok {
 			// we will add push scope for ref.Context() after the loop.
 			// for now we ask pull scope for references of the same registry
-			if ml.Reference.Context() != repo && ml.Reference.Context().Registry == repo.Registry {
+			if ml.Reference.Context().String() != repo.String() && ml.Reference.Context().Registry.String() == repo.Registry.String() {
 				scopeSet[ml.Reference.Scope(transport.PullScope)] = struct{}{}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/689

The defaulting logic is being deferred to accessors, which means
comparing the structs of a repo or registry will result in non-equal
references even if they're semantically equivalent. This converts them
to strings to fix that.