### PR TITLE
Thunk-ify layout options

### DIFF
--- a/pkg/v1/layout/options.go
+++ b/pkg/v1/layout/options.go
@@ -3,40 +3,55 @@ package layout
 import v1 "github.com/google/go-containerregistry/pkg/v1"
 
 // Option is a functional option for Layout.
-//
-// TODO: We'll need to change this signature to support Sparse/Thin images.
-// Or, alternatively, wrap it in a sparse.Image that returns an empty list for layers?
-type Option func(*v1.Descriptor) error
+type Option func(*options)
+
+type options struct {
+	descOpts []descriptorOption
+}
+
+func makeOptions(opts ...Option) *options {
+	o := &options{
+		descOpts: []descriptorOption{},
+	}
+	for _, apply := range opts {
+		apply(o)
+	}
+	return o
+}
+
+type descriptorOption func(*v1.Descriptor)
 
 // WithAnnotations adds annotations to the artifact descriptor.
 func WithAnnotations(annotations map[string]string) Option {
-	return func(desc *v1.Descriptor) error {
-		if desc.Annotations == nil {
-			desc.Annotations = make(map[string]string)
-		}
-		for k, v := range annotations {
-			desc.Annotations[k] = v
-		}
-
-		return nil
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			if desc.Annotations == nil {
+				desc.Annotations = make(map[string]string)
+			}
+			for k, v := range annotations {
+				desc.Annotations[k] = v
+			}
+		})
 	}
 }
 
 // WithURLs adds urls to the artifact descriptor.
 func WithURLs(urls []string) Option {
-	return func(desc *v1.Descriptor) error {
-		if desc.URLs == nil {
-			desc.URLs = []string{}
-		}
-		desc.URLs = append(desc.URLs, urls...)
-		return nil
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			if desc.URLs == nil {
+				desc.URLs = []string{}
+			}
+			desc.URLs = append(desc.URLs, urls...)
+		})
 	}
 }
 
 // WithPlatform sets the platform of the artifact descriptor.
 func WithPlatform(platform v1.Platform) Option {
-	return func(desc *v1.Descriptor) error {
-		desc.Platform = &platform
-		return nil
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			desc.Platform = &platform
+		})
 	}
 }

--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -59,10 +59,9 @@ func (l Path) AppendImage(img v1.Image, options ...Option) error {
 		Digest:    d,
 	}
 
-	for _, opt := range options {
-		if err := opt(&desc); err != nil {
-			return err
-		}
+	o := makeOptions(options...)
+	for _, opt := range o.descOpts {
+		opt(&desc)
 	}
 
 	return l.AppendDescriptor(desc)
@@ -96,10 +95,9 @@ func (l Path) AppendIndex(ii v1.ImageIndex, options ...Option) error {
 		Digest:    d,
 	}
 
-	for _, opt := range options {
-		if err := opt(&desc); err != nil {
-			return err
-		}
+	o := makeOptions(options...)
+	for _, opt := range o.descOpts {
+		opt(&desc)
 	}
 
 	return l.AppendDescriptor(desc)


### PR DESCRIPTION
If we want to add anything other than descriptor mutators as options, we
need a place to do that, so this introduces an options struct that holds
options and thunk-ifies the existing descriptor mutators.