### PR TITLE
Fix GitLab CI example

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -42,6 +42,6 @@ docker-tag-latest:
     name: gcr.io/go-containerregistry/crane:debug
     entrypoint: [""]
   script:
-    - crane login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - crane auth login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - crane tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA latest
 ```


### PR DESCRIPTION
The command to login should be `crane auth login`.