### PR TITLE
Implement remote.MultiDelete and crane.MultiDelete

### DIFF
--- a/cmd/crane/cmd/delete.go
+++ b/cmd/crane/cmd/delete.go
@@ -25,12 +25,11 @@ import (
 func NewCmdDelete(options *[]crane.Option) *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete IMAGE",
-		Short: "Delete an image reference from its registry",
-		Args:  cobra.ExactArgs(1),
+		Short: "Deletes image references from their registries",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			ref := args[0]
-			if err := crane.Delete(ref, *options...); err != nil {
-				log.Fatalf("deleting %s: %v", ref, err)
+			if err := crane.MultiDelete(args, *options...); err != nil {
+				log.Fatal("deleting: ", err)
 			}
 		},
 	}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -27,7 +27,7 @@ crane [flags]
 * [crane catalog](crane_catalog.md)	 - List the repos in a registry
 * [crane config](crane_config.md)	 - Get the config of an image
 * [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst
-* [crane delete](crane_delete.md)	 - Delete an image reference from its registry
+* [crane delete](crane_delete.md)	 - Deletes image references from their registries
 * [crane digest](crane_digest.md)	 - Get the digest of an image
 * [crane export](crane_export.md)	 - Export contents of a remote image as a tarball
 * [crane ls](crane_ls.md)	 - List the tags in a repo

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -1,10 +1,10 @@
 ## crane delete
 
-Delete an image reference from its registry
+Deletes image references from their registries
 
 ### Synopsis
 
-Delete an image reference from its registry
+Deletes image references from their registries
 
 ```
 crane delete IMAGE [flags]

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -38,7 +38,7 @@ By default, it will print any images that do not have tags pointing to them.
 
 This can be composed with `gcrane delete` to actually garbage collect them:
 ```shell
-gcrane gc gcr.io/${PROJECT_ID}/repo | xargs -n1 gcrane delete
+gcrane gc gcr.io/${PROJECT_ID}/repo | xargs gcrane delete
 ```
 
 ## Images

--- a/pkg/crane/delete.go
+++ b/pkg/crane/delete.go
@@ -23,11 +23,21 @@ import (
 
 // Delete deletes the remote reference at src.
 func Delete(src string, opt ...Option) error {
+	return MultiDelete([]string{src}, opt...)
+}
+
+// MultiDelete deletes the remote references in srcs.
+func MultiDelete(srcs []string, opt ...Option) error {
 	o := makeOptions(opt...)
-	ref, err := name.ParseReference(src, o.name...)
-	if err != nil {
-		return fmt.Errorf("parsing reference %q: %v", src, err)
+
+	var refs []name.Reference
+	for _, src := range srcs {
+		ref, err := name.ParseReference(src, o.name...)
+		if err != nil {
+			return fmt.Errorf("parsing reference %q: %v", src, err)
+		}
+		refs = append(refs, ref)
 	}
 
-	return remote.Delete(ref, o.remote...)
+	return remote.MultiDelete(refs, o.remote...)
 }


### PR DESCRIPTION
This adds support for `crane delete foo:one foo:two foo@sha256:...` and updates `gcrane gc` docs to use the new `crane delete` form without `xargs -n1`.

This is currently limited to deleting refs for the same repo, like `MultiWrite` is currently limited. This should support the `gcrane gc` use case at least.

Fixes #843 