### PR TITLE
crane: add a mirror command

### DIFF
--- a/cmd/crane/cmd/mirror.go
+++ b/cmd/crane/cmd/mirror.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func init() { Root.AddCommand(NewCmdMirror()) }
+
+// NewCmdMirror creates a new cobra.Command for the mirror subcommand.
+func NewCmdMirror() *cobra.Command {
+	return &cobra.Command{
+		Use:     "mirror SRC DST",
+		Aliases: []string{"mr"},
+		Short:   "Efficiently mirror a remote repository from src to dst",
+		Args:    cobra.ExactArgs(2),
+		Run: func(_ *cobra.Command, args []string) {
+			src, dst := args[0], args[1]
+			tags, err := crane.ListTags(src, options...)
+			if err != nil {
+				log.Fatalf("reading tags for %s: %v", src, err)
+			}
+			for _, tag := range tags {
+				srcImg := fmt.Sprintf("%s:%s", src, tag)
+				dstImg := fmt.Sprintf("%s:%s", dst, tag)
+				if err := crane.Copy(srcImg, dstImg, options...); err != nil {
+					log.Fatal(err)
+				}
+			}
+		},
+	}
+}


### PR DESCRIPTION
Mirror command can be used to mirror a whole repository.

