### PR TITLE
feat(gcrane): add gc pattern and upload date filters

### DIFF
--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -36,6 +36,14 @@ for backing up images, georeplicating images, or renaming images en masse.
 `gcrane gc` will calculate images that can be garbage-collected.
 By default, it will print any images that do not have tags pointing to them.
 
+`gcrane gc` can be extended with `--before <unix timestamp>` and `--pattern <regex>` options to extend its behaviour. Any image that has been uploaded after `timestamp` will **not** be printed. If pattern is not empty, any images that does not have at least one tag matching `<regex>` will be printed. For example
+
+```shell
+gcrane gc gcr.io/${PROJECT_ID}/repo --before 1604793600 --pattern "^(latest|stable)$"
+```
+
+will print any image that has been uploaded before Sun, 08 Nov 2020 **and** that has not been tagged `latest` nor `stable`.
+
 This can be composed with `gcrane delete` to actually garbage collect them:
 ```shell
 gcrane gc gcr.io/${PROJECT_ID}/repo | xargs -n1 gcrane delete

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -36,13 +36,13 @@ for backing up images, georeplicating images, or renaming images en masse.
 `gcrane gc` will calculate images that can be garbage-collected.
 By default, it will print any images that do not have tags pointing to them.
 
-`gcrane gc` can be extended with `--before <unix timestamp>` and `--pattern <regex>` options to extend its behaviour. Any image that has been uploaded after `timestamp` will **not** be printed. If pattern is not empty, any images that does not have at least one tag matching `<regex>` will be printed. For example
+`gcrane gc` can be extended with `--before <duration>` and `--pattern <regex>` options to extend its behaviour. Any image that has been uploaded after `duration` will **not** be printed. If pattern is not empty, any images that does not have at least one tag matching `<regex>` will be printed. For example
 
 ```shell
-gcrane gc gcr.io/${PROJECT_ID}/repo --before 1604793600 --pattern "^(latest|stable)$"
+gcrane gc gcr.io/${PROJECT_ID}/repo --before 24h --pattern "^(latest|stable)$"
 ```
 
-will print any image that has been uploaded before Sun, 08 Nov 2020 **and** that has not been tagged `latest` nor `stable`.
+will print any image that has been **uploaded** (and not created) until yesterday and that has not been tagged `latest` nor `stable`.
 
 This can be composed with `gcrane delete` to actually garbage collect them:
 ```shell

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -36,10 +36,10 @@ for backing up images, georeplicating images, or renaming images en masse.
 `gcrane gc` will calculate images that can be garbage-collected.
 By default, it will print any images that do not have tags pointing to them.
 
-`gcrane gc` can be extended with `--before <duration>` and `--pattern <regex>` options to extend its behaviour. Any image that has been uploaded after `duration` will **not** be printed. If pattern is not empty, any images that does not have at least one tag matching `<regex>` will be printed. For example
+`gcrane gc` can be extended with `--grace <duration>` and `--pattern <regex>` options to extend its behaviour. Any image that has been uploaded after `duration` will **not** be printed. If pattern is not empty, any images that does not have at least one tag matching `<regex>` will be printed. For example
 
 ```shell
-gcrane gc gcr.io/${PROJECT_ID}/repo --before 24h --pattern "^(latest|stable)$"
+gcrane gc gcr.io/${PROJECT_ID}/repo --grace 24h --pattern "^(latest|stable)$"
 ```
 
 will print any image that has been **uploaded** (and not created) until yesterday and that has not been tagged `latest` nor `stable`.

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
@@ -36,11 +35,8 @@ func NewCmdGc() *cobra.Command {
 		Use:   "gc",
 		Short: "List images that are not tagged",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
-			err := gc(args[0], recursive, time.Now().Add(-before), pattern)
-			if err != nil {
-				log.Fatalln(err)
-			}
+		RunE: func(_ *cobra.Command, args []string) error {
+			return gc(args[0], recursive, time.Now().Add(-before), pattern)
 		},
 	}
 

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -29,7 +29,7 @@ import (
 // NewCmdGc creates a new cobra.Command for the gc subcommand.
 func NewCmdGc() *cobra.Command {
 	recursive := false
-	before := int64(-1)
+	before := time.Duration(0)
 	pattern := ""
 
 	cmd := &cobra.Command{
@@ -37,12 +37,12 @@ func NewCmdGc() *cobra.Command {
 		Short: "List images that are not tagged",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			gc(args[0], recursive, time.Unix(before, 0), pattern)
+			gc(args[0], recursive, time.Now().Add(-before), pattern)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Whether to recurse through repos")
-	cmd.Flags().Int64VarP(&before, "before", "b", time.Now().Unix(), "Oldest upload time (unix timestamp)")
+	cmd.Flags().DurationVarP(&before, "before", "b", time.Duration(0), "Age of the oldest uploaded image to print (ns, us, ms, s, m, h)")
 	cmd.Flags().StringVarP(&pattern, "pattern", "p", "", "Will also collect images with no tags matching this pattern")
 
 	return cmd

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -108,6 +108,9 @@ func collector(filters []func(manifest google.ManifestInfo) bool) func(repo name
 				}
 			}
 			if collect {
+				for _, tag := range manifest.Tags {
+					fmt.Printf("%s:%s\n", repo, tag)
+				}
 				fmt.Printf("%s@%s\n", repo, digest)
 			}
 		}

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -42,7 +42,7 @@ func NewCmdGc() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Whether to recurse through repos")
-	cmd.Flags().DurationVarP(&before, "before", "b", time.Duration(0), "Age of the oldest uploaded image to print (ns, us, ms, s, m, h)")
+	cmd.Flags().DurationVarP(&before, "grace", "g", time.Duration(0), "Relative duration in which to ignore references. Only checks the uploaded time. If set, refs newer than the duration will not be print.")
 	cmd.Flags().StringVarP(&pattern, "pattern", "p", "", "Will also collect images with no tags matching this pattern")
 
 	return cmd


### PR DESCRIPTION
This PR add `--before` add `--pattern` to `gcrane gc`.

`--before <timestamp>` will avoid images uploaded after `<timestamp>` being collected.
`--pattern <regex>` if set, will also collect images that have not been tagged with at least one tag matching this pattern.