### PR TITLE
Avoid long delays on http-only registries

### DIFF
--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -173,10 +173,10 @@ func TestPingHttpFallback(t *testing.T) {
 		wantCount: 1,
 	}, {
 		reg:       mustRegistry("ko.local"),
-		wantCount: 2,
+		wantCount: 1,
 	}, {
 		reg:       mustInsecureRegistry("us.gcr.io"),
-		wantCount: 2,
+		wantCount: 1,
 	}}
 
 	gotCount := 0


### PR DESCRIPTION
This fixes a number of reported slow push time on Minikube.

The reason is that it did a first ping on https, even if the registry is declared as insecure. But connection to port 443 is kept idle by kubernetes until a timeout occurs (which is a typical firewall behavior as well).

If the registry is insecure, the go-containerregistry lib should not try https as first attempt.

Eg.
- https://github.com/GoogleContainerTools/kaniko/issues/970
- https://github.com/GoogleContainerTools/kaniko/issues/1013
- https://github.com/apache/camel-k/issues/1416