### PR TITLE
Consistent ordering when processing images to create a tarball manifest

### DIFF
--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -108,6 +110,7 @@ func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Mani
 	var m Manifest
 
 	seenLayerDigests := make(map[string]struct{})
+
 	for img, tags := range imageToTags {
 		// Write the config.
 		cfgName, err := img.ConfigName()
@@ -191,6 +194,12 @@ func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Mani
 			LayerSources: layerSources,
 		})
 	}
+	// sort by name of the repotags so it is consistent. Alternatively, we could sort by hash of the
+	// descriptor, but that would make it hard for humans to process
+	sort.Slice(m, func(i, j int) bool {
+		return strings.Join(m[i].RepoTags, ",") < strings.Join(m[j].RepoTags, ",")
+	})
+
 	return m, nil
 }
 

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -431,16 +431,18 @@ func TestComputeManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error calculating manifest: %v", err)
 	}
+	// the order of these two is based on the repo tags
+	// so mutated "gcr.io/baz/bat:latest" is before random "gcr.io/foo/bar:latest"
 	expected := []tarball.Descriptor{
-		tarball.Descriptor{
-			Config:   randConfig.String(),
-			RepoTags: []string{randomTag},
-			Layers:   randomLayersFilenames,
-		},
 		tarball.Descriptor{
 			Config:   mutatedConfig.String(),
 			RepoTags: []string{mutatedTag},
 			Layers:   mutatedLayersFilenames,
+		},
+		tarball.Descriptor{
+			Config:   randConfig.String(),
+			RepoTags: []string{randomTag},
+			Layers:   randomLayersFilenames,
 		},
 	}
 	if len(m) != len(expected) {


### PR DESCRIPTION
Resolves the issue raised in [this comment](https://github.com/google/go-containerregistry/pull/685#issuecomment-612885360) by @ImJasonH . 

When creating a v1/tarball manifest of multiple images, _always_ provide the order in order of the repo tags. It doesn't matter to the tarball, but it allows for us to have consistent results. It ensures tests pass, but consistency is good overall.

The sort key is just the repo tags joined together by `","`. It is simple, but it does work. I considered using the hash of the specific manifest, but that would make it too hard to eyeball. Why use complexity unnecessarily?