### PR TITLE
Make gcrane ls --json output consistent

### DIFF
--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -105,14 +105,12 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 	return &tags, nil
 }
 
-// Uploaded uses json.Number to work around GCR returning timeUploaded
-// as a string, while AR returns the same field as int64.
 type rawManifestInfo struct {
-	Size      string      `json:"imageSizeBytes"`
-	MediaType string      `json:"mediaType"`
-	Created   string      `json:"timeCreatedMs"`
-	Uploaded  json.Number `json:"timeUploadedMs"`
-	Tags      []string    `json:"tag"`
+	Size      string   `json:"imageSizeBytes"`
+	MediaType string   `json:"mediaType"`
+	Created   string   `json:"timeCreatedMs"`
+	Uploaded  string   `json:"timeUploadedMs"`
+	Tags      []string `json:"tag"`
 }
 
 // ManifestInfo is a Manifests entry is the output of List and Walk.
@@ -140,7 +138,7 @@ func (m ManifestInfo) MarshalJSON() ([]byte, error) {
 		Size:      strconv.FormatUint(m.Size, 10),
 		MediaType: m.MediaType,
 		Created:   toUnixMs(m.Created),
-		Uploaded:  json.Number(toUnixMs(m.Uploaded)),
+		Uploaded:  toUnixMs(m.Uploaded),
 		Tags:      m.Tags,
 	})
 }

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -67,64 +67,6 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
-// GCR returns timeUploaded as string
-func TestTimeUploadedMsAsString(t *testing.T) {
-	data := []byte(`
-		{
-			"imageSizeBytes": "100",
-			"mediaType": "hi",
-	  		"tag": ["latest"],
-	  		"timeCreatedMs": "12345678",
-	  		"timeUploadedMs": "23456789"
-		}
-	`)
-
-	raw := rawManifestInfo{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatal(err)
-	}
-
-	expectedRaw := rawManifestInfo{
-		Size:      "100",
-		MediaType: "hi",
-		Created:   "12345678",
-		Uploaded:  "23456789",
-		Tags:      []string{"latest"},
-	}
-
-	if diff := cmp.Diff(expectedRaw, raw); diff != "" {
-		t.Errorf("Can't unmarshal rawManifestInfo with string timeUploadedMs: (-want +got) = %s", diff)
-	}
-}
-
-// AR returns timeUploaded as int64, and timeCreatedMs is missing
-func TestTimeUploadedMsAsInt64(t *testing.T) {
-	data := []byte(`
-		{
-			"imageSizeBytes": "100",
-			"mediaType": "hi",
-	  		"tag": ["latest"],
-	  		"timeUploadedMs": 23456789
-		}
-	`)
-
-	raw := rawManifestInfo{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatal(err)
-	}
-
-	expectedRaw := rawManifestInfo{
-		Size:      "100",
-		MediaType: "hi",
-		Uploaded:  "23456789",
-		Tags:      []string{"latest"},
-	}
-
-	if diff := cmp.Diff(expectedRaw, raw); diff != "" {
-		t.Errorf("Can't unmarshal rawManifestInfo with int64 timeUploadedMs: (-want +got) = %s", diff)
-	}
-}
-
 func TestList(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
This json.Number thing was added when AR was returning the wrong thing,
now they are consistent, so we should be too.

This partially reverts https://github.com/google/go-containerregistry/pull/667 now that it's no longer needed.