### PR TITLE
Use gcrane.Keychain for not only crane-inherit commands but also gcrane-specific commands.

### DIFF
--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/spf13/cobra"
@@ -47,7 +47,7 @@ func gc(root string, recursive bool) {
 		log.Fatalln(err)
 	}
 
-	auth := google.WithAuthFromKeychain(authn.DefaultKeychain)
+	auth := google.WithAuthFromKeychain(gcrane.Keychain)
 
 	if recursive {
 		if err := google.Walk(repo, printUntaggedImages, auth); err != nil {

--- a/cmd/gcrane/cmd/list.go
+++ b/cmd/gcrane/cmd/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/spf13/cobra"
@@ -50,13 +51,13 @@ func ls(root string, recursive, j bool) {
 	}
 
 	if recursive {
-		if err := google.Walk(repo, printImages(j), google.WithAuthFromKeychain(google.Keychain)); err != nil {
+		if err := google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain)); err != nil {
 			log.Fatalln(err)
 		}
 		return
 	}
 
-	tags, err := google.List(repo, google.WithAuthFromKeychain(google.Keychain))
+	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain))
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
https://github.com/google/go-containerregistry/pull/845 introduces `gcrane.Keychain`.

This PR uses `gcrane.Keychain` for not only crane-inherit commands(ex. pull) but also gcrane-specific commands(gc/ls).