### PR TITLE
Use Google keychain on gcrane commands

### DIFF
--- a/cmd/gcrane/cmd/delete.go
+++ b/cmd/gcrane/cmd/delete.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdDelete()) }
+
+func NewCmdDelete() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete IMAGE",
+		Short: "Delete an image reference from its registry",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			if err := gcrane.Delete(args[0]); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func gc(root string, recursive bool) {
 		log.Fatalln(err)
 	}
 
-	auth := google.WithAuthFromKeychain(authn.DefaultKeychain)
+	auth := google.WithAuthFromKeychain(google.Keychain)
 
 	if recursive {
 		if err := google.Walk(repo, printUntaggedImages, auth); err != nil {

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -32,10 +32,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// gcraneKeychain tries to use google-specific credential sources, falling back to
-// the DefaultKeychain (config-file based).
-var gcraneKeychain = authn.NewMultiKeychain(google.Keychain, authn.DefaultKeychain)
-
 // GCRBackoff returns a retry.Backoff that is suitable for use with gcr.io.
 //
 // These numbers are based on GCR's posted quotas:

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -17,14 +17,11 @@ package gcrane
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +30,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/internal/retry"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -41,96 +37,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
-
-func mustRepo(s string) name.Repository {
-	repo, err := name.NewRepository(s)
-	if err != nil {
-		panic(err)
-	}
-	return repo
-}
-
-type fakeGCR struct {
-	h     http.Handler
-	repos map[string]google.Tags
-	t     *testing.T
-}
-
-func (gcr *fakeGCR) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	gcr.t.Logf("%s %s", r.Method, r.URL)
-	if strings.HasPrefix(r.URL.Path, "/v2/") && strings.HasSuffix(r.URL.Path, "/tags/list") {
-		repo := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/"), "/tags/list")
-		if tags, ok := gcr.repos[repo]; !ok {
-			w.WriteHeader(http.StatusNotFound)
-		} else {
-			gcr.t.Logf("%+v", tags)
-			json.NewEncoder(w).Encode(tags)
-		}
-	} else {
-		gcr.h.ServeHTTP(w, r)
-	}
-}
-
-func newFakeGCR(stuff map[name.Reference]partial.Describable, t *testing.T) (*fakeGCR, error) {
-	h := registry.New()
-
-	repos := make(map[string]google.Tags)
-
-	for ref, thing := range stuff {
-		repo := ref.Context().RepositoryStr()
-		tags, ok := repos[repo]
-		if !ok {
-			tags = google.Tags{
-				Name:     repo,
-				Children: []string{},
-			}
-		}
-
-		// Populate the "child" field.
-		for parentPath := repo; parentPath != "."; parentPath = path.Dir(parentPath) {
-			child, parent := path.Base(parentPath), path.Dir(parentPath)
-			tags, ok := repos[parent]
-			if !ok {
-				tags = google.Tags{}
-			}
-			for _, c := range repos[parent].Children {
-				if c == child {
-					break
-				}
-			}
-			tags.Children = append(tags.Children, child)
-			repos[parent] = tags
-		}
-
-		// Populate the "manifests" and "tags" field.
-		d, err := thing.Digest()
-		if err != nil {
-			return nil, err
-		}
-		mt, err := thing.MediaType()
-		if err != nil {
-			return nil, err
-		}
-		if tags.Manifests == nil {
-			tags.Manifests = make(map[string]google.ManifestInfo)
-		}
-		mi, ok := tags.Manifests[d.String()]
-		if !ok {
-			mi = google.ManifestInfo{
-				MediaType: string(mt),
-				Tags:      []string{},
-			}
-		}
-		if tag, ok := ref.(name.Tag); ok {
-			tags.Tags = append(tags.Tags, tag.Identifier())
-			mi.Tags = append(mi.Tags, tag.Identifier())
-		}
-		tags.Manifests[d.String()] = mi
-		repos[repo] = tags
-	}
-
-	return &fakeGCR{h: h, t: t, repos: repos}, nil
-}
 
 func TestCopy(t *testing.T) {
 	logs.Warn.SetOutput(os.Stderr)

--- a/pkg/gcrane/delete.go
+++ b/pkg/gcrane/delete.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrane
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+// Delete deletes a remote image or index.
+func Delete(ref string) error {
+	// Same implementation of github.com/google/go-containerregistry/pkg/gcrane/copy
+	original := authn.DefaultKeychain
+	authn.DefaultKeychain = gcraneKeychain
+	defer func() {
+		authn.DefaultKeychain = original
+	}()
+	return crane.Delete(ref)
+}

--- a/pkg/gcrane/delete_test.go
+++ b/pkg/gcrane/delete_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrane
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	ggcrtest "github.com/google/go-containerregistry/pkg/internal/httptest"
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestDelete(t *testing.T) {
+	logs.Warn.SetOutput(os.Stderr)
+	refStr := "gcr.io/test/gcrane"
+
+	deleteImg, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notExistImg, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	latestRef, err := name.ParseReference(refStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := deleteImg.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteRef := latestRef.Context().Digest(d.String())
+	d2, err := notExistImg.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	notExistRef := latestRef.Context().Digest(d2.String())
+
+	h, err := newFakeGCR(map[name.Reference]partial.Describable{
+		deleteRef: deleteImg,
+	}, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := ggcrtest.NewTLSServer("gcr.io", h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Make sure we don't actually talk to GCR.
+	http.DefaultTransport = s.Client().Transport
+
+	if err := remote.Write(deleteRef, deleteImg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Delete(notExistRef.Name()); err == nil {
+		t.Fatal("Not exist reference shouldn't be accepted")
+	}
+	if err := Delete(deleteRef.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if err := Delete(deleteRef.Name()); err == nil {
+		t.Fatal("Already deleted reference shouldn't be accepted")
+	}
+}

--- a/pkg/gcrane/gcrane_test.go
+++ b/pkg/gcrane/gcrane_test.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrane
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+)
+
+func mustRepo(s string) name.Repository {
+	repo, err := name.NewRepository(s)
+	if err != nil {
+		panic(err)
+	}
+	return repo
+}
+
+type fakeGCR struct {
+	h     http.Handler
+	repos map[string]google.Tags
+	t     *testing.T
+}
+
+func (gcr *fakeGCR) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	gcr.t.Logf("%s %s", r.Method, r.URL)
+	if strings.HasPrefix(r.URL.Path, "/v2/") && strings.HasSuffix(r.URL.Path, "/tags/list") {
+		repo := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/"), "/tags/list")
+		if tags, ok := gcr.repos[repo]; !ok {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			gcr.t.Logf("%+v", tags)
+			json.NewEncoder(w).Encode(tags)
+		}
+	} else {
+		gcr.h.ServeHTTP(w, r)
+	}
+}
+
+func newFakeGCR(stuff map[name.Reference]partial.Describable, t *testing.T) (*fakeGCR, error) {
+	h := registry.New()
+
+	repos := make(map[string]google.Tags)
+
+	for ref, thing := range stuff {
+		repo := ref.Context().RepositoryStr()
+		tags, ok := repos[repo]
+		if !ok {
+			tags = google.Tags{
+				Name:     repo,
+				Children: []string{},
+			}
+		}
+
+		// Populate the "child" field.
+		for parentPath := repo; parentPath != "."; parentPath = path.Dir(parentPath) {
+			child, parent := path.Base(parentPath), path.Dir(parentPath)
+			tags, ok := repos[parent]
+			if !ok {
+				tags = google.Tags{}
+			}
+			for _, c := range repos[parent].Children {
+				if c == child {
+					break
+				}
+			}
+			tags.Children = append(tags.Children, child)
+			repos[parent] = tags
+		}
+
+		// Populate the "manifests" and "tags" field.
+		d, err := thing.Digest()
+		if err != nil {
+			return nil, err
+		}
+		mt, err := thing.MediaType()
+		if err != nil {
+			return nil, err
+		}
+		if tags.Manifests == nil {
+			tags.Manifests = make(map[string]google.ManifestInfo)
+		}
+		mi, ok := tags.Manifests[d.String()]
+		if !ok {
+			mi = google.ManifestInfo{
+				MediaType: string(mt),
+				Tags:      []string{},
+			}
+		}
+		if tag, ok := ref.(name.Tag); ok {
+			tags.Tags = append(tags.Tags, tag.Identifier())
+			mi.Tags = append(mi.Tags, tag.Identifier())
+		}
+		tags.Manifests[d.String()] = mi
+		repos[repo] = tags
+	}
+
+	return &fakeGCR{h: h, t: t, repos: repos}, nil
+}

--- a/pkg/gcrane/keychain.go
+++ b/pkg/gcrane/keychain.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrane
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+)
+
+// gcraneKeychain tries to use google-specific credential sources, falling back to
+// the DefaultKeychain (config-file based).
+var gcraneKeychain = authn.NewMultiKeychain(google.Keychain, authn.DefaultKeychain)

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -131,6 +131,29 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 		resp.WriteHeader(http.StatusCreated)
 		return nil
 	}
+	if req.Method == "DELETE" {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		_, ok = c[target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+		delete(c, target)
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+	}
 	return &regError{
 		Status:  http.StatusBadRequest,
 		Code:    "METHOD_UNKNOWN",


### PR DESCRIPTION
This PR includes following changes.

- `gcrane gc` command uses Google keychain like `gcrane ls`.
- `gcrane delete` command uses Google keychain like `gcrane copy`.

My motivation is using above two commands on GCP services(on my case, Cloud Run).