### PR TITLE
add to layout replacedescriptor and removedescriptor

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/internal/gzip"
+	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -89,6 +90,14 @@ func AppendManifests(base v1.ImageIndex, adds ...IndexAddendum) v1.ImageIndex {
 	return &index{
 		base: base,
 		adds: adds,
+	}
+}
+
+// RemoveManifests removes any descriptors that match the match.Matcher.
+func RemoveManifests(base v1.ImageIndex, matcher match.Matcher) v1.ImageIndex {
+	return &index{
+		base:   base,
+		remove: matcher,
 	}
 }
 


### PR DESCRIPTION
Fixes #842 

adds the following to `v1/layout`:

* `RemoveDescriptors(matcher match.Matcher)` - removes from `index.json` any descriptors that match 
* `ReplaceDescriptor(desc v1.Descriptor, matcher match.Matcher)` - equivalent of `RemoveDescriptors(matcher)` followed by `AppendDescriptor(desc)`
* `ReplaceImage(image v1.Image, matcher match.Matcher)` - equivalent of `RemoveDescriptors(matcher)` followed by `AppendImage(image)`
* `ReplaceIndex(index v1.ImageIndex, matcher match.Matcher)` - equivalent of `RemoveDescriptors(matcher)` followed by `AppendIndex(index)`

None of these does garbage collection in the blobs dir, which is a completely separate topic, and should be handled under separate cover.
