### PR TITLE
Add platform option to crane copy and digest

### DIFF
--- a/pkg/crane/copy.go
+++ b/pkg/crane/copy.go
@@ -47,8 +47,15 @@ func Copy(src, dst string, opt ...Option) error {
 	switch desc.MediaType {
 	case types.OCIImageIndex, types.DockerManifestList:
 		// Handle indexes separately.
-		if err := copyIndex(desc, dstRef, o); err != nil {
-			return fmt.Errorf("failed to copy index: %v", err)
+		if o.platform != nil {
+			// If platform is explicitly set, don't copy the whole index, just the appropriate image.
+			if err := copyImage(desc, dstRef, o); err != nil {
+				return fmt.Errorf("failed to copy image: %v", err)
+			}
+		} else {
+			if err := copyIndex(desc, dstRef, o); err != nil {
+				return fmt.Errorf("failed to copy index: %v", err)
+			}
 		}
 	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
 		// Handle schema 1 images separately.

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -16,6 +16,22 @@ package crane
 
 // Digest returns the sha256 hash of the remote image at ref.
 func Digest(ref string, opt ...Option) (string, error) {
+	o := makeOptions(opt...)
+	if o.platform != nil {
+		desc, err := getManifest(ref, opt...)
+		if err != nil {
+			return "", err
+		}
+		img, err := desc.Image()
+		if err != nil {
+			return "", err
+		}
+		digest, err := img.Digest()
+		if err != nil {
+			return "", err
+		}
+		return digest.String(), nil
+	}
 	desc, err := head(ref, opt...)
 	if err != nil {
 		return "", err

--- a/pkg/crane/manifest.go
+++ b/pkg/crane/manifest.go
@@ -20,5 +20,13 @@ func Manifest(ref string, opt ...Option) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	o := makeOptions(opt...)
+	if o.platform != nil {
+		img, err := desc.Image()
+		if err != nil {
+			return nil, err
+		}
+		return img.RawManifest()
+	}
 	return desc.Manifest, nil
 }

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -19,12 +19,14 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 type options struct {
-	name   []name.Option
-	remote []remote.Option
+	name     []name.Option
+	remote   []remote.Option
+	platform *v1.Platform
 }
 
 func makeOptions(opts ...Option) options {
@@ -53,4 +55,12 @@ func WithTransport(t http.RoundTripper) Option {
 // Insecure is an Option that allows image references to be fetched without TLS.
 func Insecure(o *options) {
 	o.name = append(o.name, name.Insecure)
+}
+
+// WithPlatform is an Option to specify the platform.
+func WithPlatform(platform *v1.Platform) Option {
+	return func(o *options) {
+		o.remote = append(o.remote, remote.WithPlatform(*platform))
+		o.platform = platform
+	}
 }


### PR DESCRIPTION
Add platform option to crane copy and digest. If the remote reference is an index/list it only copies the image which matches the specified platform.

This would be a possible solution for #741 