### PR TITLE
Retry on TOOMANYREQUESTS error from ECR

### DIFF
--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -89,8 +89,13 @@ func (e *Error) Temporary() bool {
 		return false
 	}
 	for _, d := range e.Errors {
-		// TODO: Include other error types.
-		if d.Code != BlobUploadInvalidErrorCode {
+		isTempCode := false
+		for _, code := range temporaryErrorCodes {
+			if d.Code == code {
+				isTempCode = true
+			}
+		}
+		if !isTempCode {
 			return false
 		}
 	}
@@ -149,7 +154,14 @@ const (
 	UnauthorizedErrorCode        ErrorCode = "UNAUTHORIZED"
 	DeniedErrorCode              ErrorCode = "DENIED"
 	UnsupportedErrorCode         ErrorCode = "UNSUPPORTED"
+	TooManyRequestsErrorCode     ErrorCode = "TOOMANYREQUESTS"
 )
+
+// TODO: Include other error types.
+var temporaryErrorCodes = []ErrorCode{
+	BlobUploadInvalidErrorCode,
+	TooManyRequestsErrorCode,
+}
 
 // CheckError returns a structured error if the response status is not in codes.
 func CheckError(resp *http.Response, codes ...int) error {

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -89,13 +89,7 @@ func (e *Error) Temporary() bool {
 		return false
 	}
 	for _, d := range e.Errors {
-		isTempCode := false
-		for _, code := range temporaryErrorCodes {
-			if d.Code == code {
-				isTempCode = true
-			}
-		}
-		if !isTempCode {
+		if _, ok := temporaryErrorCodes[d.Code]; !ok {
 			return false
 		}
 	}
@@ -158,9 +152,9 @@ const (
 )
 
 // TODO: Include other error types.
-var temporaryErrorCodes = []ErrorCode{
-	BlobUploadInvalidErrorCode,
-	TooManyRequestsErrorCode,
+var temporaryErrorCodes = map[ErrorCode]struct{}{
+	BlobUploadInvalidErrorCode: struct{}{},
+	TooManyRequestsErrorCode:   struct{}{},
 }
 
 // CheckError returns a structured error if the response status is not in codes.

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -50,6 +50,13 @@ func TestTemporary(t *testing.T) {
 			}},
 		},
 		retry: false,
+	}, {
+		error: &Error{
+			Errors: []Diagnostic{{
+				Code: TooManyRequestsErrorCode,
+			}},
+		},
+		retry: true,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
What it says on the tin

I made a test go program [here](https://gist.github.com/jchorl/24aa7797524fbb0b1b59d1d3877cb751) to force 429s. The output was:
```
...
I0803 03:21:58.695399    1477 main.go:44] body: {"errors":[{"code":"TOOMANYREQUESTS","message":"Rate exceeded"}]}
I0803 03:21:58.695412    1477 main.go:45] temporary: false
...
```

Quite obviously, go-containerregistry is not treating `TOOMANYREQUESTS` as temporary even though it is, in fact, a temporary error. This is preventing retries [here](https://github.com/google/go-containerregistry/blob/38ad4ec12b1d707307f901c6675d99e738f4d7e3/pkg/v1/remote/write.go#L377) because the error _does_ implement the `temporary` interface ([here](https://github.com/google/go-containerregistry/blob/38ad4ec12b1d707307f901c6675d99e738f4d7e3/pkg/internal/retry/retry.go#L33-L35)) but this error is deemed non-temporary.

The error manifested itself when kaniko was trying to push a bunch of images in parallel:
```
error pushing image: failed to push to destination <redacted>.dkr.ecr.<redacted>.amazonaws.com/<redacted>: POST https://<redacted>.dkr.ecr.<redacted>.amazonaws.com/v2/<redacted>/blobs/uploads/: TOOMANYREQUESTS: Rate exceeded
```

The error is explained in the registry spec here: https://github.com/docker/distribution/blob/master/docs/spec/api.md#errors-2

Anyway, this change causes go-containerregistry to treat a 429 as a retryable error.

