### PR TITLE
Add WithContext to google.ListerOption

### DIFF
--- a/pkg/v1/google/options.go
+++ b/pkg/v1/google/options.go
@@ -15,6 +15,7 @@
 package google
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -51,6 +52,15 @@ func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
 			logs.Warn.Println("No matching credentials were found, falling back on anonymous")
 		}
 		l.auth = auth
+		return nil
+	}
+}
+
+// WithContext is a functional option for overriding the default
+// context.Context for HTTP request to list remote images
+func WithContext(ctx context.Context) ListerOption {
+	return func(l *lister) error {
+		l.ctx = ctx
 		return nil
 	}
 }


### PR DESCRIPTION
Added `WithContext` function, which implements `google.ListerOption`. This enables us to pass `context.Context` so that we could cancel sending HTTP requests. This PR won't change the default behavior since [`(*http.Client).Get`](https://golang.org/src/net/http/client.go?s=16191:16251#L460) wraps [`http.NewRequest`](https://golang.org/src/net/http/request.go?s=27051:27120#L802) and [`(*http.Client).Do`](https://golang.org/src/net/http/client.go?s=20422:20474#L575) and `http.NewRequest` wraps [`http.NewRequestWithContext`](https://golang.org/src/net/http/request.go?s=28365:28466#L828) with `context.Background`.