### PR TITLE
fail computing manifest if no refs are provided

### DIFF
--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -222,6 +222,10 @@ func writeImagesToTar(refToImage map[name.Reference]v1.Image, m []byte, size int
 func calculateManifest(refToImage map[name.Reference]v1.Image) (m Manifest, err error) {
 	imageToTags := dedupRefToImage(refToImage)
 
+	if len(imageToTags) == 0 {
+		return nil, errors.New("at least one reference must be provided to calculate a manifest")
+	}
+
 	for img, tags := range imageToTags {
 		cfgName, err := img.ConfigName()
 		if err != nil {

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -223,7 +223,7 @@ func calculateManifest(refToImage map[name.Reference]v1.Image) (m Manifest, err 
 	imageToTags := dedupRefToImage(refToImage)
 
 	if len(imageToTags) == 0 {
-		return nil, errors.New("at least one reference must be provided to calculate a manifest")
+		return nil, errors.New("set of images is empty")
 	}
 
 	for img, tags := range imageToTags {

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -463,12 +463,12 @@ func TestComputeManifest(t *testing.T) {
 
 func TestComputeManifest_FailsOnNoRefs(t *testing.T) {
 	_, err := tarball.ComputeManifest(nil)
-	if err == nil || !strings.Contains(err.Error(), "at least one reference must be provided to calculate a manifest") {
+	if err == nil || !strings.Contains(err.Error(), "set of images is empty") {
 		t.Error("expected calculateManifest to fail with nil input")
 	}
 
 	_, err = tarball.ComputeManifest(map[name.Reference]v1.Image{})
-	if err == nil || !strings.Contains(err.Error(), "at least one reference must be provided to calculate a manifest") {
+	if err == nil || !strings.Contains(err.Error(), "set of images is empty") {
 		t.Error("expected calculateManifest to fail with empty input")
 	}
 }

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -461,6 +461,18 @@ func TestComputeManifest(t *testing.T) {
 	}
 }
 
+func TestComputeManifest_FailsOnNoRefs(t *testing.T) {
+	_, err := tarball.ComputeManifest(nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one reference must be provided to calculate a manifest") {
+		t.Error("expected calculateManifest to fail with nil input")
+	}
+
+	_, err = tarball.ComputeManifest(map[name.Reference]v1.Image{})
+	if err == nil || !strings.Contains(err.Error(), "at least one reference must be provided to calculate a manifest") {
+		t.Error("expected calculateManifest to fail with empty input")
+	}
+}
+
 func getLayersHashes(img v1.Image) ([]string, error) {
 	hashes := []string{}
 	layers, err := img.Layers()


### PR DESCRIPTION
This PR just adds some validation to ensure we're not producing invalid manifests. `null` might be a valid digest but I can't imagine any user intentionally producing an image with a `null` manifest (Docker can't import that or do anything useful with it).


I found a weird quirk in [kaniko](https://github.com/GoogleContainerTools/kaniko) where they were passing no refs into `WriteToFile`. Unfortunately, this produced a `nil` manifest, which json-encoded to `null` (valid json!), so I ended up with a tarball with only a `manifest.json` with the contents `null`.

Of course, ECR and Docker were happy to accept this tarball and just... silently do nothing with it.

I opened a [PR](https://github.com/moby/moby/pull/41842) to fix docker loads with a `null` manifest. I'll also open a PR to kaniko to reject no destinations.