### PR TITLE
remote: disable http2 for transports by default

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +59,7 @@ var (
 				logs.Debug.Printf("failed to read config file: %v", err)
 			} else if len(cf.HTTPHeaders) != 0 {
 				options = append(options, crane.WithTransport(&headerTransport{
-					inner:       http.DefaultTransport,
+					inner:       remote.DefaultTransport,
 					httpHeaders: cf.HTTPHeaders,
 				}))
 			}

--- a/pkg/internal/legacy/copy.go
+++ b/pkg/internal/legacy/copy.go
@@ -58,7 +58,7 @@ func CopySchema1(desc *remote.Descriptor, srcRef, dstRef name.Reference, srcAuth
 func putManifest(desc *remote.Descriptor, dstRef name.Reference, dstAuth authn.Authenticator) error {
 	reg := dstRef.Context().Registry
 	scopes := []string{dstRef.Scope(transport.PushScope)}
-	tr, err := transport.New(reg, dstAuth, http.DefaultTransport, scopes)
+	tr, err := transport.New(reg, dstAuth, remote.DefaultTransport, scopes)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/legacy/copy.go
+++ b/pkg/internal/legacy/copy.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/internal/net"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -58,7 +59,7 @@ func CopySchema1(desc *remote.Descriptor, srcRef, dstRef name.Reference, srcAuth
 func putManifest(desc *remote.Descriptor, dstRef name.Reference, dstAuth authn.Authenticator) error {
 	reg := dstRef.Context().Registry
 	scopes := []string{dstRef.Scope(transport.PushScope)}
-	tr, err := transport.New(reg, dstAuth, remote.DefaultTransport, scopes)
+	tr, err := transport.New(reg, dstAuth, net.NewDefaultTransport(), scopes)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/net/default_transport.go
+++ b/pkg/internal/net/default_transport.go
@@ -1,0 +1,27 @@
+package net
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewDefaultTransport is a an extension of the default net/http DefaultTransport with http2 disabled.
+// According to moby/buildkit#1420, net/http's lack of tunable flow control prevents full throughput on push.
+func NewDefaultTransport() http.RoundTripper {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+	}
+}

--- a/pkg/internal/net/default_transport.go
+++ b/pkg/internal/net/default_transport.go
@@ -1,3 +1,18 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package net provides an override of the net/http DefaultTransport suitable for pushing images efficiently.
 package net
 
 import (

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
@@ -44,7 +45,7 @@ type lister struct {
 func newLister(repo name.Repository, options ...ListerOption) (*lister, error) {
 	l := &lister{
 		auth:      authn.Anonymous,
-		transport: http.DefaultTransport,
+		transport: remote.DefaultTransport,
 		repo:      repo,
 		ctx:       context.Background(),
 	}

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/internal/net"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
@@ -45,7 +45,7 @@ type lister struct {
 func newLister(repo name.Repository, options ...ListerOption) (*lister, error) {
 	l := &lister{
 		auth:      authn.Anonymous,
-		transport: remote.DefaultTransport,
+		transport: net.NewDefaultTransport(),
 		repo:      repo,
 		ctx:       context.Background(),
 	}

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -16,33 +16,14 @@ package remote
 
 import (
 	"context"
-	"crypto/tls"
-	"net"
 	"net/http"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/internal/net"
 	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
-
-// DefaultTransport is a an extension of the default net/http DefaultTransport with http2 disabled.
-// According to moby/buildkit#1420, net/http lack of tunable flow control prevents full throughput on push.
-var DefaultTransport = &http.Transport{
-	Proxy: http.ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		DualStack: true,
-	}).DialContext,
-	ForceAttemptHTTP2:     true,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
-	TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-}
 
 // Option is a functional option for remote operations.
 type Option func(*options) error
@@ -58,7 +39,7 @@ type options struct {
 func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 	o := &options{
 		auth:      authn.Anonymous,
-		transport: DefaultTransport,
+		transport: net.NewDefaultTransport(),
 		platform:  defaultPlatform,
 		context:   context.Background(),
 	}


### PR DESCRIPTION
Image pushes are seemingly bottlenecked on http2 flow control that isn't tunable at the moment. Found through moby/buildkit#1420.

This is causing some slowness pushing images from [rules_docker](https://github.com/bazelbuild/rules_docker/blob/master/container/go/cmd/pusher/pusher.go).

Bit of contrived example, but the following Dockerfile pushing to quay.io (and this might actually be quay-specific?):
```
FROM ubuntu
RUN head -c 200m </dev/urandom > rand
```

```
$ time ./crane-upstream push /var/folders/qn/89b8d26x7_g9n8dk67bvf02w0000gq/T/tmp.XXnIZ1xjSB/fb4c28b88869.tar quay.io/...
2020/10/27 13:45:20 existing blob: sha256:2def2f19de92c6f5b8ab88ff6b6412ef6b707a57c21b7ed70b551599b99c17c6
2020/10/27 13:45:20 existing blob: sha256:67b07e4ef43acc7e7006ee1f89eca4efaf2f6ff90dedaadce1fd6d2048f544c1
2020/10/27 13:45:20 existing blob: sha256:d020da9bf8302f8f33abeb47848b066c228a292e099510763fb6ba457966e45b
2020/10/27 13:45:23 pushed blob: sha256:fb4c28b8886938f849679b8c70759955354e56033ee8522d305fbfe5f98b49d5
2020/10/27 13:51:38 pushed blob: sha256:eb264d9b5081a6be9899f5dc781af7449312d92005088b24a57f148828b734e9
2020/10/27 13:51:41 quay.io/...: digest: sha256:d1d8a4e6dda28397f0711ef47eed98d6a1f6c4b3a3c7cbb1ce41dfa1d9658233 size: 915

real	6m23.588s
user	0m7.649s
sys	0m2.857s

$ time ./crane push /var/folders/qn/89b8d26x7_g9n8dk67bvf02w0000gq/T/tmp.XXnIZ1xjSB/48d9788dad89.tar quay.io/...
2020/10/27 13:52:46 existing blob: sha256:67b07e4ef43acc7e7006ee1f89eca4efaf2f6ff90dedaadce1fd6d2048f544c1
2020/10/27 13:52:46 existing blob: sha256:d020da9bf8302f8f33abeb47848b066c228a292e099510763fb6ba457966e45b
2020/10/27 13:52:46 existing blob: sha256:2def2f19de92c6f5b8ab88ff6b6412ef6b707a57c21b7ed70b551599b99c17c6
2020/10/27 13:52:49 pushed blob: sha256:48d9788dad897d9c5bbc793aeda5ee7f7c0b759d07645cc709cdf3edaaf3cf9b
2020/10/27 13:53:14 pushed blob: sha256:625043d53457e5d3ec269ddb6b452df166391bda5b93b62a2db6f5728630a4de
2020/10/27 13:53:16 quay.io/...: digest: sha256:a9d5990d9c39d471d4aeff849a0e2033092cc2ce5a49fb50c19612ddd743f83c size: 915

real	0m33.215s
user	0m5.972s
sys	0m4.029s
```