### PR TITLE
Canonical should keep OS/ARCH

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -281,6 +281,7 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 	// Copy basic config over
 	cfg.Architecture = ocf.Architecture
 	cfg.OS = ocf.OS
+	cfg.OSVersion = ocf.OSVersion
 	cfg.Config = ocf.Config
 
 	// Strip away timestamps from the config file

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -279,6 +279,8 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 	cfg := cf.DeepCopy()
 
 	// Copy basic config over
+	cfg.Architecture = ocf.Architecture
+	cfg.OS = ocf.OS
 	cfg.Config = ocf.Config
 
 	// Strip away timestamps from the config file

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -459,6 +459,11 @@ func TestCanonical(t *testing.T) {
 	if want != got {
 		t.Errorf("%q != %q", want, got)
 	}
+	want = cf.OSVersion
+	got = sourceCf.OSVersion
+	if want != got {
+		t.Errorf("%q != %q", want, got)
+	}
 	for _, s := range []string{
 		cf.Container,
 		cf.Config.Hostname,

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -440,11 +440,25 @@ func TestCanonical(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sourceCf, err := source.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
 	cf, err := img.ConfigFile()
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	var want, got string
+	want = cf.Architecture
+	got = sourceCf.Architecture
+	if want != got {
+		t.Errorf("%q != %q", want, got)
+	}
+	want = cf.OS
+	got = sourceCf.OS
+	if want != got {
+		t.Errorf("%q != %q", want, got)
+	}
 	for _, s := range []string{
 		cf.Container,
 		cf.Config.Hostname,


### PR DESCRIPTION
These fields should be considered in canonical image. Upstream of a kaniko PR (tbd)