### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -63,11 +63,11 @@ func NewCmdAuthGet() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			auth, err := authn.DefaultKeychain.Resolve(reg)
+			authorizer, err := authn.DefaultKeychain.Resolve(reg)
 			if err != nil {
 				log.Fatal(err)
 			}
-			auth, err := auth.Authorization()
+			auth, err := authorizer.Authorization()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -63,7 +63,7 @@ func NewCmdAuthGet() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			auther, err := authn.DefaultKeychain.Resolve(reg)
+			author, err := authn.DefaultKeychain.Resolve(reg)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -63,11 +63,11 @@ func NewCmdAuthGet() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			author, err := authn.DefaultKeychain.Resolve(reg)
+			auth, err := authn.DefaultKeychain.Resolve(reg)
 			if err != nil {
 				log.Fatal(err)
 			}
-			auth, err := auther.Authorization()
+			auth, err := auth.Authorization()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -375,7 +375,7 @@ func TestErrors(t *testing.T) {
 }
 
 func TestRetryErrors(t *testing.T) {
-	// We log a warning during retries, so we can tell if somethign retried by checking logs.Warn.
+	// We log a warning during retries, so we can tell if something retried by checking logs.Warn.
 	var b bytes.Buffer
 	logs.Warn.SetOutput(&b)
 

--- a/pkg/v1/tarball/README.md
+++ b/pkg/v1/tarball/README.md
@@ -75,7 +75,7 @@ ubuntu/
 There are a couple interesting files here.
 
 `manifest.json` is the entrypoint: a list of [`tarball.Descriptor`s](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Descriptor)
-that describe the images containd in this tarball.
+that describe the images contained in this tarball.
 
 For each image, this has the `RepoTags` (how it was pulled), a `Config` file
 that points to the image's config file, a list of `Layers`, and (optionally)


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc @jonjohnsonjr @ImJasonH
/assign @jonjohnsonjr @ImJasonH