### PR TITLE
pkg/v1/cache/fs.go delete cached layer on UnexpectedEOF

### DIFF
--- a/pkg/v1/cache/fs.go
+++ b/pkg/v1/cache/fs.go
@@ -105,6 +105,13 @@ func (fs *fscache) Get(h v1.Hash) (v1.Layer, error) {
 	if os.IsNotExist(err) {
 		return nil, ErrNotFound
 	}
+	if err == io.ErrUnexpectedEOF {
+		// Delete and return ErrNotFound because the layer was incomplete.
+		if err := fs.Delete(h); err != nil {
+			return nil, err
+		}
+		return nil, ErrNotFound
+	}
 	return l, err
 }
 


### PR DESCRIPTION
This fixes an issue when the cache has to handle with interrupted downloads of previous executions.

It solves #717 