### PR TITLE
Fix some weirdness in google.Keychain

### DIFF
--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -53,7 +53,12 @@ func NewEnvAuthenticator() (authn.Authenticator, error) {
 		return nil, err
 	}
 
-	return &tokenSourceAuth{oauth2.ReuseTokenSource(nil, ts)}, nil
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenSourceAuth{oauth2.ReuseTokenSource(token, ts)}, nil
 }
 
 // NewGcloudAuthenticator returns an oauth2.TokenSource that generates access
@@ -96,6 +101,11 @@ func NewTokenAuthenticator(serviceAccountJSON string, scope string) (authn.Authe
 	}
 
 	return &tokenSourceAuth{oauth2.ReuseTokenSource(nil, ts)}, nil
+}
+
+// NewTokenSourceAuthenticator converts an oauth2.TokenSource into an authn.Authenticator.
+func NewTokenSourceAuthenticator(ts oauth2.TokenSource) authn.Authenticator {
+	return &tokenSourceAuth{ts}
 }
 
 // tokenSourceAuth turns an oauth2.TokenSource into an authn.Authenticator.

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -221,27 +220,6 @@ func TestKeychainGCRandAR(t *testing.T) {
 	}
 }
 
-func TestKeychainEnv(t *testing.T) {
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("unexpected err os.Getwd: %v", err)
-	}
-
-	keyFile := filepath.Join(wd, "testdata", "key.json")
-
-	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyFile); err != nil {
-		t.Fatalf("unexpected err os.Setenv: %v", err)
-	}
-
-	// Reset the keychain to ensure we don't cache earlier results.
-	Keychain = &googleKeychain{}
-	if auth, err := Keychain.Resolve(mustRegistry("gcr.io")); err != nil {
-		t.Errorf("expected success, got: %v", err)
-	} else if auth == authn.Anonymous {
-		t.Errorf("expected not anonymous auth, got: %v", auth)
-	}
-}
-
 func TestKeychainError(t *testing.T) {
 	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
 		t.Fatalf("unexpected err os.Setenv: %v", err)
@@ -281,23 +259,5 @@ func TestNewEnvAuthenticatorFailure(t *testing.T) {
 	_, err := NewEnvAuthenticator()
 	if err == nil {
 		t.Errorf("expected err, got nil")
-	}
-}
-
-func TestNewEnvAuthenticatorSuccess(t *testing.T) {
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("unexpected err os.Getwd: %v", err)
-	}
-
-	keyFile := filepath.Join(wd, "testdata", "key.json")
-
-	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyFile); err != nil {
-		t.Fatalf("unexpected err os.Setenv: %v", err)
-	}
-
-	_, err = NewEnvAuthenticator()
-	if err != nil {
-		t.Fatalf("unexpected err NewEnvAuthenticator: %v", err)
 	}
 }


### PR DESCRIPTION
Add a NewTokenSourceAuthenticator function that converts an
oauth2.TokenSource into an authn.Authenticator, for convenience.

Make NewEnvAuthenticator actually pull down a token to make sure we
actually found valid credentials, for use in google.Keychain.

Remove some unit tests that relied on us not doing that.

Fixes https://github.com/google/go-containerregistry/issues/806