### PR TITLE
Extend the remote tag listing to include more tag details from the manifest

### DIFF
--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -17,6 +17,11 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
@@ -26,20 +31,53 @@ func init() { Root.AddCommand(NewCmdList()) }
 
 // NewCmdList creates a new cobra.Command for the ls subcommand.
 func NewCmdList() *cobra.Command {
-	return &cobra.Command{
+	var all bool
+	listCmd := &cobra.Command{
 		Use:   "ls REPO",
 		Short: "List the tags in a repo",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			repo := args[0]
-			tags, err := crane.ListTags(repo, options...)
-			if err != nil {
-				log.Fatalf("reading tags for %s: %v", repo, err)
-			}
+			if all {
+				_, tagDetailsList, err := crane.ListTagsDetails(repo, options...)
+				if err != nil {
+					log.Fatalf("reading tags for %s: %v", repo, err)
+				}
 
-			for _, tag := range tags {
-				fmt.Println(tag)
+				// sort the tag details list by creation time
+				sort.Slice(tagDetailsList, func(i, j int) bool {
+					return tagDetailsList[i].CreateTime.After(tagDetailsList[j].CreateTime)
+				})
+
+				tw := tabwriter.NewWriter(os.Stdout, 30, 8, 2, '\t', 0)
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+					"TAGS",
+					"SHA",
+					"CREATE TIME",
+					"UPLOAD TIME",
+				)
+				for _, tag := range tagDetailsList {
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+						strings.Join(tag.Tags, ","),
+						tag.Sha,
+						tag.CreateTime.Format(time.RFC822),
+						tag.UploadTime.Format(time.RFC822),
+					)
+					tw.Flush()
+				}
+			} else {
+				tags, err := crane.ListTags(repo, options...)
+				if err != nil {
+					log.Fatalf("reading tags for %s: %v", repo, err)
+				}
+				for _, tag := range tags {
+					fmt.Println(tag)
+				}
 			}
 		},
 	}
+
+	listCmd.Flags().BoolVarP(&all, "all", "a", false, "List all tag details")
+
+	return listCmd
 }

--- a/pkg/crane/list.go
+++ b/pkg/crane/list.go
@@ -31,3 +31,14 @@ func ListTags(src string, opt ...Option) ([]string, error) {
 
 	return remote.List(repo, o.remote...)
 }
+
+// ListTagsDetails returns the tags and a tags details list in repository src.
+func ListTagsDetails(src string, opt ...Option) ([]string, []remote.TagDetails, error) {
+	o := makeOptions(opt...)
+	repo, err := name.NewRepository(src, o.name...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing repo %q: %v", src, err)
+	}
+
+	return remote.ListDetails(repo, o.remote...)
+}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -18,17 +18,67 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
+// TagDetails keeps various details related to a tag which
+// are returned form the remote registry
+type TagDetails struct {
+	Sha            string    `json:"sha"`
+	ImageSizeBytes string    `json:"image_size_bytes"`
+	Tags           []string  `json:"tags"`
+	CreateTime     time.Time `json:"create_time"`
+	UploadTime     time.Time `json:"upload_time"`
+}
+
 type tags struct {
-	Name string   `json:"name"`
-	Tags []string `json:"tags"`
+	Manifest map[string]tagDetails `json:"manifest,omitempty"`
+	Name     string                `json:"name"`
+	Tags     []string              `json:"tags"`
+}
+
+type tagDetails struct {
+	ImageSizeBytes string   `json:"imageSizeBytes,omitempty"`
+	Tag            []string `json:"tag,omitempty"`
+	TimeCreatedMs  string   `json:"timeCreatedMs,omitempty"`
+	TimeUploadedMs string   `json:"timeUploadedMs,omitempty"`
+}
+
+// createTagDetailsList builds a TagDetails list from the manifest returned by
+// the remote repository
+func createTagDetailsList(manifest map[string]tagDetails) []TagDetails {
+	tags := []TagDetails{}
+	for sha, tag := range manifest {
+		// Skip empty tags
+		if len(tag.Tag) == 0 {
+			continue
+		}
+		createTimeMs, err := strconv.ParseInt(tag.TimeCreatedMs, 10, 64)
+		if err != nil {
+			continue
+		}
+		uploadTimeMs, err := strconv.ParseInt(tag.TimeUploadedMs, 10, 64)
+		if err != nil {
+			continue
+		}
+		tagDetails := TagDetails{
+			Sha:            sha,
+			ImageSizeBytes: tag.ImageSizeBytes,
+			Tags:           tag.Tag,
+			CreateTime:     time.Unix(createTimeMs/1000, 0),
+			UploadTime:     time.Unix(uploadTimeMs/1000, 0),
+		}
+		tags = append(tags, tagDetails)
+	}
+	return tags
 }
 
 // List wraps ListWithContext using the background context.
