### PR TITLE
Test go 1.14, not 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language:
   - go
 
 go:
-  - "1.12"
   - "1.13"
+  - "1.14"
 
 env:
   - "GO111MODULE=off"


### PR DESCRIPTION
I noticed that go 1.12 with GO111MODULE=on takes over 20 minutes to run. Let's drop it in favor of 1.14, given that even 1.15 has been released already.