### PR TITLE
Parse WWW-Authenticate challenges on retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.31.6 // indirect
 	github.com/containerd/containerd v1.3.0 // indirect
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
-	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -504,12 +504,11 @@ func TestInsufficientScope(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Logf("%v", r.URL)
 			query := r.URL.Query()
 
 			if scopes := query["scope"]; len(scopes) == 0 {
 				if !passed {
-					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s",scope="%s"`, realm, right))
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=%q,scope=%q", realm, right))
 					w.WriteHeader(http.StatusUnauthorized)
 				}
 			} else if len(scopes) == 1 {
@@ -517,8 +516,6 @@ func TestInsufficientScope(t *testing.T) {
 			} else if len(scopes) == 2 && scopes[1] == right {
 				passed = true
 				w.Write([]byte(`{"token": "arbitrary-token-2"}`))
-			} else {
-				t.Logf("%v", scopes)
 			}
 		}))
 	defer server.Close()
@@ -526,13 +523,13 @@ func TestInsufficientScope(t *testing.T) {
 	basic := &authn.Basic{Username: "foo", Password: "bar"}
 	u, err := url.Parse(server.URL)
 	if err != nil {
-		t.Errorf("Unexpected error during url.Parse: %v", err)
+		t.Error("Unexpected error during url.Parse: ", err)
 	}
 	realm = u.Host
 
 	registry, err := name.NewRegistry(expectedService, name.WeakValidation)
 	if err != nil {
-		t.Errorf("Unexpected error during NewRegistry: %v", err)
+		t.Error("Unexpected error during NewRegistry: ", err)
 	}
 
 	bt := &bearerTransport{
@@ -549,7 +546,7 @@ func TestInsufficientScope(t *testing.T) {
 
 	res, err := client.Get(fmt.Sprintf("http://%s/v2/foo/bar/blobs/blah", u.Host))
 	if err != nil {
-		t.Errorf("Unexpected error during client.Get: %v", err)
+		t.Error("Unexpected error during client.Get: ", err)
 		return
 	}
 	if res.StatusCode != http.StatusOK {
@@ -557,6 +554,6 @@ func TestInsufficientScope(t *testing.T) {
 	}
 
 	if !passed {
-		t.Errorf("didn't refresh insufficient scope")
+		t.Error("didn't refresh insufficient scope")
 	}
 }

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -159,6 +159,7 @@ func TestBearerTransportTokenRefresh(t *testing.T) {
 				w.Write([]byte(fmt.Sprintf(`{"token": %q}`, refreshedToken)))
 			}
 
+			w.Header().Set("WWW-Authenticate", "scope=foo")
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 	defer server.Close()
@@ -238,6 +239,7 @@ func TestBearerTransportOauthRefresh(t *testing.T) {
 				return
 			}
 
+			w.Header().Set("WWW-Authenticate", "scope=foo")
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 	defer server.Close()
@@ -302,6 +304,7 @@ func TestBearerTransportOauth404Fallback(t *testing.T) {
 				return
 			}
 
+			w.Header().Set("WWW-Authenticate", "scope=foo")
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 	defer server.Close()
@@ -489,5 +492,71 @@ func TestCanonicalAddressResolution(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("Wrong canonical host: wanted %v got %v", tt.want, got)
 		}
+	}
+}
+
+func TestInsufficientScope(t *testing.T) {
+	wrong := "the-wrong-scope"
+	right := "the-right-scope"
+	realm := ""
+	expectedService := "my-service.io"
+	passed := false
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Logf("%v", r.URL)
+			query := r.URL.Query()
+
+			if scopes := query["scope"]; len(scopes) == 0 {
+				if !passed {
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s",scope="%s"`, realm, right))
+					w.WriteHeader(http.StatusUnauthorized)
+				}
+			} else if len(scopes) == 1 {
+				w.Write([]byte(`{"token": "arbitrary-token"}`))
+			} else if len(scopes) == 2 && scopes[1] == right {
+				passed = true
+				w.Write([]byte(`{"token": "arbitrary-token-2"}`))
+			} else {
+				t.Logf("%v", scopes)
+			}
+		}))
+	defer server.Close()
+
+	basic := &authn.Basic{Username: "foo", Password: "bar"}
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("Unexpected error during url.Parse: %v", err)
+	}
+	realm = u.Host
+
+	registry, err := name.NewRegistry(expectedService, name.WeakValidation)
+	if err != nil {
+		t.Errorf("Unexpected error during NewRegistry: %v", err)
+	}
+
+	bt := &bearerTransport{
+		inner:    http.DefaultTransport,
+		basic:    basic,
+		registry: registry,
+		realm:    server.URL,
+		scopes:   []string{wrong},
+		service:  expectedService,
+		scheme:   "http",
+	}
+
+	client := http.Client{Transport: bt}
+
+	res, err := client.Get(fmt.Sprintf("http://%s/v2/foo/bar/blobs/blah", u.Host))
+	if err != nil {
+		t.Errorf("Unexpected error during client.Get: %v", err)
+		return
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("client.Get final StatusCode got %v, want: %v", res.StatusCode, http.StatusOK)
+	}
+
+	if !passed {
+		t.Errorf("didn't refresh insufficient scope")
 	}
 }

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -124,7 +124,7 @@ func TestPingBasicChallengeNoParams(t *testing.T) {
 func TestPingBearerChallengeWithParams(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="http://auth.foo.io/token`)
+			w.Header().Set("WWW-Authenticate", `Bearer realm="http://auth.example.com/token"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		}))
 	defer server.Close()
@@ -149,7 +149,7 @@ func TestPingBearerChallengeWithParams(t *testing.T) {
 func TestUnsupportedStatus(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="http://auth.foo.io/token`)
+			w.Header().Set("WWW-Authenticate", `Bearer realm="http://auth.example.com/token`)
 			http.Error(w, "Forbidden", http.StatusForbidden)
 		}))
 	defer server.Close()

