### PR TITLE
Rewrite cloudbuild.yaml and publish with --platform=all

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,49 +1,35 @@
 steps:
-# Build the ko binary.
 - name: golang
-  env: ['GOPATH=/workspace/gopath']
-  entrypoint: go
-  args: ['get', 'github.com/google/ko/cmd/ko']
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    set -ex
 
-# Use the ko binary to build the crane and gcrane builder images.
-- name: golang
-  env:
-  - 'GOPATH=/workspace/gopath'
-  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
-  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
-  entrypoint: /workspace/gopath/bin/ko
-  dir: gopath/src
-  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/crane', '-t', 'latest', '-t', '$COMMIT_SHA']
+    export GO111MODULE=off
+    export KO_DOCKER_REPO="gcr.io/$PROJECT_ID"
+    export GOFLAGS="-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA"
 
-- name: golang
-  env:
-  - 'GOPATH=/workspace/gopath'
-  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
-  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
-  entrypoint: /workspace/gopath/bin/ko
-  dir: gopath/src
-  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/gcrane', '-t', 'latest', '-t', '$COMMIT_SHA']
+    # Put contents of /workspace on GOPATH.
+    shadow=$$GOPATH/src/github.com/google/go-containerregistry
+    link_dir=$$(dirname "$$shadow")
+    mkdir -p $$link_dir
+    ln -s $$PWD $$shadow || stat $$shadow
 
-# Use the ko binary to build the crane and gcrane builder *debug* images.
-- name: golang
-  env:
-  - 'GOPATH=/workspace/gopath'
-  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
-  - 'KO_CONFIG_PATH=/workspace/.ko/debug/'
-  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
-  entrypoint: /workspace/gopath/bin/ko
-  dir: gopath/src
-  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/crane', '-t', 'debug']
+    # Install ko from release.
+    curl -L -o ko.tar.gz https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_i386.tar.gz
+    tar xvfz ko.tar.gz
+    chmod +x ko
+    alias ko=./ko
 
-- name: golang
-  env:
-  - 'GOPATH=/workspace/gopath'
-  - 'KO_DOCKER_REPO=gcr.io/$PROJECT_ID'
-  - 'KO_CONFIG_PATH=/workspace/.ko/debug/'
-  - 'GOFLAGS=-ldflags=-X=github.com/google/go-containerregistry/cmd/crane/cmd.Version=$COMMIT_SHA'
-  entrypoint: /workspace/gopath/bin/ko
-  dir: gopath/src
-  args: ['publish', '-B', 'github.com/google/go-containerregistry/cmd/gcrane', '-t', 'debug']
+    # Use the ko binary to build the crane and gcrane builder images.
+    ko publish --platform=all -B github.com/google/go-containerregistry/cmd/crane -t latest -t "$COMMIT_SHA"
+    ko publish --platform=all -B github.com/google/go-containerregistry/cmd/gcrane -t latest -t "$COMMIT_SHA"
+
+    # Use the ko binary to build the crane and gcrane builder *debug* images.
+    KO_CONFIG_PATH=./ko/debug/
+    ko publish --platform=all -B github.com/google/go-containerregistry/cmd/crane -t debug
+    ko publish --platform=all -B github.com/google/go-containerregistry/cmd/gcrane -t debug
 
 # Use the crane builder to get the digest for crane and gcrane.
 - name: gcr.io/$PROJECT_ID/crane


### PR DESCRIPTION
- consolidate golang steps into a single step for readability
- symlink /workspace into $GOPATH
- install ko from release, instead of from head