### PR TITLE
Return basic auth from google.Keychain

### DIFF
--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -118,7 +118,8 @@ func (tsa *tokenSourceAuth) Authorization() (*authn.AuthConfig, error) {
 	}
 
 	return &authn.AuthConfig{
-		RegistryToken: token.AccessToken,
+		Username: "_token",
+		Password: token.AccessToken,
 	}, nil
 }
 

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -135,7 +135,7 @@ func TestGcloudSuccess(t *testing.T) {
 		t.Fatalf("Authorization got error %v", err)
 	}
 
-	if got, want := token.RegistryToken, "mytoken"; got != want {
+	if got, want := token.Password, "mytoken"; got != want {
 		t.Errorf("wanted token %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
Before, we were taking advantage of the fact that GCR will allow you to
just send an access token as bearer auth, but apparently this breaks
`gcrane cp` if it's your first push to a registry, so this change
returns basic auth to force us to always do a token exchange.