### PR TITLE
Refactor to support caching compression.

### DIFF
--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -103,7 +103,16 @@ func LayerFromFile(path string, opts ...LayerOption) (v1.Layer, error) {
 	return LayerFromOpener(opener, opts...)
 }
 
-// LayerFromOpener returns a v1.Layer given an Opener function
+// LayerFromOpener returns a v1.Layer given an Opener function.
+// The Opener may return either an uncompressed tarball (common),
+// or a compressed tarball (uncommon).
+//
+// When using this in conjunction with something like remote.Write
+// the uncompressed path may end up gzipping things multiple times:
+//  1. Compute the layer SHA256
+//  2. Upload the compressed layer.
+// Since gzip can be expensive, we support an option to memoize the
+// compression that can be passed here: tarball.WithCompressedCaching
 func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 	rc, err := opener()
 	if err != nil {

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -63,14 +63,17 @@ func (l *layer) MediaType() (types.MediaType, error) {
 // LayerOption applies options to layer
 type LayerOption func(*layer)
 
-// WithCompressionLevel sets the gzip compression. See `gzip.NewWriterLevel` for possible values.
+// WithCompressionLevel is a functional option for overriding the default
+// compression level used for compressing uncompressed tarballs.
 func WithCompressionLevel(level int) LayerOption {
 	return func(l *layer) {
 		l.compression = level
 	}
 }
 
-// WithCompressedCaching ensures that we only compress the tarball once.
+// WithCompressedCaching is a functional option that overrides the
+// logic for accessing the compressed bytes to memoize the result
+// and avoid expensive repeated gzips.
 func WithCompressedCaching(l *layer) {
 	var once sync.Once
 	var err error

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -135,20 +135,20 @@ func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 	if compressed {
 		layer.compressedopener = opener
 		layer.uncompressedopener = func() (io.ReadCloser, error) {
-			rc, err := opener()
+			urc, err := opener()
 			if err != nil {
 				return nil, err
 			}
-			return v1util.GunzipReadCloser(rc)
+			return v1util.GunzipReadCloser(urc)
 		}
 	} else {
 		layer.uncompressedopener = opener
 		layer.compressedopener = func() (io.ReadCloser, error) {
-			rc, err := opener()
+			crc, err := opener()
 			if err != nil {
 				return nil, err
 			}
-			return v1util.GzipReadCloserLevel(rc, layer.compression), nil
+			return v1util.GzipReadCloserLevel(crc, layer.compression), nil
 		}
 	}
 

--- a/pkg/v1/tarball/layer_test.go
+++ b/pkg/v1/tarball/layer_test.go
@@ -92,7 +92,7 @@ func TestLayerFromOpenerReader(t *testing.T) {
 	}
 	tarLayer, err := LayerFromOpener(ucOpener, WithCompressedCaching)
 	if err != nil {
-		t.Fatalf("Unable to create layer from tar file: %v", err)
+		t.Fatal("Unable to create layer from tar file:", err)
 	}
 	for i := 0; i < 10; i++ {
 		tarLayer.Compressed()
@@ -104,7 +104,7 @@ func TestLayerFromOpenerReader(t *testing.T) {
 
 	tarLayer, err = LayerFromOpener(ucOpener)
 	if err != nil {
-		t.Fatalf("Unable to create layer from tar file: %v", err)
+		t.Fatal("Unable to create layer from tar file:", err)
 	}
 	for i := 0; i < 10; i++ {
 		tarLayer.Compressed()

--- a/pkg/v1/tarball/layer_test.go
+++ b/pkg/v1/tarball/layer_test.go
@@ -85,12 +85,37 @@ func TestLayerFromOpenerReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to read tar file: %v", err)
 	}
+	count := 0
 	ucOpener := func() (io.ReadCloser, error) {
+		count++
 		return ioutil.NopCloser(bytes.NewReader(ucBytes)), nil
 	}
-	tarLayer, err := LayerFromOpener(ucOpener)
+	tarLayer, err := LayerFromOpener(ucOpener, WithCompressedCaching)
 	if err != nil {
 		t.Fatalf("Unable to create layer from tar file: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		tarLayer.Compressed()
+	}
+
+	// Store the count and reset the counter.
+	cachedCount := count
+	count = 0
+
+	tarLayer, err = LayerFromOpener(ucOpener)
+	if err != nil {
+		t.Fatalf("Unable to create layer from tar file: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		tarLayer.Compressed()
+	}
+
+	// We expect three calls: gzip sniff, diffid computation, cached compression
+	if cachedCount != 3 {
+		t.Errorf("cached count = %d, wanted %d", cachedCount, 3)
+	}
+	if cachedCount+10 != count {
+		t.Errorf("count = %d, wanted %d", count, cachedCount+10)
 	}
 
 	gzBytes, err := ioutil.ReadFile("gzip_content.tgz")

--- a/pkg/v1/v1util/zip.go
+++ b/pkg/v1/v1util/zip.go
@@ -70,9 +70,11 @@ func GunzipReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
 	return &readAndCloser{
 		Reader: gr,
 		CloseFunc: func() error {
-			if err := gr.Close(); err != nil {
-				return err
-			}
+			// If the unzip fails, then this seems to return the same
+			// error as the read.  We don't want this to interfere with
+			// us closing the main ReadCloser, since this could leave
+			// an open file descriptor (fails on Windows).
+			gr.Close()
 			return r.Close()
 		},
 	}, nil


### PR DESCRIPTION
Today `tarball.LayerFromOpener` must either compress or decompress its input based on which it receives.

Virtually all clients of this interface have an uncompressed tarball they want to turn into a layer, but the API we have presents two fun problems.
1. If we simply present the uncompressed tarball (as most clients do) then we will often end up compressing the layer (expensive!) twice.  The first time is to compute the layer's digest, and the second is typically to publish the layer as part of `remote.Write`.
2. If we present a precompressed tarball (as ko does), then we will have an extra decompression (less expensive, but still redundant) to compute the diff id.

This refactors the layer to store an opener for each form of the layer.  The constructor sniffs whether the layer is compressed and based on this makes the "other" opener (that requires conversion) a lazy thunk that performs the conversion each time (this is effectively what we were doing before based on the stored `compressed` bit).  The advantage of this approach is that by setting them up before option evaluation we can make them memoizing on their first invocation.  Given that most consumers of this library only pass the uncompressed form (or should), I have only provided an option for memoizing the compression.