### PR TITLE
Update codegen step to use vendored codegen tools

### DIFF
--- a/.github/workflows/knative-verify.yaml
+++ b/.github/workflows/knative-verify.yaml
@@ -1,0 +1,86 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
+
+name: Verify
+
+on:
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  verify:
+    name: Verify Deps and Codegen
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/ko/cmd/ko
+        go get github.com/google/go-licenses
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Update Codegen
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/${{ github.event.repository.name }}
+        [[ ! -f hack/update-codegen.sh ]] || ./hack/update-codegen.sh
+        popd
+
+    - name: Verify
+      shell: bash
+      run: |
+        # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
+        # This is to leverage this workaround:
+        # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+        function urlencode() {
+          sed ':begin;$!N;s/\n/%0A/;tbegin'
+        }
+
+        pushd ./src/knative.dev/${{ github.event.repository.name }}
+        if [[ -z "$(git status --porcelain)" ]]; then
+            echo "${{ github.repository }} up to date."
+        else
+            # Print it both ways because sometimes we haven't modified the file (e.g. zz_generated),
+            # and sometimes we have (e.g. configmap checksum).
+            echo "Found diffs in: $(git diff-index --name-only HEAD --)"
+            for x in $(git diff-index --name-only HEAD --); do
+                echo "::error file=$x::Please run ./hack/update-codegen.sh.%0A$(git diff $x | urlencode)"
+            done
+            echo "${{ github.repository }} is out of date. Please run hack/update-codegen.sh"
+            exit 1
+        fi
+        popd

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -27,7 +27,6 @@ trap popd EXIT
 export GOPATH=$(go env GOPATH)
 export PATH="${GOPATH}/bin:${PATH}"
 
-
 go mod tidy
 go mod vendor
 go run $PROJECT_ROOT/cmd/crane/help/main.go --dir=$PROJECT_ROOT/cmd/crane/doc/

--- a/pkg/v1/doc.go
+++ b/pkg/v1/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate deepcopy-gen -O zz_deepcopy_generated --go-header-file $BOILER_PLATE_FILE -i .
+//go:generate go run ./../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/ -O zz_deepcopy_generated --go-header-file $BOILER_PLATE_FILE -i .
 // +k8s:deepcopy-gen=package
 
 // Package v1 defines structured types for OCI v1 images

--- a/pkg/v1/image.go
+++ b/pkg/v1/image.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Image defines the interface for interacting with an OCI v1 image.
-//go:generate counterfeiter -o fake/image.go . Image
+//go:generate go run ./../../vendor/github.com/maxbrunsfeld/counterfeiter/v6/ -o fake/image.go . Image
 type Image interface {
 	// Layers returns the ordered collection of filesystem layers that comprise this image.
 	// The order of the list is oldest/base layer first, and most-recent/top layer last.

--- a/pkg/v1/index.go
+++ b/pkg/v1/index.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ImageIndex defines the interface for interacting with an OCI image index.
-//go:generate counterfeiter -o fake/index.go . ImageIndex
+//go:generate go run ./../../vendor/github.com/maxbrunsfeld/counterfeiter/v6/ -o fake/index.go . ImageIndex
 type ImageIndex interface {
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)


### PR DESCRIPTION
Also include `knative-verify.yaml` to make sure this passes @mattmoor's automated GitHub Actions.

Hopefully fixes the last of errors blocking https://github.com/google/go-containerregistry/pull/792 🤞 