### PR TITLE
Add ImageFromReader

### DIFF
--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -68,6 +68,18 @@ func ImageFromPath(path string, tag *name.Tag) (v1.Image, error) {
 	return Image(pathOpener(path), tag)
 }
 
+// ImageFromReader returns a v1.Image given a io.Reader.
+func ImageFromReader(reader io.Reader, tag *name.Tag) (v1.Image, error) {
+	// Buffering due to Opener requiring multiple calls.
+	a, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return Image(func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(bytes.NewReader(a)), nil
+	}, tag)
+}
+
 // Image exposes an image from the tarball at the provided path.
 func Image(opener Opener, tag *name.Tag) (v1.Image, error) {
 	img := &image{

--- a/pkg/v1/tarball/image_test.go
+++ b/pkg/v1/tarball/image_test.go
@@ -15,6 +15,7 @@
 package tarball
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -23,6 +24,37 @@ import (
 
 func TestManifestAndConfig(t *testing.T) {
 	img, err := ImageFromPath("testdata/test_image_1.tar", nil)
+	if err != nil {
+		t.Fatalf("Error loading image: %v", err)
+	}
+	manifest, err := img.Manifest()
+	if err != nil {
+		t.Fatalf("Error loading manifest: %v", err)
+	}
+	if len(manifest.Layers) != 1 {
+		t.Fatalf("layers should be 1, got %d", len(manifest.Layers))
+	}
+
+	config, err := img.ConfigFile()
+	if err != nil {
+		t.Fatalf("Error loading config file: %v", err)
+	}
+	if len(config.History) != 1 {
+		t.Fatalf("history length should be 1, got %d", len(config.History))
+	}
+
+	if err := validate.Image(img); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestImageFromReader(t *testing.T) {
+	f, err := os.Open("testdata/test_image_1.tar")
+	if err != nil {
+		t.Fatalf("Unable to read tar file: %v", err)
+	}
+
+	img, err := ImageFromReader(f, nil)
 	if err != nil {
 		t.Fatalf("Error loading image: %v", err)
 	}


### PR DESCRIPTION
`tarball.Layer` has `LayerFromReader`, while `tarball.Image` doesn't have `ImageFromReader`. This PR just copies `LayerFromReader` to `ImageFromReader`.
https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#LayerFromReader