### PR TITLE
Implement `crane digest` using a HEAD request

### DIFF
--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -16,7 +16,7 @@ package crane
 
 // Digest returns the sha256 hash of the remote image at ref.
 func Digest(ref string, opt ...Option) (string, error) {
-	desc, err := getManifest(ref, opt...)
+	desc, err := head(ref, opt...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -43,3 +43,12 @@ func getManifest(r string, opt ...Option) (*remote.Descriptor, error) {
 	}
 	return remote.Get(ref, o.remote...)
 }
+
+func head(r string, opt ...Option) (*v1.Descriptor, error) {
+	o := makeOptions(opt...)
+	ref, err := name.ParseReference(r, o.name...)
+	if err != nil {
+		return nil, err
+	}
+	return remote.Head(ref, o.remote...)
+}


### PR DESCRIPTION
#### Before
```
$ crane digest ubuntu
sha256:bc2f7250f69267c9c6b66d7b6a81a54d3878bb85f1ebb5f951c896d13e6ba537
```

#### After
```
$ go  run  ./cmd/crane/ digest ubuntu
sha256:bc2f7250f69267c9c6b66d7b6a81a54d3878bb85f1ebb5f951c896d13e6ba537
```

This wouldn't count as a "pull" from Dockerhub, which might be helpful in some cases.