### PR TITLE
interface for standard processor converters

### DIFF
--- a/pkg/v1/layout/index.go
+++ b/pkg/v1/layout/index.go
@@ -32,6 +32,8 @@ type layoutIndex struct {
 	mediaType types.MediaType
 	path      Path
 	rawIndex  []byte
+
+	v1.ResolvableDescriptor
 }
 
 // ImageIndexFromPath is a convenience function which constructs a Path and returns its v1.ImageIndex.

--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -48,6 +48,17 @@ type Descriptor struct {
 	Platform    *Platform         `json:"platform,omitempty"`
 }
 
+// ResolvableDescriptor an item that represents a descriptor that can be resolved
+// into either an Image or an ImageIndex
+type ResolvableDescriptor interface {
+	// Image resolve this Descriptor into an Image, if it is the correct image type.
+	// Returns an error if the underlying manifest does not describe an Image.
+	Image() (Image, error)
+	// ImageIndex resolve this Descriptor into an ImageIndex, if it is the correct image type.
+	// Returns an error if the underlying manifest does not describe an ImageIndex.
+	ImageIndex() (ImageIndex, error)
+}
+
 // ParseManifest parses the io.Reader's contents into a Manifest.
 func ParseManifest(r io.Reader) (*Manifest, error) {
 	m := Manifest{}

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -55,9 +55,11 @@ func (e *ErrSchema1) Error() string {
 
 // Descriptor provides access to metadata about remote artifact and accessors
 // for efficiently converting it into a v1.Image or v1.ImageIndex.
+// Implements v1.ResolvableDescriptor.
 type Descriptor struct {
 	fetcher
 	v1.Descriptor
+	v1.ResolvableDescriptor
 	Manifest []byte
 
 	// So we can share this implementation with Image..


### PR DESCRIPTION
Follow-on from discussion with @jonjohnsonjr [here](https://github.com/google/go-containerregistry/pull/828#issuecomment-728265001). This creates a "thing" in `pkg/v1` that can be resolved to either a `v1.Image` _or_ a `v1.ImageIndex`. 

`pkg/v1/remote/Descriptor` already implements this, so this creates a standard for applying it across other areas.

The name `ResolvableDescriptor` might not be the best. 😁