### PR TITLE
Fix `crane append` for named pipes

### DIFF
--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -36,7 +36,5 @@ func Push(img v1.Image, dst string, opt ...Option) error {
 	if err != nil {
 		return fmt.Errorf("parsing tag %q: %v", dst, err)
 	}
-	return remote.MultiWrite(map[name.Reference]remote.Taggable{
-		tag: img,
-	}, o.remote...)
+	return remote.Write(tag, img, o.remote...)
 }

--- a/pkg/v1/stream/layer.go
+++ b/pkg/v1/stream/layer.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"os"
 	"sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -216,7 +217,9 @@ func newMultiCloser(c ...io.Closer) multiCloser { return multiCloser(c) }
 
 func (m multiCloser) Close() error {
 	for _, c := range m {
-		if err := c.Close(); err != nil {
+		// NOTE: net/http will call close on success, so if we've already
+		// closed the inner rc, it's not an error.
+		if err := c.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #707 as well

It's annoying that `crane append` is hard to use with one-liners, which
is the secret goal of most crane commands. We now stat the layer files
and use a streaming layer for anything that's not a regular file, which
includes named pipes, which fail if we try to open them multiple times.

Now you can do this:

```
$ crane append -f <(tar -c some-dir/ -f -) -t $IMAGE
```