### PR TITLE
Set transport.Version via ldflags for release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
   - -trimpath
   ldflags:
   - "-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}"
+  - "-s -w -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}"
   goarch:
     - amd64
     - arm
@@ -38,6 +39,7 @@ builds:
   - -trimpath
   ldflags:
   - "-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}"
+  - "-s -w -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}"
   goarch:
     - amd64
     - arm

--- a/pkg/v1/remote/transport/useragent.go
+++ b/pkg/v1/remote/transport/useragent.go
@@ -20,12 +20,18 @@ import (
 	"runtime/debug"
 )
 
+var (
+	// Version can be set via:
+	// -ldflags="-X 'github.com/google/go-containerregistry/pkg/v1/remote/transport.Version=$TAG'"
+	Version string
+
+	ggcrVersion = defaultUserAgent
+)
+
 const (
 	defaultUserAgent = "go-containerregistry"
 	moduleName       = "github.com/google/go-containerregistry"
 )
-
-var ggcrVersion = defaultUserAgent
 
 type userAgentTransport struct {
 	inner http.RoundTripper
@@ -39,6 +45,11 @@ func init() {
 }
 
 func version() string {
+	if Version != "" {
+		// Version was set via ldflags, just return it.
+		return Version
+	}
+
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return ""


### PR DESCRIPTION
For most things consuming this package, they will depend on an actual
released version of go-containerregistry. When we release
go-containerregistry itself, the binaries are built at the same version
as the library, which means that they don't depend on an actual released
version of go-containerregistry, so the version in debug info is just
"(devel)". For our own release, we will just set it to the tag.

<hr>

Tested via:

```
$ goreleaser --snapshot --skip-publish --rm-dist && ./dist/crane_linux_amd64/crane ls -v ubuntu 2>&1 | grep -i agent
User-Agent: crane/v0.2.1-next go-containerregistry/v0.2.1-next
User-Agent: crane/v0.2.1-next go-containerregistry/v0.2.1-next
User-Agent: crane/v0.2.1-next go-containerregistry/v0.2.1-next
```


Before:

```
$ goreleaser --snapshot --skip-publish --rm-dist && ./dist/crane_linux_amd64/crane ls -v ubuntu 2>&1 | grep -i agent
User-Agent: crane/v0.2.1-next go-containerregistry/(devel)
User-Agent: crane/v0.2.1-next go-containerregistry/(devel)
User-Agent: crane/v0.2.1-next go-containerregistry/(devel)
```

The _real_ test will be looking at the UA of a downstream module to make sure the buildinfo stuff works.