### PR TITLE
daemon: Ensure we call NegotiateAPIVersion first

### DIFF
--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -54,8 +54,6 @@ func (i *imageOpener) Open() (v1.Image, error) {
 		return nil, err
 	}
 
-	i.client.NegotiateAPIVersion(context.Background())
-
 	tb, err := tarball.Image(opener, nil)
 	if err != nil {
 		return nil, err
@@ -117,6 +115,7 @@ func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
 			return nil, err
 		}
 	}
+	i.client.NegotiateAPIVersion(context.Background())
 
 	return i.Open()
 }


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/734