### PR TITLE
Fix misleading Authorization: <redacted>

### DIFF
--- a/pkg/v1/remote/transport/logger.go
+++ b/pkg/v1/remote/transport/logger.go
@@ -47,7 +47,7 @@ func (t *logTransport) RoundTrip(in *http.Request) (out *http.Response, err erro
 
 	// Save these headers so we can redact Authorization.
 	savedHeaders := in.Header.Clone()
-	if in.Header != nil {
+	if in.Header != nil && in.Header.Get("authorization") != "" {
 		in.Header.Set("authorization", "<redacted>")
 	}
 


### PR DESCRIPTION
This is currently always set, but we should only set it if there are
actually credentials being redacted, so that we can tell if the header
was set or not.

Noticed this in https://github.com/google/go-containerregistry/issues/861