### PR TITLE
Add ability to override default registry and tag in pkg/name

### DIFF
--- a/pkg/name/options.go
+++ b/pkg/name/options.go
@@ -14,13 +14,29 @@
 
 package name
 
+const (
+	// DefaultRegistry is the registry name that will be used if no registry
+	// provided and the default is not overridden.
+	DefaultRegistry      = "index.docker.io"
+	defaultRegistryAlias = "docker.io"
+
+	// DefaultTag is the tag name that will be used if no tag provided and the
+	// default is not overridden.
+	DefaultTag = "latest"
+)
+
 type options struct {
-	strict   bool // weak by default
-	insecure bool // secure by default
+	strict          bool // weak by default
+	insecure        bool // secure by default
+	defaultRegistry string
+	defaultTag      string
 }
 
 func makeOptions(opts ...Option) options {
-	opt := options{}
+	opt := options{
+		defaultRegistry: DefaultRegistry,
+		defaultTag:      DefaultTag,
+	}
 	for _, o := range opts {
 		o(&opt)
 	}
@@ -46,4 +62,22 @@ func WeakValidation(opts *options) {
 // Insecure is an Option that allows image references to be fetched without TLS.
 func Insecure(opts *options) {
 	opts.insecure = true
+}
+
+// OptionFn is a function that returns an option.
+type OptionFn func() Option
+
+// WithDefaultRegistry sets the default registry that will be used if one is not
+// provided.
+func WithDefaultRegistry(r string) Option {
+	return func(opts *options) {
+		opts.defaultRegistry = r
+	}
+}
+
+// WithDefaultTag sets the default tag that will be used if one is not provided.
+func WithDefaultTag(t string) Option {
+	return func(opts *options) {
+		opts.defaultTag = t
+	}
 }

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -18,6 +18,35 @@ import (
 	"testing"
 )
 
+var (
+	testDefaultRegistry = "registry.upbound.io"
+	testDefaultTag      = "stable"
+	inputDefaultNames   = []string{
+		"crossplane/provider-gcp",
+		"crossplane/provider-gcp:v0.14.0",
+		"ubuntu",
+		"gcr.io/crossplane/provider-gcp:latest",
+	}
+	outputDefaultNames = []string{
+		"registry.upbound.io/crossplane/provider-gcp:stable",
+		"registry.upbound.io/crossplane/provider-gcp:v0.14.0",
+		"registry.upbound.io/ubuntu:stable",
+		"gcr.io/crossplane/provider-gcp:latest",
+	}
+)
+
+func TestParseReferenceDefaulting(t *testing.T) {
+	for i, name := range inputDefaultNames {
+		ref, err := ParseReference(name, WithDefaultRegistry(testDefaultRegistry), WithDefaultTag(testDefaultTag))
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", name, err)
+		}
+		if ref.Name() != outputDefaultNames[i] {
+			t.Errorf("ParseReference(%q); got %v, want %v", name, ref.String(), outputDefaultNames[i])
+		}
+	}
+}
+
 func TestParseReference(t *testing.T) {
 	for _, name := range goodWeakValidationDigestNames {
 		ref, err := ParseReference(name, WeakValidation)

--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -21,12 +21,6 @@ import (
 	"strings"
 )
 
-const (
-	// DefaultRegistry is Docker Hub, assumed when a hostname is omitted.
-	DefaultRegistry      = "index.docker.io"
-	defaultRegistryAlias = "docker.io"
-)
-
 // Detect more complex forms of local references.
 var reLocal = regexp.MustCompile(`.*\.local(?:host)?(?::\d{1,5})?$`)
 
@@ -44,10 +38,7 @@ type Registry struct {
 
 // RegistryStr returns the registry component of the Registry.
 func (r Registry) RegistryStr() string {
-	if r.registry != "" {
-		return r.registry
-	}
-	return DefaultRegistry
+	return r.registry
 }
 
 // Name returns the name from which the Registry was derived.
@@ -124,6 +115,9 @@ func NewRegistry(name string, opts ...Option) (Registry, error) {
 		return Registry{}, err
 	}
 
+	if name == "" {
+		name = opt.defaultRegistry
+	}
 	// Rewrite "docker.io" to "index.docker.io".
 	// See: https://github.com/google/go-containerregistry/issues/68
 	if name == defaultRegistryAlias {

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -108,6 +108,24 @@ func TestDefaultRegistryNames(t *testing.T) {
 	}
 }
 
+func TestOverrideDefaultRegistryNames(t *testing.T) {
+	testRegistries := []string{"docker.io", ""}
+	expectedRegistries := []string{"index.docker.io", "gcr.io"}
+	overrideDefault := "gcr.io"
+
+	for i, testRegistry := range testRegistries {
+		registry, err := NewRegistry(testRegistry, WeakValidation, WithDefaultRegistry(overrideDefault))
+		if err != nil {
+			t.Fatalf("`%s` should be a valid Registry name, got error: %v", testRegistry, err)
+		}
+
+		actualRegistry := registry.RegistryStr()
+		if actualRegistry != expectedRegistries[i] {
+			t.Errorf("RegistryStr() was incorrect for %v. Wanted: `%s` Got: `%s`", registry, expectedRegistries[i], actualRegistry)
+		}
+	}
+}
+
 func TestRegistryComponents(t *testing.T) {
 	t.Parallel()
 	testRegistry := "gcr.io"

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	defaultTag = "latest"
 	// TODO(dekkagaijin): use the docker/distribution regexes for validation.
 	tagChars = "abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	tagDelim = ":"
@@ -47,10 +46,7 @@ func (t Tag) Identifier() string {
 
 // TagStr returns the tag component of the Tag.
 func (t Tag) TagStr() string {
-	if t.tag != "" {
-		return t.tag
-	}
-	return defaultTag
+	return t.tag
 }
 
 // Name returns the name from which the Tag was derived.
@@ -94,6 +90,10 @@ func NewTag(name string, opts ...Option) (Tag, error) {
 		if err := checkTag(tag); err != nil {
 			return Tag{}, err
 		}
+	}
+
+	if tag == "" {
+		tag = opt.defaultTag
 	}
 
 	repo, err := NewRepository(base, opts...)

--- a/pkg/name/tag_test.go
+++ b/pkg/name/tag_test.go
@@ -146,3 +146,17 @@ func TestAllDefaults(t *testing.T) {
 		t.Errorf("Name() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, expectedName, actualName)
 	}
 }
+
+func TestOverrideDefault(t *testing.T) {
+	tagNameStr := "ubuntu"
+	tag, err := NewTag(tagNameStr, WeakValidation, WithDefaultTag("other"))
+	if err != nil {
+		t.Fatalf("`%s` should be a valid Tag name, got error: %v", tagNameStr, err)
+	}
+
+	expectedName := "index.docker.io/library/ubuntu:other"
+	actualName := tag.Name()
+	if actualName != expectedName {
+		t.Errorf("Name() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, expectedName, actualName)
+	}
+}


### PR DESCRIPTION
Adds default registry and default tag options to `pkg/name` such that a user may configure their own defaults. Also move defaulting logic to tag / registry construction rather than methods called on the objects. See individual commits for how this maintains compatibility with existing behavior.

/cc @jonjohnsonjr @ImJasonH 

Fixes #805 