### PR TITLE
Pass RegistryToken directly

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -92,6 +92,12 @@ func (bt *bearerTransport) refresh() error {
 	if err != nil {
 		return err
 	}
+
+	if auth.RegistryToken != "" {
+		bt.bearer.RegistryToken = auth.RegistryToken
+		return nil
+	}
+
 	var content []byte
 	if auth.IdentityToken != "" {
 		// If the secret being stored is an identity token,


### PR DESCRIPTION
I would like to pass the Bearer Token generated elsewhere directly. This is because I am developing plugins of some container registries such as Harbor and Quay. These plugins receive Bearer Token directly instead of username/password and need to use it for the authentication with the registries.

```
token := "eyJhbGciOiJSUzI1NiI..." //  passed by a container registry
img, err := remote.Image(ref, remote.WithAuth(&authn.Bearer{Token: token}))
if err != nil {
	return err
}
...
```