### PR TITLE
Use pinned k8s.io/code-generator for codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -28,7 +28,7 @@ export GOPATH=$(go env GOPATH)
 export PATH="${GOPATH}/bin:${PATH}"
 
 
-go get k8s.io/code-generator/cmd/deepcopy-gen
-go get github.com/maxbrunsfeld/counterfeiter/v6
+go mod tidy
+go mod vendor
 go run $PROJECT_ROOT/cmd/crane/help/main.go --dir=$PROJECT_ROOT/cmd/crane/doc/
 go generate ./...

--- a/pkg/v1/progress.go
+++ b/pkg/v1/progress.go
@@ -17,6 +17,7 @@ package v1
 // Update representation of an update of transfer progress. Some functions
 // in this module can take a channel to which updates will be sent while a
 // transfer is in progress.
+// +k8s:deepcopy-gen=false
 type Update struct {
 	Total    int64
 	Complete int64


### PR DESCRIPTION
Updates hack/update-codegen.sh to use the pinned code-generator version
to avoid always pulling in the latest release with go get.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Added deepcopy-gen directive to avoid generating DeepCopy methods for
Update type, which fails generation due to embedded error interface not
supporting DeepCopy methods

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #782 