### PR TITLE
Handle rebasing images with empty layers properly

### DIFF
--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -69,13 +69,15 @@ func (i *image) compute() error {
 	digestMap := make(map[v1.Hash]v1.Layer)
 
 	for _, add := range i.adds {
-		diffID, err := add.Layer.DiffID()
-		if err != nil {
-			return err
-		}
-		diffIDs = append(diffIDs, diffID)
 		history = append(history, add.History)
-		diffIDMap[diffID] = add.Layer
+		if add.Layer != nil {
+			diffID, err := add.Layer.DiffID()
+			if err != nil {
+				return err
+			}
+			diffIDs = append(diffIDs, diffID)
+			diffIDMap[diffID] = add.Layer
+		}
 	}
 
 	m, err := i.base.Manifest()
@@ -85,6 +87,11 @@ func (i *image) compute() error {
 	manifest := m.DeepCopy()
 	manifestLayers := manifest.Layers
 	for _, add := range i.adds {
+		if add.Layer == nil {
+			// Empty layers include only history in manifest.
+			continue
+		}
+
 		desc, err := partial.Descriptor(add.Layer)
 		if err != nil {
 			return err
@@ -251,7 +258,7 @@ func (i *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 
 func validate(adds []Addendum) error {
 	for _, add := range adds {
-		if add.Layer == nil {
+		if add.Layer == nil && !add.History.EmptyLayer {
 			return errors.New("unable to add a nil layer to the image")
 		}
 	}

--- a/pkg/v1/mutate/rebase.go
+++ b/pkg/v1/mutate/rebase.go
@@ -50,6 +50,11 @@ func Rebase(orig, oldBase, newBase v1.Image) (v1.Image, error) {
 		}
 	}
 
+	oldConfig, err := oldBase.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config for old base: %v", err)
+	}
+
 	origConfig, err := orig.ConfigFile()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config for original: %v", err)
@@ -73,25 +78,48 @@ func Rebase(orig, oldBase, newBase v1.Image) (v1.Image, error) {
 		return nil, fmt.Errorf("could not get config for new base: %v", err)
 	}
 	// Add new base layers.
-	for i := range newBaseLayers {
-		rebasedImage, err = Append(rebasedImage, Addendum{
-			Layer:   newBaseLayers[i],
-			History: newConfig.History[i],
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to append layer %d of new base layers", i)
-		}
+	rebasedImage, err = Append(rebasedImage, createAddendums(0, 0, newConfig.History, newBaseLayers)...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append new base image: %v", err)
 	}
+
 	// Add original layers above the old base.
-	start := len(oldBaseLayers)
-	for i := range origLayers[start:] {
-		rebasedImage, err = Append(rebasedImage, Addendum{
-			Layer:   origLayers[start+i],
-			History: origConfig.History[start+i],
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to append layer %d of original layers", i)
+	rebasedImage, err = Append(rebasedImage, createAddendums(len(oldConfig.History), len(oldBaseLayers)+1, origConfig.History, origLayers)...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append original image: %v", err)
+	}
+
+	return rebasedImage, nil
+}
+
+// createAddendums makes a list of addendums from a history and layers starting from a specific history and layer
+// indexes.
+func createAddendums(startHistory, startLayer int, history []v1.History, layers []v1.Layer) []Addendum {
+	var adds []Addendum
+	// History should be a superset of layers; empty layers (e.g. ENV statements) only exist in history.
+	// They cannot be iterated identically but must be walked independently, only advancing the iterator for layers
+	// when a history entry for a non-empty layer is seen.
+	layerIndex := 0
+	for historyIndex := range history {
+		var layer v1.Layer
+		emptyLayer := history[historyIndex].EmptyLayer
+		if !emptyLayer {
+			layer = layers[layerIndex]
+			layerIndex++
+		}
+		if historyIndex >= startHistory || layerIndex >= startLayer {
+			adds = append(adds, Addendum{
+				Layer:   layer,
+				History: history[historyIndex],
+			})
 		}
 	}
-	return rebasedImage, nil
+	// In the event history was malformed or non-existent, append the remaining layers.
+	for i := layerIndex; i < len(layers); i++ {
+		if i >= startLayer {
+			adds = append(adds, Addendum{Layer: layers[layerIndex]})
+		}
+	}
+
+	return adds
 }

--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -69,7 +69,7 @@ func Image(byteSize, layers int64) (v1.Image, error) {
 			Layer: layer,
 			History: v1.History{
 				Author:    "random.Image",
-				Comment:   fmt.Sprintf("this is a random history %d", i),
+				Comment:   fmt.Sprintf("this is a random history %d of %d", i, layers),
 				CreatedBy: "random",
 				Created:   v1.Time{time.Now()},
 			},


### PR DESCRIPTION
Manifest v2 specs do not include layer entries for empty layers,
but the history in the config will include an entry for empty
layers (e.g. produced by `ENV` directive). History entries for
empty layers include `empty_layer` field set to `true`.

As a result, when rebasing and copying from the new base and
original to the rebased image, it's not sufficient to simply
iterate layers and pull from the same position/index in the
history from config. Instead, history should be iterated and
used to generate `Addendum`, while simultaneously iterating
layers, but only including the layer (and advancing the iterator)
if it's for a history item for a non-empty layer.

Since the history in config is optional per the [OCI spec][1],
iteration via layers will still happen in the event that not
all layers are consumed during the history pass. (This should
also guard against a malformed history).

## Example
Imagine a simple `Dockerfile`:
```dockerfile
FROM busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209

ENV VALUE="test"
RUN echo "${VALUE}" > /test.txt
```
Which results in the config:
```json
{
  "architecture": "amd64",
  "config": {
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "VALUE=test"
    ],
    "Cmd": [
      "sh"
    ],
    "ArgsEscaped": true,
    "OnBuild": null
  },
  "created": "2020-06-22T16:58:15.423225002-04:00",
  "history": [
    {
      "created": "2020-06-02T21:19:57.100247864Z",
      "created_by": "/bin/sh -c #(nop) ADD file:a84c53d2fe5207d17b5110e1eeeff0ab5d7ca831d743070eab1e87dc74129049 in / "
    },
    {
      "created": "2020-06-02T21:19:57.279412246Z",
      "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
      "empty_layer": true
    },
    {
      "created": "2020-06-22T16:58:15.423225002-04:00",
      "created_by": "ENV VALUE=test",
      "comment": "buildkit.dockerfile.v0",
      "empty_layer": true
    },
    {
      "created": "2020-06-22T16:58:15.423225002-04:00",
      "created_by": "RUN /bin/sh -c echo \"${VALUE}\" > /test.txt # buildkit",
      "comment": "buildkit.dockerfile.v0"
    }
  ],
  "os": "linux",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:1be74353c3d0fd55fb5638a52953e6f1bc441e5b1710921db9ec2aa202725569",
      "sha256:3104c9e118b4c9fddbc67791130783194fdebe67de2d083156e4b3fc67c09d8a"
    ]
  }
}
```

Now, rebase the image with `crane` to a different `busybox` base:
```sh
crane --insecure rebase \
  --original="localhost:5000/rebase-example:original" \
  --old_base="busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209" \
  --new_base="busybox@sha256:aaf6a895ebcb872d39306dbcda13739132674dfb5af43a9c527c5cdcb1c21e20" \
  --rebased="localhost:5000/rebase-example:rebased"
```

Comparison of the configuration between the two:
```diff
--- a/config.bad
+++ b/config.good
@@ -7,9 +7,20 @@
       "created_by": "/bin/sh -c #(nop) ADD file:5437654e1deb81bd4beeb1c4722443c5be1c2a259e46f51cf19e39698cc631ed in / "
     },
     {
-      "created": "2020-06-02T21:19:57.279412246Z",
+      "created": "2020-06-02T21:20:12.934903021Z",
       "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
       "empty_layer": true
+    },
+    {
+      "created": "2020-06-22T16:58:15.423225002-04:00",
+      "created_by": "ENV VALUE=test",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2020-06-22T16:58:15.423225002-04:00",
+      "created_by": "RUN /bin/sh -c echo \"${VALUE}\" > /test.txt # buildkit",
+      "comment": "buildkit.dockerfile.v0"
     }
   ],
   "os": "",
```
Notice that the original config was not only missing the history items from "our" image, but actually had the _wrong_ history item from the old base image (in this case, just the `created` timestamp was swapped.)

## JFrog (Artifactory)
Besides messing with the metadata in the config, this actually causes problems with JFrog products (e.g. Artifactory, JFrog Container Registry):
```
2020/06/22 16:55:22 pushing localhost:8082/docker-local/rebase-example:bad: PUT http://localhost:8082/v2/docker-local/rebase-example/manifests/bad: MANIFEST_INVALID: manifest invalid; map[description:Circuit Breaker Threshold Reached, Breaking Operation. see log output for manifest details.]
```
The images cannot be pushed - presumably internally it tries to match the history with layers, skipping empty ones, so cannot handle when there are fewer non-empty history entries than layers.

These changes ensure that rebased images can be pushed to these registries and have the benefit of preserving history properly for the general case.

[1]: https://github.com/opencontainers/image-spec/blob/master/config.md