### PR TITLE
Fix incorrect tag size limit

### DIFF
--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -69,7 +69,7 @@ func (t Tag) Scope(action string) string {
 }
 
 func checkTag(name string) error {
-	return checkElement("tag", name, tagChars, 1, 127)
+	return checkElement("tag", name, tagChars, 1, 128)
 }
 
 // NewTag returns a new Tag representing the given name, according to the given strictness.


### PR DESCRIPTION
A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of **128 characters**.