### PR TITLE
add：registry ping timeout

### DIFF
--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -66,7 +67,7 @@ func parseChallenge(suffix string) map[string]string {
 }
 
 func ping(reg name.Registry, t http.RoundTripper) (*pingResp, error) {
-	client := http.Client{Transport: t}
+	client := http.Client{Transport: t, Timeout: 2 * time.Second}
 
 	// This first attempts to use "https" for every request, falling back to http
 	// if the registry matches our localhost heuristic or if it is intentionally


### PR DESCRIPTION
I see that registry ping does not have timeout handling. The makeFetcher function clearly has a ctx timeout handling. Why is it not set during ping? I currently set the easiest 3 second timeout.