### PR TITLE
[Automated] Format markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,9 @@ information on using pull requests.
 ## Testing
 
 Ensure the following passes:
+
 ```
 ./hack/presubmit.sh
 ```
+
 and commit any resultant changes to `go.mod` and `go.sum`.

--- a/README.md
+++ b/README.md
@@ -5,103 +5,111 @@
 [![Go Report Card](https://goreportcard.com/badge/google/go-containerregistry)](https://goreportcard.com/report/google/go-containerregistry)
 [![Code Coverage](https://codecov.io/gh/google/go-containerregistry/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-containerregistry)
 
-
 ## Introduction
 
-This is a golang library for working with container registries.
-It's largely based on the [Python library of the same name](https://github.com/google/containerregistry).
+This is a golang library for working with container registries. It's largely
+based on the
+[Python library of the same name](https://github.com/google/containerregistry).
 
 The following diagram shows the main types that this library handles.
 ![OCI image representation](images/ociimage.jpeg)
 
 ## Philosophy
 
-This library primarily revolves around an [`Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#Image)
-interface (and to a lesser extent, [`ImageIndex`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#ImageIndex)
-and [`Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#Layer)).
+This library primarily revolves around an
+[`Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#Image)
+interface (and to a lesser extent,
+[`ImageIndex`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#ImageIndex)
+and
+[`Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1#Layer)).
 
-There are a number of packages for reading/writing these interfaces from/to various formats.
+There are a number of packages for reading/writing these interfaces from/to
+various formats.
 
-The main focus has been registry interactions (hence the name) via the [`remote`](pkg/v1/remote) package,
-but we have implemented other formats as we needed them to interoperate with various tools.
+The main focus has been registry interactions (hence the name) via the
+[`remote`](pkg/v1/remote) package, but we have implemented other formats as we
+needed them to interoperate with various tools.
 
 ### `v1.Image`
 
 #### Sources
 
-* [`remote.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Image)
-* [`tarball.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Image)
-* [`daemon.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/daemon#Image)
-* [`layout.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Path.Image)
-* [`random.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Image)
+- [`remote.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Image)
+- [`tarball.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Image)
+- [`daemon.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/daemon#Image)
+- [`layout.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Path.Image)
+- [`random.Image`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Image)
 
 #### Sinks
 
-* [`remote.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Write)
-* [`tarball.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Write)
-* [`daemon.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/daemon#Write)
-* [`legacy/tarball.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/legacy/tarball#Write)
-* [`layout.AppendImage`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Path.AppendImage)
+- [`remote.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Write)
+- [`tarball.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Write)
+- [`daemon.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/daemon#Write)
+- [`legacy/tarball.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/legacy/tarball#Write)
+- [`layout.AppendImage`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Path.AppendImage)
 
 ### `v1.ImageIndex`
 
 #### Sources
 
-* [`remote.Index`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Index)
-* [`random.Index`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Index)
-* [`layout.ImageIndexFromPath`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#ImageIndexFromPath)
+- [`remote.Index`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Index)
+- [`random.Index`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Index)
+- [`layout.ImageIndexFromPath`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#ImageIndexFromPath)
 
 #### Sinks
 
-* [`remote.WriteIndex`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#WriteIndex)
-* [`layout.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Write)
+- [`remote.WriteIndex`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#WriteIndex)
+- [`layout.Write`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout#Write)
 
 ### `v1.Layer`
 
 #### Sources
 
-* [`remote.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Layer)
-* [`tarball.LayerFromFile`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#LayerFromFile)
-* [`random.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Layer)
-* [`stream.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/stream#Layer)
+- [`remote.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Layer)
+- [`tarball.LayerFromFile`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#LayerFromFile)
+- [`random.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/random#Layer)
+- [`stream.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/stream#Layer)
 
 #### Sinks
 
-* [`remote.WriteLayer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#WriteLayer)
+- [`remote.WriteLayer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#WriteLayer)
 
 ## Overview
 
 ### `mutate`
 
-The simplest use for these libraries is to read from one source and write to another.
+The simplest use for these libraries is to read from one source and write to
+another.
 
 For example,
 
- * `crane pull` is `remote.Image -> tarball.Write`,
- * `crane push` is `tarball.Image -> remote.Write`,
- * `crane cp` is `remote.Image -> remote.Write`.
+- `crane pull` is `remote.Image -> tarball.Write`,
+- `crane push` is `tarball.Image -> remote.Write`,
+- `crane cp` is `remote.Image -> remote.Write`.
 
-However, often you actually want to _change something_ about an image.
-This is the purpose of the [`mutate`](pkg/v1/mutate) package, which exposes
-some commonly useful things to change about an image.
+However, often you actually want to _change something_ about an image. This is
+the purpose of the [`mutate`](pkg/v1/mutate) package, which exposes some
+commonly useful things to change about an image.
 
 ### `partial`
 
-If you're trying to use this library with a different source or sink than it already supports,
-it can be somewhat cumbersome. The `Image` and `Layer` interfaces are pretty wide, with a lot
-of redundant information. This is somewhat by design, because we want to expose this information
-as efficiently as possible where we can, but again it is a pain to implement yourself.
+If you're trying to use this library with a different source or sink than it
+already supports, it can be somewhat cumbersome. The `Image` and `Layer`
+interfaces are pretty wide, with a lot of redundant information. This is
+somewhat by design, because we want to expose this information as efficiently as
+possible where we can, but again it is a pain to implement yourself.
 
-The purpose of the [`partial`](pkg/v1/partial) package is to make implementing a `v1.Image`
-much easier, by filling in all the derived accessors for you if you implement a minimal
-subset of `v1.Image`.
+The purpose of the [`partial`](pkg/v1/partial) package is to make implementing a
+`v1.Image` much easier, by filling in all the derived accessors for you if you
+implement a minimal subset of `v1.Image`.
 
 ### `transport`
 
-You might think our abstractions are bad and you just want to authenticate
-and send requests to a registry.
+You might think our abstractions are bad and you just want to authenticate and
+send requests to a registry.
 
-This is the purpose of the [`transport`](pkg/v1/remote/transport) and [`authn`](pkg/authn) packages.
+This is the purpose of the [`transport`](pkg/v1/remote/transport) and
+[`authn`](pkg/authn) packages.
 
 ## Tools
 
@@ -109,8 +117,8 @@ This repo hosts some tools built on top of the library.
 
 ### `crane`
 
-[`crane`](cmd/crane/README.md) is a tool for interacting with remote images
-and registries.
+[`crane`](cmd/crane/README.md) is a tool for interacting with remote images and
+registries.
 
 ### `gcrane`
 

--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -1,7 +1,7 @@
 # `crane`
 
-[`crane`](doc/crane.md) is a tool for interacting with remote images
-and registries.
+[`crane`](doc/crane.md) is a tool for interacting with remote images and
+registries.
 
 ## Installation
 
@@ -42,6 +42,7 @@ docker-tag-latest:
     name: gcr.io/go-containerregistry/crane:debug
     entrypoint: [""]
   script:
-    - crane auth login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - crane auth login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
+      $CI_REGISTRY
     - crane tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA latest
 ```

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -20,21 +20,24 @@ crane [flags]
 
 ### SEE ALSO
 
-* [crane append](crane_append.md)	 - Append contents of a tarball to a remote image
-* [crane auth](crane_auth.md)	 - Log in or access credentials
-* [crane blob](crane_blob.md)	 - Read a blob from the registry
-* [crane catalog](crane_catalog.md)	 - List the repos in a registry
-* [crane config](crane_config.md)	 - Get the config of an image
-* [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst
-* [crane delete](crane_delete.md)	 - Delete an image reference from its registry
-* [crane digest](crane_digest.md)	 - Get the digest of an image
-* [crane export](crane_export.md)	 - Export contents of a remote image as a tarball
-* [crane ls](crane_ls.md)	 - List the tags in a repo
-* [crane manifest](crane_manifest.md)	 - Get the manifest of an image
-* [crane pull](crane_pull.md)	 - Pull a remote image by reference and store its contents in a tarball
-* [crane push](crane_push.md)	 - Push image contents as a tarball to a remote registry
-* [crane rebase](crane_rebase.md)	 - Rebase an image onto a new base image
-* [crane tag](crane_tag.md)	 - Efficiently tag a remote image
-* [crane validate](crane_validate.md)	 - Validate that an image is well-formed
-* [crane version](crane_version.md)	 - Print the version
-
+- [crane append](crane_append.md) - Append contents of a tarball to a remote
+  image
+- [crane auth](crane_auth.md) - Log in or access credentials
+- [crane blob](crane_blob.md) - Read a blob from the registry
+- [crane catalog](crane_catalog.md) - List the repos in a registry
+- [crane config](crane_config.md) - Get the config of an image
+- [crane copy](crane_copy.md) - Efficiently copy a remote image from src to dst
+- [crane delete](crane_delete.md) - Delete an image reference from its registry
+- [crane digest](crane_digest.md) - Get the digest of an image
+- [crane export](crane_export.md) - Export contents of a remote image as a
+  tarball
+- [crane ls](crane_ls.md) - List the tags in a repo
+- [crane manifest](crane_manifest.md) - Get the manifest of an image
+- [crane pull](crane_pull.md) - Pull a remote image by reference and store its
+  contents in a tarball
+- [crane push](crane_push.md) - Push image contents as a tarball to a remote
+  registry
+- [crane rebase](crane_rebase.md) - Rebase an image onto a new base image
+- [crane tag](crane_tag.md) - Efficiently tag a remote image
+- [crane validate](crane_validate.md) - Validate that an image is well-formed
+- [crane version](crane_version.md) - Print the version

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -29,5 +29,4 @@ crane append [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -25,7 +25,6 @@ crane auth [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-* [crane auth get](crane_auth_get.md)	 - Implements a credential helper
-* [crane auth login](crane_auth_login.md)	 - Log in to a registry
-
+- [crane](crane.md) - Crane is a tool for managing container images
+- [crane auth get](crane_auth_get.md) - Implements a credential helper
+- [crane auth login](crane_auth_login.md) - Log in to a registry

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -33,5 +33,4 @@ crane auth get [flags]
 
 ### SEE ALSO
 
-* [crane auth](crane_auth.md)	 - Log in or access credentials
-
+- [crane auth](crane_auth.md) - Log in or access credentials

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -35,5 +35,4 @@ crane auth login [OPTIONS] [SERVER] [flags]
 
 ### SEE ALSO
 
-* [crane auth](crane_auth.md)	 - Log in or access credentials
-
+- [crane auth](crane_auth.md) - Log in or access credentials

--- a/cmd/crane/doc/crane_blob.md
+++ b/cmd/crane/doc/crane_blob.md
@@ -31,5 +31,4 @@ crane blob ubuntu@sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac3
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -25,5 +25,4 @@ crane catalog [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -25,5 +25,4 @@ crane config IMAGE [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -25,5 +25,4 @@ crane copy SRC DST [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -25,5 +25,4 @@ crane delete IMAGE [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -25,5 +25,4 @@ crane digest IMAGE [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -35,5 +35,4 @@ crane export IMAGE TARBALL [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -25,5 +25,4 @@ crane ls REPO [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -25,5 +25,4 @@ crane manifest IMAGE [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -27,5 +27,4 @@ crane pull IMAGE TARBALL [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -25,5 +25,4 @@ crane push TARBALL IMAGE [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -29,5 +29,4 @@ crane rebase [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_tag.md
+++ b/cmd/crane/doc/crane_tag.md
@@ -6,13 +6,16 @@ Efficiently tag a remote image
 
 This differs slightly from the "copy" command in a couple subtle ways:
 
-1. You don't have to specify the entire repository for the tag you're adding. For example, these two commands are functionally equivalent:
+1. You don't have to specify the entire repository for the tag you're adding.
+   For example, these two commands are functionally equivalent:
+
 ```
 crane cp registry.example.com/library/ubuntu:v0 registry.example.com/library/ubuntu:v1
 crane tag registry.example.com/library/ubuntu:v0 v1
 ```
 
-2. We can skip layer existence checks because we know the manifest already exists. This makes "tag" slightly faster than "copy".
+2. We can skip layer existence checks because we know the manifest already
+   exists. This makes "tag" slightly faster than "copy".
 
 ```
 crane tag IMG TAG [flags]
@@ -40,5 +43,4 @@ crane tag ubuntu v1
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -27,5 +27,4 @@ crane validate [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/doc/crane_version.md
+++ b/cmd/crane/doc/crane_version.md
@@ -4,10 +4,11 @@ Print the version
 
 ### Synopsis
 
-The version string is completely dependent on how the binary was built, so you should not depend on the version format. It may change without notice.
+The version string is completely dependent on how the binary was built, so you
+should not depend on the version format. It may change without notice.
 
-This could be an arbitrary string, if specified via -ldflags.
-This could also be the go module version, if built with go modules (often "(devel)").
+This could be an arbitrary string, if specified via -ldflags. This could also be
+the go module version, if built with go modules (often "(devel)").
 
 ```
 crane version [flags]
@@ -28,5 +29,4 @@ crane version [flags]
 
 ### SEE ALSO
 
-* [crane](crane.md)	 - Crane is a tool for managing container images
-
+- [crane](crane.md) - Crane is a tool for managing container images

--- a/cmd/crane/rebase.md
+++ b/cmd/crane/rebase.md
@@ -86,5 +86,5 @@ In general, it's a good practice to tag rebased images to some other tag than
 the `original` tag, perform some sanity checks, then tag the image to the
 `original` tag once it's determined the image is valid.
 
-There is ongoing work to standardize and advertise base image contract
-adherence to make rebasing safer.
+There is ongoing work to standardize and advertise base image contract adherence
+to make rebasing safer.

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -1,7 +1,7 @@
 # `gcrane`
 
-This tool implements a superset of the [`crane`](../crane/README.md) commands, with
-additional commands that are specific to [gcr.io](https://gcr.io).
+This tool implements a superset of the [`crane`](../crane/README.md) commands,
+with additional commands that are specific to [gcr.io](https://gcr.io).
 
 Note that this relies on some implementation details of GCR that are not
 consistent with the [registry spec](https://docs.docker.com/registry/spec/api/),
@@ -27,10 +27,11 @@ for backing up images, georeplicating images, or renaming images en masse.
 
 ### gc
 
-`gcrane gc` will calculate images that can be garbage-collected.
-By default, it will print any images that do not have tags pointing to them.
+`gcrane gc` will calculate images that can be garbage-collected. By default, it
+will print any images that do not have tags pointing to them.
 
 This can be composed with `gcrane delete` to actually garbage collect them:
+
 ```shell
 gcrane gc gcr.io/${PROJECT_ID}/repo | xargs -n1 gcrane delete
 ```

--- a/pkg/authn/k8schain/README.md
+++ b/pkg/authn/k8schain/README.md
@@ -1,8 +1,9 @@
 # `k8schain`
 
-This is an implementation of the [github.com/google/go-containerregistry](
-https://github.com/google/go-containerregistry) library's [`authn.Keychain`](
-https://godoc.org/github.com/google/go-containerregistry/authn#Keychain)
+This is an implementation of the
+[github.com/google/go-containerregistry](https://github.com/google/go-containerregistry)
+library's
+[`authn.Keychain`](https://godoc.org/github.com/google/go-containerregistry/authn#Keychain)
 interface based on the authentication semantics used by the Kubelet when
 performing the pull of a Pod's images.
 
@@ -33,8 +34,8 @@ The `k8schain` keychain can be used directly as an `authn.Keychain`, e.g.
 	}
 ```
 
-Or, it can be used to override the default keychain used by this process,
-which by default follows Docker's keychain semantics:
+Or, it can be used to override the default keychain used by this process, which
+by default follows Docker's keychain semantics:
 
 ```go
 func init() {

--- a/pkg/v1/daemon/README.md
+++ b/pkg/v1/daemon/README.md
@@ -4,8 +4,9 @@
 
 The `daemon` package enables reading/writing images from/to the docker daemon.
 
-It is not fully fleshed out, but is useful for interoperability, see various issues:
+It is not fully fleshed out, but is useful for interoperability, see various
+issues:
 
-* https://github.com/google/go-containerregistry/issues/205
-* https://github.com/google/go-containerregistry/issues/552
-* https://github.com/google/go-containerregistry/issues/627
+- https://github.com/google/go-containerregistry/issues/205
+- https://github.com/google/go-containerregistry/issues/552
+- https://github.com/google/go-containerregistry/issues/627

--- a/pkg/v1/empty/README.md
+++ b/pkg/v1/empty/README.md
@@ -2,7 +2,9 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/empty?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/empty)
 
-The empty packages provides an empty base for constructing a `v1.Image` or `v1.ImageIndex`.
-This is especially useful when paired with the [`mutate`](/pkg/v1/mutate) package,
-see [`mutate.Append`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate#Append)
-and [`mutate.AppendManifests`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate#AppendManifests).
+The empty packages provides an empty base for constructing a `v1.Image` or
+`v1.ImageIndex`. This is especially useful when paired with the
+[`mutate`](/pkg/v1/mutate) package, see
+[`mutate.Append`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate#Append)
+and
+[`mutate.AppendManifests`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate#AppendManifests).

--- a/pkg/v1/google/README.md
+++ b/pkg/v1/google/README.md
@@ -3,5 +3,6 @@
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/google?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/google)
 
 The `google` package provides:
-* Some google-specific authentication methods.
-* Some [GCR](gcr.io)-specific listing methods.
+
+- Some google-specific authentication methods.
+- Some [GCR](gcr.io)-specific listing methods.

--- a/pkg/v1/google/testdata/README.md
+++ b/pkg/v1/google/testdata/README.md
@@ -1,4 +1,5 @@
 # testdata
 
-This key is cribbed from [here](https://github.com/golang/oauth2/blob/d668ce993890a79bda886613ee587a69dd5da7a6/google/testdata/gcloud/credentials).
+This key is cribbed from
+[here](https://github.com/golang/oauth2/blob/d668ce993890a79bda886613ee587a69dd5da7a6/google/testdata/gcloud/credentials).
 It's invalid but parses sufficiently to test `NewEnvAuthenticator`.

--- a/pkg/v1/layout/README.md
+++ b/pkg/v1/layout/README.md
@@ -2,4 +2,5 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout)
 
-The `layout` package implements support for interacting with an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/master/image-layout.md).
+The `layout` package implements support for interacting with an
+[OCI Image Layout](https://github.com/opencontainers/image-spec/blob/master/image-layout.md).

--- a/pkg/v1/mutate/README.md
+++ b/pkg/v1/mutate/README.md
@@ -2,12 +2,12 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/mutate)
 
-The `v1.Image`, `v1.ImageIndex`, and `v1.Layer` interfaces provide only
-accessor methods, so they are essentially immutable. If you want to change
-something about them, you need to produce a new instance of that interface.
+The `v1.Image`, `v1.ImageIndex`, and `v1.Layer` interfaces provide only accessor
+methods, so they are essentially immutable. If you want to change something
+about them, you need to produce a new instance of that interface.
 
-A common use case for this library is to read an image from somewhere (a source),
-change something about it, and write the image somewhere else (a sink).
+A common use case for this library is to read an image from somewhere (a
+source), change something about it, and write the image somewhere else (a sink).
 
 Graphically, this looks something like:
 
@@ -17,40 +17,45 @@ Graphically, this looks something like:
 
 ## Mutations
 
-This is obviously not a comprehensive set of useful transformations (PRs welcome!),
-but a rough summary of what the `mutate` package currently does:
+This is obviously not a comprehensive set of useful transformations (PRs
+welcome!), but a rough summary of what the `mutate` package currently does:
 
 ### `Config` and `ConfigFile`
 
-These allow you to change the [image configuration](https://github.com/opencontainers/image-spec/blob/master/config.md#properties),
+These allow you to change the
+[image configuration](https://github.com/opencontainers/image-spec/blob/master/config.md#properties),
 e.g. to change the entrypoint, environment, author, etc.
 
 ### `Time`, `Canonical`, and `CreatedAt`
 
-These are useful in the context of [reproducible builds](https://reproducible-builds.org/),
-where you may want to strip timestamps and other non-reproducible information.
+These are useful in the context of
+[reproducible builds](https://reproducible-builds.org/), where you may want to
+strip timestamps and other non-reproducible information.
 
 ### `Append`, `AppendLayers`, and `AppendManifests`
 
-These functions allow the extension of a `v1.Image` or `v1.ImageIndex` with
-new layers or manifests.
+These functions allow the extension of a `v1.Image` or `v1.ImageIndex` with new
+layers or manifests.
 
-For constructing an image `FROM scratch`, see the [`empty`](/pkg/v1/empty) package.
+For constructing an image `FROM scratch`, see the [`empty`](/pkg/v1/empty)
+package.
 
 ### `MediaType` and `IndexMediaType`
 
-Sometimes, it is necessary to change the media type of an image or index,
-e.g. to appease a registry with strict validation of images (_looking at you, GCR_).
+Sometimes, it is necessary to change the media type of an image or index, e.g.
+to appease a registry with strict validation of images (_looking at you, GCR_).
 
 ### `Rebase`
 
 Rebase has [its own README](/cmd/crane/rebase.md).
 
-This is the underlying implementation of [`crane rebase`](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane_rebase.md).
+This is the underlying implementation of
+[`crane rebase`](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane_rebase.md).
 
 ### `Extract`
 
-Extract will flatten an image filesystem into a single tar stream,
-respecting whiteout files.
+Extract will flatten an image filesystem into a single tar stream, respecting
+whiteout files.
 
-This is the underlying implementation of [`crane export`](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane_export.md).
+This is the underlying implementation of
+[`crane export`](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane_export.md).

--- a/pkg/v1/mutate/testdata/README.md
+++ b/pkg/v1/mutate/testdata/README.md
@@ -1,9 +1,10 @@
-# whiteout\_image.tar
+# whiteout_image.tar
 
-Including whiteout files in our source caused [issues](https://github.com/google/go-containerregistry/issues/305)
-when cloning this repo inside a docker build. Removing the whiteout file from
-this test data doesn't break anything (since we checked in the tar), but if you
-want to rebuild it for some reason:
+Including whiteout files in our source caused
+[issues](https://github.com/google/go-containerregistry/issues/305) when cloning
+this repo inside a docker build. Removing the whiteout file from this test data
+doesn't break anything (since we checked in the tar), but if you want to rebuild
+it for some reason:
 
 ```
 touch whiteout/.wh.foo.txt

--- a/pkg/v1/partial/README.md
+++ b/pkg/v1/partial/README.md
@@ -4,17 +4,20 @@
 
 ## Partial Implementations
 
-There are roughly two kinds of image representations: compressed and uncompressed.
+There are roughly two kinds of image representations: compressed and
+uncompressed.
 
-The implementations for these kinds of images are almost identical, with the only
-major difference being how blobs (config and layers) are fetched. This common
-code lives in this package, where you provide a _partial_ implementation of a
-compressed or uncompressed image, and you get back a full `v1.Image` implementation.
+The implementations for these kinds of images are almost identical, with the
+only major difference being how blobs (config and layers) are fetched. This
+common code lives in this package, where you provide a _partial_ implementation
+of a compressed or uncompressed image, and you get back a full `v1.Image`
+implementation.
 
 ### Examples
 
-In a registry, blobs are compressed, so it's easiest to implement a `v1.Image` in terms
-of compressed layers. `remote.remoteImage` does this by implementing `CompressedImageCore`:
+In a registry, blobs are compressed, so it's easiest to implement a `v1.Image`
+in terms of compressed layers. `remote.remoteImage` does this by implementing
+`CompressedImageCore`:
 
 ```go
 type CompressedImageCore interface {
@@ -25,8 +28,9 @@ type CompressedImageCore interface {
 }
 ```
 
-In a tarball, blobs are (often) uncompressed, so it's easiest to implement a `v1.Image` in terms
-of uncompressed layers. `tarball.uncompressedImage` does this by implementing `UncompressedImageCore`:
+In a tarball, blobs are (often) uncompressed, so it's easiest to implement a
+`v1.Image` in terms of uncompressed layers. `tarball.uncompressedImage` does
+this by implementing `UncompressedImageCore`:
 
 ```go
 type CompressedImageCore interface {
@@ -38,16 +42,19 @@ type CompressedImageCore interface {
 
 ## Optional Methods
 
-Where possible, we access some information via optional methods as an optimization.
+Where possible, we access some information via optional methods as an
+optimization.
 
 ### [`partial.Descriptor`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/partial#Descriptor)
 
-There are some properties of a [`Descriptor`](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties) that aren't derivable from just image data:
+There are some properties of a
+[`Descriptor`](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties)
+that aren't derivable from just image data:
 
-* `MediaType`
-* `Platform`
-* `URLs`
-* `Annotations`
+- `MediaType`
+- `Platform`
+- `URLs`
+- `Annotations`
 
 For example, in a `tarball.Image`, there is a `LayerSources` field that contains
 an entire layer descriptor with `URLs` information for foreign layers. This

--- a/pkg/v1/remote/README.md
+++ b/pkg/v1/remote/README.md
@@ -2,11 +2,11 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote)
 
-The `remote` package implements a client for accessing a registry,
-per the [OCI distribution spec](https://github.com/opencontainers/distribution-spec/blob/master/spec.md).
+The `remote` package implements a client for accessing a registry, per the
+[OCI distribution spec](https://github.com/opencontainers/distribution-spec/blob/master/spec.md).
 
-It leans heavily on the lower level [`transport`](/pkg/v1/remote/transport) package, which handles the
-authentication handshake and structured errors.
+It leans heavily on the lower level [`transport`](/pkg/v1/remote/transport)
+package, which handles the authentication handshake and structured errors.
 
 ## Usage
 
@@ -40,19 +40,23 @@ func main() {
   <img src="/images/remote.dot.svg" />
 </p>
 
-
 ## Background
 
-There are a lot of confusingly similar terms that come up when talking about images in registries.
+There are a lot of confusingly similar terms that come up when talking about
+images in registries.
 
 ### Anatomy of an image
 
 In general...
 
-* A tag refers to an image manifest.
-* An image manifest references a config file and an orderered list of _compressed_ layers by sha256 digest.
-* A config file references an ordered list of _uncompressed_ layers by sha256 digest and contains runtime configuration.
-* The sha256 digest of the config file is the [image id](https://github.com/opencontainers/image-spec/blob/master/config.md#imageid) for the image.
+- A tag refers to an image manifest.
+- An image manifest references a config file and an orderered list of
+  _compressed_ layers by sha256 digest.
+- A config file references an ordered list of _uncompressed_ layers by sha256
+  digest and contains runtime configuration.
+- The sha256 digest of the config file is the
+  [image id](https://github.com/opencontainers/image-spec/blob/master/config.md#imageid)
+  for the image.
 
 For example, an image with two layers would look something like this:
 
@@ -60,9 +64,11 @@ For example, an image with two layers would look something like this:
 
 ### Anatomy of an index
 
-In the normal case, an [index](https://github.com/opencontainers/image-spec/blob/master/image-index.md) is used to represent a multi-platform image.
-This was the original use case for a [manifest
-list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list).
+In the normal case, an
+[index](https://github.com/opencontainers/image-spec/blob/master/image-index.md)
+is used to represent a multi-platform image. This was the original use case for
+a
+[manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list).
 
 ![image index anatomy](/images/index-anatomy.dot.svg)
 
@@ -70,48 +76,56 @@ It is possible for an index to reference another index, per the OCI
 [image-spec](https://github.com/opencontainers/image-spec/blob/master/media-types.md#compatibility-matrix).
 In theory, both an image and image index can reference arbitrary things via
 [descriptors](https://github.com/opencontainers/image-spec/blob/master/descriptor.md),
-e.g. see the [image layout
-example](https://github.com/opencontainers/image-spec/blob/master/image-layout.md#index-example),
+e.g. see the
+[image layout example](https://github.com/opencontainers/image-spec/blob/master/image-layout.md#index-example),
 which references an application/xml file from an image index.
 
 That could look something like this:
 
 ![exotic image index anatomy](/images/index-anatomy-exotic.dot.svg)
 
-Using a recursive index like this might not be possible with all registries,
-but this flexibility allows for some interesting applications, e.g. the
+Using a recursive index like this might not be possible with all registries, but
+this flexibility allows for some interesting applications, e.g. the
 [OCI Artifacts](https://github.com/opencontainers/artifacts) effort.
 
 ### Anatomy of an image upload
 
-The structure of an image requires a delicate ordering when uploading an image to a registry.
-Below is a (slightly simplified) figure that describes how an image is prepared for upload
-to a registry and how the data flows between various artifacts:
+The structure of an image requires a delicate ordering when uploading an image
+to a registry. Below is a (slightly simplified) figure that describes how an
+image is prepared for upload to a registry and how the data flows between
+various artifacts:
 
 ![upload](/images/upload.dot.svg)
 
 Note that:
 
-* A config file references the uncompressed layer contents by sha256.
-* A manifest references the compressed layer contents by sha256 and the size of the layer.
-* A manifest references the config file contents by sha256 and the size of the file.
+- A config file references the uncompressed layer contents by sha256.
+- A manifest references the compressed layer contents by sha256 and the size of
+  the layer.
+- A manifest references the config file contents by sha256 and the size of the
+  file.
 
-It follows that during an upload, we need to upload layers before the config file,
-and we need to upload the config file before the manifest.
+It follows that during an upload, we need to upload layers before the config
+file, and we need to upload the config file before the manifest.
 
-Sometimes, we know all of this information ahead of time, (e.g. when copying from remote.Image),
-so the ordering is less important.
+Sometimes, we know all of this information ahead of time, (e.g. when copying
+from remote.Image), so the ordering is less important.
 
-In other cases, e.g. when using a [`stream.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/stream#Layer),
-we can't compute anything until we have already uploaded the layer, so we need to be careful about ordering.
+In other cases, e.g. when using a
+[`stream.Layer`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/stream#Layer),
+we can't compute anything until we have already uploaded the layer, so we need
+to be careful about ordering.
 
 ## Caveats
 
 ### schema 1
 
-This package does not support schema 1 images, see [`#377`](https://github.com/google/go-containerregistry/issues/377),
-however, it's possible to do _something_ useful with them via [`remote.Get`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Get),
+This package does not support schema 1 images, see
+[`#377`](https://github.com/google/go-containerregistry/issues/377), however,
+it's possible to do _something_ useful with them via
+[`remote.Get`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote#Get),
 which doesn't try to interpret what is returned by the registry.
 
-[`crane.Copy`](https://godoc.org/github.com/google/go-containerregistry/pkg/crane#Copy) takes advantage of this to implement support for copying schema 1 images,
-see [here](https://github.com/google/go-containerregistry/blob/master/pkg/internal/legacy/copy.go).
+[`crane.Copy`](https://godoc.org/github.com/google/go-containerregistry/pkg/crane#Copy)
+takes advantage of this to implement support for copying schema 1 images, see
+[here](https://github.com/google/go-containerregistry/blob/master/pkg/internal/legacy/copy.go).

--- a/pkg/v1/remote/transport/README.md
+++ b/pkg/v1/remote/transport/README.md
@@ -2,43 +2,62 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/transport?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/transport)
 
-The [distribution protocol](https://github.com/opencontainers/distribution-spec) is fairly simple, but correctly [implementing authentication](../../../authn/README.md) is **hard**.
+The [distribution protocol](https://github.com/opencontainers/distribution-spec)
+is fairly simple, but correctly
+[implementing authentication](../../../authn/README.md) is **hard**.
 
-This package [implements](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote/transport#New) an [`http.RoundTripper`](https://godoc.org/net/http#RoundTripper)
-that transparently performs:
-* [Token
-Authentication](https://docs.docker.com/registry/spec/auth/token/) and
-* [OAuth2
-Authentication](https://docs.docker.com/registry/spec/auth/oauth/)
+This package
+[implements](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote/transport#New)
+an [`http.RoundTripper`](https://godoc.org/net/http#RoundTripper) that
+transparently performs:
+
+- [Token Authentication](https://docs.docker.com/registry/spec/auth/token/) and
+- [OAuth2 Authentication](https://docs.docker.com/registry/spec/auth/oauth/)
 
 for registry clients.
 
 ## Raison d'être
 
-> Why not just use the [`docker/distribution`](https://godoc.org/github.com/docker/distribution/registry/client/auth) client?
+> Why not just use the
+> [`docker/distribution`](https://godoc.org/github.com/docker/distribution/registry/client/auth)
+> client?
 
-Great question! Mostly, because I don't want to depend on [`prometheus/client_golang`](https://github.com/prometheus/client_golang).
+Great question! Mostly, because I don't want to depend on
+[`prometheus/client_golang`](https://github.com/prometheus/client_golang).
 
-As a performance optimization, that client uses [a cache](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/client/repository.go#L173) to keep track of a mapping between blob digests and their [descriptors](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/blobs.go#L57-L86). Unfortunately, the cache [uses prometheus](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/storage/cache/cachedblobdescriptorstore.go#L44) to track hits and misses, so if you want to use that client you have to pull in all of prometheus, which is pretty large.
+As a performance optimization, that client uses
+[a cache](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/client/repository.go#L173)
+to keep track of a mapping between blob digests and their
+[descriptors](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/blobs.go#L57-L86).
+Unfortunately, the cache
+[uses prometheus](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/storage/cache/cachedblobdescriptorstore.go#L44)
+to track hits and misses, so if you want to use that client you have to pull in
+all of prometheus, which is pretty large.
 
 ![docker/distribution](../../../../images/docker.dot.svg)
 
 > Why does it matter if you depend on prometheus? Who cares?
 
-It's generally polite to your downstream to reduce the number of dependencies your package requires:
+It's generally polite to your downstream to reduce the number of dependencies
+your package requires:
 
-* Downloading your package is faster, which helps our Australian friends and people on airplanes.
-* There is less code to compile, which speeds up builds and saves the planet from global warming.
-* You reduce the likelihood of inflicting dependency hell upon your consumers.
-* [Tim Hockin](https://twitter.com/thockin/status/958606077456654336) prefers it based on his experience working on Kubernetes, and he's a pretty smart guy.
+- Downloading your package is faster, which helps our Australian friends and
+  people on airplanes.
+- There is less code to compile, which speeds up builds and saves the planet
+  from global warming.
+- You reduce the likelihood of inflicting dependency hell upon your consumers.
+- [Tim Hockin](https://twitter.com/thockin/status/958606077456654336) prefers it
+  based on his experience working on Kubernetes, and he's a pretty smart guy.
 
-> Okay, what about [`containerd/containerd`](https://godoc.org/github.com/containerd/containerd/remotes/docker)?
+> Okay, what about
+> [`containerd/containerd`](https://godoc.org/github.com/containerd/containerd/remotes/docker)?
 
 Similar reasons! That ends up pulling in grpc, protobuf, and logrus.
 
 ![containerd/containerd](../../../../images/containerd.dot.svg)
 
-> Well... what about [`containers/image`](https://godoc.org/github.com/containers/image/docker)?
+> Well... what about
+> [`containers/image`](https://godoc.org/github.com/containers/image/docker)?
 
 That just uses the the `docker/distribution` client... and more!
 
@@ -53,8 +72,8 @@ interacting with a registry.
 
 ![google/go-containerregistry](../../../../images/ggcr.dot.svg)
 
-*These graphs were generated by
-[`kisielk/godepgraph`](https://github.com/kisielk/godepgraph).*
+_These graphs were generated by
+[`kisielk/godepgraph`](https://github.com/kisielk/godepgraph)._
 
 ## Usage
 
@@ -62,11 +81,11 @@ This is heavily used by the
 [`remote`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote)
 package, which implements higher level image-centric functionality, but this
 package is useful if you want to interact directly with the registry to do
-something that `remote` doesn't support, e.g. [to handle with schema 1
-images](https://github.com/google/go-containerregistry/pull/509).
+something that `remote` doesn't support, e.g.
+[to handle with schema 1 images](https://github.com/google/go-containerregistry/pull/509).
 
-This package also includes some [error
-handling](https://github.com/opencontainers/distribution-spec/blob/60be706c34ee7805bdd1d3d11affec53b0dfb8fb/spec.md#errors)
+This package also includes some
+[error handling](https://github.com/opencontainers/distribution-spec/blob/60be706c34ee7805bdd1d3d11affec53b0dfb8fb/spec.md#errors)
 facilities in the form of
 [`CheckError`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/remote/transport#CheckError),
 which will parse the response body into a structured error for unexpected http

--- a/pkg/v1/stream/README.md
+++ b/pkg/v1/stream/README.md
@@ -37,13 +37,13 @@ func main() {
 
 ## Structure
 
-This implements the layer portion of an [image
-upload](/pkg/v1/remote#anatomy-of-an-image-upload). We launch a goroutine that
-is responsible for hashing the uncompressed contents to compute the `DiffID`,
-gzipping them to produce the `Compressed` contents, and hashing/counting the
-bytes to produce the `Digest`/`Size`. This goroutine writes to an
-`io.PipeWriter`, which blocks until `Compressed` reads the gzipped contents from
-the corresponding `io.PipeReader`.
+This implements the layer portion of an
+[image upload](/pkg/v1/remote#anatomy-of-an-image-upload). We launch a goroutine
+that is responsible for hashing the uncompressed contents to compute the
+`DiffID`, gzipping them to produce the `Compressed` contents, and
+hashing/counting the bytes to produce the `Digest`/`Size`. This goroutine writes
+to an `io.PipeWriter`, which blocks until `Compressed` reads the gzipped
+contents from the corresponding `io.PipeReader`.
 
 <p align="center">
   <img src="/images/stream.dot.svg" />

--- a/pkg/v1/tarball/README.md
+++ b/pkg/v1/tarball/README.md
@@ -2,10 +2,10 @@
 
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball)
 
-This package produces tarballs that can consumed via `docker load`. Note
-that this is a _different_ format from the [`legacy`](/pkg/legacy/tarball)
-tarballs that are produced by `docker save`, but this package is still able to
-read the legacy tarballs produced by `docker save`.
+This package produces tarballs that can consumed via `docker load`. Note that
+this is a _different_ format from the [`legacy`](/pkg/legacy/tarball) tarballs
+that are produced by `docker save`, but this package is still able to read the
+legacy tarballs produced by `docker save`.
 
 ## Usage
 
@@ -55,7 +55,6 @@ func main() {
 
 Let's look at what happens when we write out a tarball:
 
-
 ### `ubuntu:latest`
 
 ```
@@ -74,7 +73,8 @@ ubuntu/
 
 There are a couple interesting files here.
 
-`manifest.json` is the entrypoint: a list of [`tarball.Descriptor`s](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Descriptor)
+`manifest.json` is the entrypoint: a list of
+[`tarball.Descriptor`s](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/tarball#Descriptor)
 that describe the images contained in this tarball.
 
 For each image, this has the `RepoTags` (how it was pulled), a `Config` file
@@ -188,19 +188,21 @@ $ jq < nanoserver/manifest.json
 ```
 
 A couple things to note about this `manifest.json` versus the other:
-* The `RepoTags` field is a bit weird here. `hello-world` is a multi-platform
+
+- The `RepoTags` field is a bit weird here. `hello-world` is a multi-platform
   image, so We had to pull this image by digest, since we're (I'm) on
   amd64/linux and wanted to grab a windows image. Since the tarball format
   expects a tag under `RepoTags`, and we didn't pull by tag, we replace the
   digest with a sentinel `i-was-a-digest` "tag" to appease docker.
-* The `LayerSources` has enough information to reconstruct the foreign layers
+- The `LayerSources` has enough information to reconstruct the foreign layers
   pointer when pushing/pulling from the registry. For legal reasons, microsoft
   doesn't want anyone but them to serve windows base images, so the mediaType
   here indicates a "foreign" or "non-distributable" layer with an URL for where
-  you can download it from microsoft (see the [OCI
-  image-spec](https://github.com/opencontainers/image-spec/blob/master/layer.md#non-distributable-layers)).
+  you can download it from microsoft (see the
+  [OCI image-spec](https://github.com/opencontainers/image-spec/blob/master/layer.md#non-distributable-layers)).
 
 We can look at what's in the registry to explain both of these things:
+
 ```
 $ crane manifest hello-world:nanoserver | jq .
 {
@@ -254,7 +256,10 @@ $ crane manifest hello-world:nanoserver@sha256:63c287625c2b0b72900e562de73c0e381
 }
 ```
 
-The `LayerSources` map is keyed by the diffid. Note that `sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e` matches the first layer in the config file:
+The `LayerSources` map is keyed by the diffid. Note that
+`sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e`
+matches the first layer in the config file:
+
 ```
 $ jq '.[0].LayerSources' < nanoserver/manifest.json
 {


### PR DESCRIPTION
Produced via:
```shell
prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github | grep -v docs/cmd/)
```
/cc @jonjohnsonjr @ImJasonH
/assign @jonjohnsonjr @ImJasonH