--- a/vendor/github.com/docker/distribution/registry/client/auth/challenge/addr.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/challenge/addr.go
@@ -1,0 +1,27 @@
+package challenge
+
+import (
+	"net/url"
+	"strings"
+)
+
+// FROM: https://golang.org/src/net/http/http.go
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
+
+// FROM: http://golang.org/src/net/http/transport.go
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+// FROM: http://golang.org/src/net/http/transport.go
+func canonicalAddr(url *url.URL) string {
+	addr := url.Host
+	if !hasPort(addr) {
+		return addr + ":" + portMap[url.Scheme]
+	}
+	return addr
+}

--- a/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
@@ -1,0 +1,237 @@
+package challenge
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// Challenge carries information from a WWW-Authenticate response header.
+// See RFC 2617.
+type Challenge struct {
+	// Scheme is the auth-scheme according to RFC 2617
+	Scheme string
+
+	// Parameters are the auth-params according to RFC 2617
+	Parameters map[string]string
+}
+
+// Manager manages the challenges for endpoints.
+// The challenges are pulled out of HTTP responses. Only
+// responses which expect challenges should be added to
+// the manager, since a non-unauthorized request will be
+// viewed as not requiring challenges.
+type Manager interface {
+	// GetChallenges returns the challenges for the given
+	// endpoint URL.
+	GetChallenges(endpoint url.URL) ([]Challenge, error)
+
+	// AddResponse adds the response to the challenge
+	// manager. The challenges will be parsed out of
+	// the WWW-Authenicate headers and added to the
+	// URL which was produced the response. If the
+	// response was authorized, any challenges for the
+	// endpoint will be cleared.
+	AddResponse(resp *http.Response) error
+}
+
+// NewSimpleManager returns an instance of
+// Manger which only maps endpoints to challenges
+// based on the responses which have been added the
+// manager. The simple manager will make no attempt to
+// perform requests on the endpoints or cache the responses
+// to a backend.
+func NewSimpleManager() Manager {
+	return &simpleManager{
+		Challenges: make(map[string][]Challenge),
+	}
+}
+
+type simpleManager struct {
+	sync.RWMutex
+	Challenges map[string][]Challenge
+}
+
+func normalizeURL(endpoint *url.URL) {
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	endpoint.Host = canonicalAddr(endpoint)
+}
+
+func (m *simpleManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
+	normalizeURL(&endpoint)
+
+	m.RLock()
+	defer m.RUnlock()
+	challenges := m.Challenges[endpoint.String()]
+	return challenges, nil
+}
+
+func (m *simpleManager) AddResponse(resp *http.Response) error {
+	challenges := ResponseChallenges(resp)
+	if resp.Request == nil {
+		return fmt.Errorf("missing request reference")
+	}
+	urlCopy := url.URL{
+		Path:   resp.Request.URL.Path,
+		Host:   resp.Request.URL.Host,
+		Scheme: resp.Request.URL.Scheme,
+	}
+	normalizeURL(&urlCopy)
+
+	m.Lock()
+	defer m.Unlock()
+	m.Challenges[urlCopy.String()] = challenges
+	return nil
+}
+
+// Octet types from RFC 2616.
+type octetType byte
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+// ResponseChallenges returns a list of authorization challenges
+// for the given http Response. Challenges are only checked if
+// the response status code was a 401.
+func ResponseChallenges(resp *http.Response) []Challenge {
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Parse the WWW-Authenticate Header and store the challenges
+		// on this endpoint object.
+		return parseAuthHeader(resp.Header)
+	}
+
+	return nil
+}
+
+func parseAuthHeader(header http.Header) []Challenge {
+	challenges := []Challenge{}
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		if v != "" {
+			challenges = append(challenges, Challenge{Scheme: v, Parameters: p})
+		}
+	}
+	return challenges
+}
+
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	s = "," + skipSpace(s)
+	for strings.HasPrefix(s, ",") {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s[1:]))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,6 +85,7 @@ github.com/docker/cli/cli/config/types
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
+github.com/docker/distribution/registry/client/auth/challenge
 # github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
 ## explicit
 github.com/docker/docker/api


### PR DESCRIPTION
This allows us to recover from insufficient scope errors.

This PR introduces a dependency on `github.com/docker/distribution/registry/client/auth/challenge`. We already had an indirect dependency on it through the daemon package, so maybe not a huge deal?