### PR TITLE
Fix some login issues

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -77,7 +77,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 	commands := []*cobra.Command{
 		NewCmdAppend(&options),
 		NewCmdBlob(&options),
-		NewCmdAuth(),
+		NewCmdAuth("crane", "auth"),
 		NewCmdCatalog(&options),
 		NewCmdConfig(&options),
 		NewCmdCopy(&options),

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -41,7 +41,7 @@ func main() {
 	root := cmd.New(use, short, []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)})
 
 	// Add or override commands.
-	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy()}
+	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy(), cmd.NewCmdAuth("gcrane", "auth")}
 
 	// Maintain a map of google-specific commands that we "override".
 	used := make(map[string]bool)


### PR DESCRIPTION
NewCmdAuthLogin now requires you to pass in your usage string, so that it is
no longer hard-coded to "crane auth".

Also log the config file that we used.