### PR TITLE
Add Windows support - Fix tests, enable CI, and release Windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,11 +12,27 @@ builds:
   - CGO_ENABLED=0
   main: ./cmd/crane/main.go
   binary: crane
+  goos:
+    - linux
+    - darwin
+    - windows
+  ignore:
+    - goos: windows
+      goarch: 386
+
 - id: gcrane
   env:
   - CGO_ENABLED=0
   main: ./cmd/gcrane/main.go
   binary: gcrane
+  goos:
+    - linux
+    - darwin
+    - windows
+  ignore:
+    - goos: windows
+      goarch: 386
+
 archives:
 - replacements:
     darwin: Darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,23 @@ env:
   - "GO111MODULE=off"
   - "GO111MODULE=on"
 
+os:
+  - windows
+  - linux
+
+# Don't run all combos on Windows
+jobs:
+  exclude:
+    - os: windows
+      go: "1.14"
+    - os: windows
+      go: "1.15"
+      env: "GO111MODULE=off"
+
+
 git:
   depth: 1
+  autocrlf: input
 
 go_import_path: github.com/google/go-containerregistry
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
 git:
   depth: 1
 
+go_import_path: github.com/google/go-containerregistry
+
 cache:
   directories:
     - $GOPATH/pkg/mod

--- a/cmd/registry/test.sh
+++ b/cmd/registry/test.sh
@@ -1,11 +1,46 @@
 #!/bin/bash
-set -ev
+set -ex
+
+CONTAINER_OS=$(docker info -f '{{ .OSType }}')
+
+# crane can run on a Windows system, but doesn't currently support pulling Windows
+# containers, so this test can only run if Docker is in Linux container mode.
+if [[ ${CONTAINER_OS} = "windows" ]]; then
+    set +x
+    echo [TEST SKIPPED] Windows containers are not yet supported by crane
+    exit
+fi
+
+function cleanup {
+    [[ -n $PID ]] && kill $PID
+    [[ -n $CTR ]] && docker stop $CTR
+    rm -f ubuntu.tar debiand.tar debianc.tar
+    docker rmi -f \
+        localhost:1338/debianc:latest \
+        localhost:1338/debiand:latest \
+        localhost:1338/ubuntuc:foo \
+        localhost:1338/ubuntud:latest \
+        || true
+}
+trap cleanup EXIT
+
+case "$OSTYPE" in
+    # On Windows, Docker runs in a VM, so a registry running on the Windows
+    # host is not accessible via localhost for `docker pull|push`.
+    win*|msys*|cygwin*)
+        docker run -d --rm -p 1338:5000 --name test-reg registry:2
+        CTR=test-reg
+        ;;
+
+    *)
+        registry &
+        PID=$!
+        ;;
+esac
 
 go install ./cmd/registry
 go install ./cmd/crane
 
-registry &
-PID=$!
 
 crane pull debian:latest debianc.tar
 crane push debianc.tar localhost:1338/debianc:latest
@@ -20,8 +55,3 @@ docker push localhost:1338/ubuntud:latest
 crane pull localhost:1338/ubuntud:latest ubuntu.tar
 crane push ubuntu.tar localhost:1338/ubuntuc:foo
 docker pull localhost:1338/ubuntuc:foo
-rm ubuntu.tar
-rm debiand.tar
-rm debianc.tar
-
-kill $PID

--- a/pkg/v1/cache/fs_test.go
+++ b/pkg/v1/cache/fs_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -167,7 +166,7 @@ func TestErrUnexpectedEOF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("layer.Digest(): %v", err)
 	}
-	p := path.Join(dir, h.String())
+	p := cachepath(dir, h)
 
 	// Write only the first segment of the compressed layer to produce an
 	// UnexpectedEOF error when reading it

--- a/pkg/v1/layout/image_test.go
+++ b/pkg/v1/layout/image_test.go
@@ -15,6 +15,7 @@
 package layout
 
 import (
+	"path/filepath"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -39,9 +40,9 @@ var (
 		Algorithm: "sha256",
 		Hex:       "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 	}
-	bogusPath        = "testdata/does_not_exist"
-	testPath         = "testdata/test_index"
-	testPathOneImage = "testdata/test_index_one_image"
+	bogusPath        = filepath.Join("testdata", "does_not_exist")
+	testPath         = filepath.Join("testdata", "test_index")
+	testPathOneImage = filepath.Join("testdata", "test_index_one_image")
 )
 
 func TestImage(t *testing.T) {

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -175,6 +175,7 @@ func extract(img v1.Image, w io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("reading layer contents: %v", err)
 		}
+		defer layerReader.Close()
 		tarReader := tar.NewReader(layerReader)
 		for {
 			header, err := tarReader.Next()
@@ -300,6 +301,7 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting layer: %v", err)
 	}
+	defer layerReader.Close()
 	w := new(bytes.Buffer)
 	tarWriter := tar.NewWriter(w)
 	defer tarWriter.Close()

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -199,6 +199,13 @@ func extractFileFromTar(opener Opener, filePath string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	close := true
+	defer func() {
+		if close {
+			f.Close()
+		}
+	}()
+
 	tf := tar.NewReader(f)
 	for {
 		hdr, err := tf.Next()
@@ -209,6 +216,7 @@ func extractFileFromTar(opener Opener, filePath string) (io.ReadCloser, error) {
 			return nil, err
 		}
 		if hdr.Name == filePath {
+			close = false
 			return tarFile{
 				Reader: tf,
 				Closer: f,

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -163,6 +163,7 @@ func computeDiffID(opener Opener, compressed bool) (v1.Hash, error) {
 	if err != nil {
 		return v1.Hash{}, err
 	}
+	defer reader.Close()
 
 	diffID, _, err := v1.SHA256(reader)
 	return diffID, err

--- a/pkg/v1/validate/layer.go
+++ b/pkg/v1/validate/layer.go
@@ -163,6 +163,7 @@ func computeLayer(layer v1.Layer) (*computedLayer, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer ur.Close()
 	udiffid, usize, err := v1.SHA256(ur)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #778 

With these changes, all tests pass running on a Windows system with Docker in Linux container mode.
One test file cannot run if Docker is in Windows container mode because crane can only pull Linux containers.

I'm not normally a Go developer, so let me know if I need to make any changes to how I've done anything here.

Please take a hard look at the "unclosed ReadClosers" fix, as that one is the most involved and has the most potential for me to have done something incorrectly.
