### PR TITLE
Support MultiWrite for multiple repos

### DIFF
--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -30,6 +31,7 @@ type image struct {
 	base v1.Image
 	adds []Addendum
 
+	lock       sync.Mutex
 	computed   bool
 	configFile *v1.ConfigFile
 	manifest   *v1.Manifest
@@ -48,6 +50,9 @@ func (i *image) MediaType() (types.MediaType, error) {
 }
 
 func (i *image) compute() error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
 	// Don't re-compute if already computed.
 	if i.computed {
 		return nil


### PR DESCRIPTION
This naively segments the input map by destination repository and
processes each repo's uploads separately, in parallel. This could be
improved to increase throughput by maintaining a map of repo to writer,
but this complicates blob uploads which had otherwise lost a reference
to the repo they were being uploaded to.

I think this form is also easier to read and comprehend, and is I think
unlikely to cause serious slowness, especially compared to the status
quo before MultiWrite.

In any case, the method signature remains the same and future
optimizations are possible without changing that.