### PR TITLE
Peek at gzip header bytes

### DIFF
--- a/pkg/v1/internal/gzip/zip_test.go
+++ b/pkg/v1/internal/gzip/zip_test.go
@@ -55,7 +55,16 @@ func TestIs(t *testing.T) {
 	}
 	for _, test := range tests {
 		reader := bytes.NewReader(test.in)
-		got, _, err := Is(reader)
+		got, buf, err := Is(reader)
+		if got != test.out {
+			t.Errorf("Is; n: got %v, wanted %v\n", got, test.out)
+		}
+		if err != test.err {
+			t.Errorf("Is; err: got %v, wanted %v\n", err, test.err)
+		}
+
+		// Test reuse of the buffer should just get returned.
+		got, _, err = Is(buf)
 		if got != test.out {
 			t.Errorf("Is; n: got %v, wanted %v\n", got, test.out)
 		}

--- a/pkg/v1/internal/gzip/zip_test.go
+++ b/pkg/v1/internal/gzip/zip_test.go
@@ -55,7 +55,7 @@ func TestIs(t *testing.T) {
 	}
 	for _, test := range tests {
 		reader := bytes.NewReader(test.in)
-		got, err := Is(reader)
+		got, _, err := Is(reader)
 		if got != test.out {
 			t.Errorf("Is; n: got %v, wanted %v\n", got, test.out)
 		}
@@ -77,7 +77,7 @@ func (f failReader) Read(_ []byte) (int, error) {
 
 func TestReadErrors(t *testing.T) {
 	fr := failReader{}
-	if _, err := Is(fr); err != errRead {
+	if _, _, err := Is(fr); err != errRead {
 		t.Error("Is: expected errRead, got", err)
 	}
 

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -148,7 +148,10 @@ func (i *image) areLayersCompressed() (bool, error) {
 		return false, err
 	}
 	defer blob.Close()
-	return gzip.Is(blob)
+
+	// TODO: Can we reuse this reader?
+	ok, _, err := gzip.Is(blob)
+	return ok, err
 }
 
 func (i *image) loadTarDescriptorAndConfig() error {

--- a/pkg/v1/tarball/layer_test.go
+++ b/pkg/v1/tarball/layer_test.go
@@ -200,9 +200,10 @@ func TestLayerFromOpenerReader(t *testing.T) {
 		tarLayer.Compressed()
 	}
 
-	// We expect three calls: gzip sniff, diffid computation, cached compression
-	if cachedCount != 3 {
-		t.Errorf("cached count = %d, wanted %d", cachedCount, 3)
+	// We expect two calls: diffid computation and cached compression, because the
+	// gzip sniff uses reopener() to avoid paying for open() just to read two bytes.
+	if cachedCount != 2 {
+		t.Errorf("cached count = %d, wanted %d", cachedCount, 2)
 	}
 	if cachedCount+10 != count {
 		t.Errorf("count = %d, wanted %d", count, cachedCount+10)


### PR DESCRIPTION
First commit doesn't take advantage of the new interface yet, but this allows
us to avoid consuming a ReadCloser just to get the first two bytes.

Second commit uses this for tarball.Layer.

Doing this in tarball.Image will require some more work.