### PR TITLE
Allow Reference also for daemon write

### DIFF
--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -60,7 +60,11 @@ func Save(img v1.Image, src, path string) error {
 		if !ok {
 			return fmt.Errorf("ref wasn't a tag or digest")
 		}
-		tag = d.Repository.Tag(iWasADigestTag)
+		if d.TagStr() != "" {
+			tag = d.Tag()
+		} else {
+			tag = d.Repository.Tag(iWasADigestTag)
+		}
 	}
 
 	// no progress channel (for now)

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -28,6 +28,7 @@ const (
 // Digest stores a digest name in a structured form.
 type Digest struct {
 	Repository
+	tag      string
 	digest   string
 	original string
 }
@@ -45,6 +46,11 @@ func (d Digest) Identifier() string {
 	return d.DigestStr()
 }
 
+// TagStr returns the tag component of the Digest.
+func (d Digest) TagStr() string {
+	return d.tag
+}
+
 // DigestStr returns the digest component of the Digest.
 func (d Digest) DigestStr() string {
 	return d.digest
@@ -52,7 +58,19 @@ func (d Digest) DigestStr() string {
 
 // Name returns the name from which the Digest was derived.
 func (d Digest) Name() string {
-	return d.Repository.Name() + digestDelim + d.DigestStr()
+	name := d.Repository.Name()
+	if d.tag != "" {
+		name += tagDelim + d.TagStr()
+	}
+	name += digestDelim + d.DigestStr()
+	return name
+}
+
+// Tag returns the tag component of the Digest (if any)
+func (d Digest) Tag() Tag {
+	name := d.Repository.Name() + tagDelim + d.TagStr()
+	tag, _ := NewTag(name, StrictValidation)
+	return tag
 }
 
 // String returns the original input string.
@@ -90,6 +108,7 @@ func NewDigest(name string, opts ...Option) (Digest, error) {
 	}
 	return Digest{
 		Repository: repo,
+		tag:        tag.tag,
 		digest:     digest,
 		original:   name,
 	}, nil

--- a/pkg/name/digest_test.go
+++ b/pkg/name/digest_test.go
@@ -63,8 +63,10 @@ func TestNewDigestStrictValidation(t *testing.T) {
 	}
 
 	for _, name := range goodStrictValidationTagDigestNames {
-		if _, err := NewDigest(name, StrictValidation); err != nil {
+		if digest, err := NewDigest(name, StrictValidation); err != nil {
 			t.Errorf("`%s` should be a valid Digest name, got error: %v", name, err)
+		} else if digest.Name() != name {
+			t.Errorf("`%v` .Name() should reproduce the original name. Wanted: %s Got: %s", digest, name, digest.Name())
 		}
 	}
 
@@ -95,9 +97,10 @@ func TestDigestComponents(t *testing.T) {
 	t.Parallel()
 	testRegistry := "gcr.io"
 	testRepository := "project-id/image"
+	testTag := "latest"
 	fullRepo := path.Join(testRegistry, testRepository)
 
-	digestNameStr := testRegistry + "/" + testRepository + "@" + validDigest
+	digestNameStr := testRegistry + "/" + testRepository + ":" + testTag + "@" + validDigest
 	digest, err := NewDigest(digestNameStr, StrictValidation)
 	if err != nil {
 		t.Fatalf("`%s` should be a valid Digest name, got error: %v", digestNameStr, err)
@@ -105,6 +108,9 @@ func TestDigestComponents(t *testing.T) {
 
 	if got := digest.String(); got != digestNameStr {
 		t.Errorf("String() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, digestNameStr, got)
+	}
+	if got := digest.Name(); got != digestNameStr {
+		t.Errorf("Name() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, digestNameStr, got)
 	}
 	if got := digest.Identifier(); got != validDigest {
 		t.Errorf("Identifier() was incorrect for %v. Wanted: `%s` Got: `%s`", digest, validDigest, got)

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -54,8 +54,6 @@ func (i *imageOpener) Open() (v1.Image, error) {
 		return nil, err
 	}
 
-	i.client.NegotiateAPIVersion(context.Background())
-
 	tb, err := tarball.Image(opener, nil)
 	if err != nil {
 		return nil, err
@@ -117,6 +115,7 @@ func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
 			return nil, err
 		}
 	}
+	i.client.NegotiateAPIVersion(context.Background())
 
 	return i.Open()
 }

--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -54,7 +54,7 @@ func Tag(src, dest name.Tag) error {
 }
 
 // Write saves the image into the daemon as the given tag.
-func Write(tag name.Tag, img v1.Image) (string, error) {
+func Write(ref name.Reference, img v1.Image) (string, error) {
 	cli, err := GetImageLoader()
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func Write(tag name.Tag, img v1.Image) (string, error) {
 
 	pr, pw := io.Pipe()
 	go func() {
-		pw.CloseWithError(tarball.Write(tag, img, pw))
+		pw.CloseWithError(tarball.Write(ref, img, pw))
 	}()
 
 	// write the image in docker save format first, then load it

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -329,6 +329,12 @@ func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]stri
 			} else {
 				imageToTags[img] = []string{tag.String()}
 			}
+		} else if digest, ok := ref.(name.Digest); ok && digest.TagStr() != "" {
+			if tags, ok := imageToTags[img]; ok && tags != nil {
+				imageToTags[img] = append(tags, digest.Tag().String())
+			} else {
+				imageToTags[img] = []string{digest.Tag().String()}
+			}
 		} else {
 			if _, ok := imageToTags[img]; !ok {
 				imageToTags[img] = nil

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -115,10 +115,15 @@ func TestMultiWriteSameImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating test dig3.")
 	}
+	dig4, err := name.NewDigest("gcr.io/baz/baz:latest@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", name.StrictValidation)
+	if err != nil {
+		t.Fatalf("Error creating test dig4.")
+	}
 	refToImage := make(map[name.Reference]v1.Image)
 	refToImage[tag1] = randImage
 	refToImage[tag2] = randImage
 	refToImage[dig3] = randImage
+	refToImage[dig4] = randImage
 
 	// Write the images with both tags to the tarball
 	if err := tarball.MultiRefWriteToFile(fp.Name(), refToImage); err != nil {
@@ -127,7 +132,11 @@ func TestMultiWriteSameImage(t *testing.T) {
 	for ref := range refToImage {
 		tag, ok := ref.(name.Tag)
 		if !ok {
-			continue
+			digest, ok := ref.(name.Digest)
+			if !ok || digest.TagStr() == "" {
+				continue
+			}
+			tag = digest.Tag()
 		}
 
 		tarImage, err := tarball.ImageFromPath(fp.Name(), &tag)


### PR DESCRIPTION

I thought this was going to be a simple one-liner, like before:

```diff
-func Write(tag name.Tag, img v1.Image) (string, error) {
+func Write(ref name.Reference, img v1.Image) (string, error) {
```

But I was wrong, since I actually wanted to keep the tag too...

Closes #702