### PR TITLE
Include target resource in credential warning

### DIFF
--- a/pkg/v1/google/options.go
+++ b/pkg/v1/google/options.go
@@ -49,7 +49,7 @@ func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
 			return err
 		}
 		if auth == authn.Anonymous {
-			logs.Warn.Println("No matching credentials were found, falling back on anonymous")
+			logs.Warn.Printf("No matching credentials were found for %q, falling back on anonymous", l.repo.Registry)
 		}
 		l.auth = auth
 		return nil

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -66,7 +66,7 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 			return nil, err
 		}
 		if auth == authn.Anonymous {
-			logs.Warn.Println("No matching credentials were found, falling back on anonymous")
+			logs.Warn.Printf("No matching credentials were found for %q, falling back on anonymous", target)
 		}
 		o.auth = auth
 	}


### PR DESCRIPTION
This should be slightly less confusing the first time you see it, we can look at removing this entirely by skipping ping and only falling back on 401, but that might take a while to implement.