### PR TITLE
Add remote.WithJobs and use it in remote.MultiWrite

### DIFF
--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -34,11 +34,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/v1util"
 )
 
-var defaultPlatform = v1.Platform{
-	Architecture: "amd64",
-	OS:           "linux",
-}
-
 // ErrSchema1 indicates that we received a schema1 manifest from the registry.
 // This library doesn't have plans to support this legacy image format:
 // https://github.com/google/go-containerregistry/issues/377

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -92,6 +92,7 @@ func Write(ref name.Reference, img v1.Image, options ...Option) error {
 			uploaded[h] = true
 		}
 
+		// TODO(#803): Pipe through remote.WithJobs and upload these in parallel.
 		g.Go(func() error {
 			return w.uploadOne(l)
 		})
@@ -501,6 +502,7 @@ func WriteIndex(ref name.Reference, ii v1.ImageIndex, options ...Option) error {
 		context: o.context,
 	}
 
+	// TODO(#803): Pipe through remote.WithJobs and upload these in parallel.
 	for _, desc := range index.Manifests {
 		ref := ref.Context().Digest(desc.Digest.String())
 		exists, err := w.checkExistingManifest(desc.Digest, desc.MediaType)


### PR DESCRIPTION
- default parallel is 4
- an error is returned if WithParallel is called with a value <=0 or >100

We can probably reuse this to fetch and push blobs elsewhere in remote.

MultiWrite'ing 123 distroless images with `WithParallel(100)` took 4s compared to 11s for the default.