@@ -39,14 +89,32 @@ func List(repo name.Repository, options ...Option) ([]string, error) {
 // ListWithContext calls /tags/list for the given repository, returning the list of tags
 // in the "tags" property.
 func ListWithContext(ctx context.Context, repo name.Repository, options ...Option) ([]string, error) {
+	tags, _, err := listWithContext(ctx, repo, options...)
+	return tags, err
+}
+
+// ListDetails wraps ListDeatilsWithContext using the background context.
+func ListDetails(repo name.Repository, options ...Option) ([]string, []TagDetails, error) {
+	return ListDetailsWithContext(context.Background(), repo, options...)
+}
+
+// ListDetailsWithContext calls /tags/list for the given repository, returning the list of tags
+// in the "tags" property along with a list of tag details available in the "manifest" property
+func ListDetailsWithContext(ctx context.Context, repo name.Repository, options ...Option) ([]string, []TagDetails, error) {
+	return listWithContext(ctx, repo, options...)
+}
+
+// ListWithContext calls /tags/list for the given repository, returning the list of tags
+// in the "tags" property.
+func listWithContext(ctx context.Context, repo name.Repository, options ...Option) ([]string, []TagDetails, error) {
 	o, err := makeOptions(repo, options...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	scopes := []string{repo.Scope(transport.PullScope)}
 	tr, err := transport.New(repo.Registry, o.auth, o.transport, scopes)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	uri := &url.URL{
@@ -60,44 +128,45 @@ func ListWithContext(ctx context.Context, repo name.Repository, options ...Optio
 
 	client := http.Client{Transport: tr}
 	tagList := []string{}
-	parsed := tags{}
+	tagDetailsList := []TagDetails{}
 
 	// get responses until there is no next page
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 		}
 
 		req, err := http.NewRequest("GET", uri.String(), nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		req = req.WithContext(ctx)
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if err := transport.CheckError(resp, http.StatusOK); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-			return nil, err
+		tags, tdList, err := decodeReponse(resp.Body)
+		if err != nil {
+			return nil, nil, err
 		}
+		tagList = append(tagList, tags...)
+		tagDetailsList = append(tagDetailsList, tdList...)
 
 		if err := resp.Body.Close(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		tagList = append(tagList, parsed.Tags...)
 
 		uri, err = getNextPageURL(resp)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// no next page
 		if uri == nil {
@@ -105,7 +174,16 @@ func ListWithContext(ctx context.Context, repo name.Repository, options ...Optio
 		}
 	}
 
-	return tagList, nil
+	return tagList, tagDetailsList, nil
+}
+
+// decodeReponse parse the tags details from response
+func decodeReponse(resp io.ReadCloser) ([]string, []TagDetails, error) {
+	parsed := tags{}
+	if err := json.NewDecoder(resp).Decode(&parsed); err != nil {
+		return []string{}, []TagDetails{}, err
+	}
+	return parsed.Tags, createTagDetailsList(parsed.Manifest), nil
 }
 
 // getNextPageURL checks if there is a Link header in a http.Response which


### PR DESCRIPTION
In addition, the cran command was extended to print these details when the `-a` option
is provided.

The `cran list -a` command returns the following output:
```
./crane ls -a gcr.io/jenkinsxio/builder-jx
TAGS                            SHA                                                                             CREATE TIME                     UPLOAD TIME
2.0.1253-593,latest             sha256:521546feceeca228fea2e42c181361f6aa7d5e0e89f7eefe6f369cfb2ad7b73b         24 Mar 20 20:30 CET             24 Mar 20 20:31 CET
0.0.0-SNAPSHOT-PR-6961-2        sha256:786f17061022643ffb03c73905b483706202b22436f81d598d268b1840af8316         24 Mar 20 20:02 CET             24 Mar 20 20:03 CET
```

cc @madchap @mestrade 