### PR TITLE
Add --platform CLI option for crane

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -13,22 +13,19 @@
 package cmd
 
 import (
-	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	Root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
 	Root.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow image references to be fetched without TLS")
-	Root.PersistentFlags().Var(platform, "platform", "Specifies the platform in the form os/arch (e.g. linux/amd64).")
+	Root.PersistentFlags().Var(platform, "platform", "Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64).")
 }
 
 var (
@@ -86,32 +83,4 @@ func (ht *headerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		in.Header.Set(k, v)
 	}
 	return ht.inner.RoundTrip(in)
-}
-
-type platformValue struct {
-	platform *v1.Platform
-}
-
-func (pv *platformValue) Set(platform string) error {
-	parts := strings.Split(platform, "/")
-	if len(parts) < 2 {
-		return fmt.Errorf("failed to parse platform")
-	}
-	if pv.platform == nil {
-		pv.platform = &v1.Platform{}
-	}
-	pv.platform.OS = parts[0]
-	pv.platform.Architecture = parts[1]
-	return nil
-}
-
-func (pv *platformValue) String() string {
-	if pv.platform == nil {
-		return "none"
-	}
-	return fmt.Sprintf("%s/%s", pv.platform.OS, pv.platform.Architecture)
-}
-
-func (pv *platformValue) Type() string {
-	return "os/arch"
 }

--- a/cmd/crane/cmd/util.go
+++ b/cmd/crane/cmd/util.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type platformValue struct {
+	platform *v1.Platform
+}
+
+func (pv *platformValue) Set(platform string) error {
+	p, err := parsePlatform(platform)
+	if err != nil {
+		return err
+	}
+	pv.platform = p
+	return nil
+}
+
+func (pv *platformValue) String() string {
+	return platformToString(pv.platform)
+}
+
+func (pv *platformValue) Type() string {
+	return "platform"
+}
+
+func platformToString(p *v1.Platform) string {
+	if p == nil {
+		return "all"
+	}
+	platform := ""
+	if p.OS != "" && p.Architecture != "" {
+		platform = p.OS + "/" + p.Architecture
+	}
+	if p.Variant != "" {
+		platform += "/" + p.Variant
+	}
+	return platform
+}
+
+func parsePlatform(platform string) (*v1.Platform, error) {
+	if platform == "all" {
+		return nil, nil
+	}
+
+	p := &v1.Platform{}
+	parts := strings.Split(platform, "/")
+
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("failed to parse platform '%s': expected format os/arch[/variant]", platform)
+	}
+	if len(parts) > 3 {
+		return nil, fmt.Errorf("failed to parse platform '%s': too many slashes", platform)
+	}
+
+	p.OS = parts[0]
+	p.Architecture = parts[1]
+	if len(parts) > 2 {
+		p.Variant = parts[2]
+	}
+
+	return p, nil
+}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -13,9 +13,10 @@ crane [flags]
 ### Options
 
 ```
-  -h, --help       help for crane
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+  -h, --help                help for crane
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -23,8 +23,9 @@ crane append [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -19,8 +19,9 @@ crane auth [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -27,8 +27,9 @@ crane auth get [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -29,8 +29,9 @@ crane auth login [OPTIONS] [SERVER] [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_blob.md
+++ b/cmd/crane/doc/crane_blob.md
@@ -25,8 +25,9 @@ crane blob ubuntu@sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac3
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -19,8 +19,9 @@ crane catalog [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -19,8 +19,9 @@ crane config IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -19,8 +19,9 @@ crane copy SRC DST [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -19,8 +19,9 @@ crane delete IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -19,8 +19,9 @@ crane digest IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -29,8 +29,9 @@ crane export IMAGE TARBALL [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -19,8 +19,9 @@ crane ls REPO [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -19,8 +19,9 @@ crane manifest IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -21,8 +21,9 @@ crane pull IMAGE TARBALL [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -19,8 +19,9 @@ crane push TARBALL IMAGE [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -23,8 +23,9 @@ crane rebase [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_tag.md
+++ b/cmd/crane/doc/crane_tag.md
@@ -34,8 +34,9 @@ crane tag ubuntu v1
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -21,8 +21,9 @@ crane validate [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/cmd/crane/doc/crane_version.md
+++ b/cmd/crane/doc/crane_version.md
@@ -22,8 +22,9 @@ crane version [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure   Allow image references to be fetched without TLS
-  -v, --verbose    Enable debug logs
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
 ```
 
 ### SEE ALSO

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -60,7 +60,9 @@ func Insecure(o *options) {
 // WithPlatform is an Option to specify the platform.
 func WithPlatform(platform *v1.Platform) Option {
 	return func(o *options) {
-		o.remote = append(o.remote, remote.WithPlatform(*platform))
+		if platform != nil {
+			o.remote = append(o.remote, remote.WithPlatform(*platform))
+		}
 		o.platform = platform
 	}
 }

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -155,7 +155,7 @@ func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error)
 			return r.childDescriptor(childDesc, platform)
 		}
 	}
-	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.Architecture, platform.OS, r.Ref)
+	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.OS, platform.Architecture, r.Ref)
 }
 
 func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {


### PR DESCRIPTION
Adds a `--platform` option for the crane CLI tool.

I added a if-statement in `pkg/crane/options.go` that we don't get a nil pointer dereference if WithPlatform is called with nil. We could also catch this in cmd/crane/cmd/root.go` but I think it would in general make sense to avoid the nil pointer dereference.

I changed the error output in `pkg/v1/remote/index.go` to the form `os/arch`. This is not necessary but i think we should use the same form in the error output and the flag. I think this is quite arbitrary but I prefer os/arch over arch/os.