### PR TITLE
Make detection of gcr.io and pkg.dev domains stricter

### DIFF
--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -54,7 +54,8 @@ type googleKeychain struct {
 // gcloud configuration in the scope of this one process.
 func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
 	// Only authenticate GCR and AR so it works with authn.NewMultiKeychain to fallback.
-	if !strings.HasSuffix(target.RegistryStr(), "gcr.io") && !strings.HasSuffix(target.RegistryStr(), "pkg.dev") {
+	host := target.RegistryStr()
+	if host != "gcr.io" && !strings.HasSuffix(host, ".gcr.io") && !strings.HasSuffix(host, ".pkg.dev") {
 		return authn.Anonymous, nil
 	}
 


### PR DESCRIPTION
Make detection of gcr.io and pkg.dev domains stricter to avoid matching similar prefixes.  It's important that google creds aren't sent to domains other than those controlled by Google.