### PR TITLE
Fix crane digest for v1 and platform option

### DIFF
--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -25,6 +25,8 @@ func Digest(ref string, opt ...Option) (string, error) {
 		if !desc.MediaType.IsIndex() {
 			return desc.Digest.String(), nil
 		}
+
+		// TODO: does not work for indexes which contain schema v1 manifests
 		img, err := desc.Image()
 		if err != nil {
 			return "", err

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -19,6 +19,9 @@ func Digest(ref string, opt ...Option) (string, error) {
 	o := makeOptions(opt...)
 	if o.platform != nil {
 		desc, err := getManifest(ref, opt...)
+		if !desc.MediaType.IsIndex() {
+			return desc.Digest.String(), nil
+		}
 		if err != nil {
 			return "", err
 		}

--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -19,11 +19,11 @@ func Digest(ref string, opt ...Option) (string, error) {
 	o := makeOptions(opt...)
 	if o.platform != nil {
 		desc, err := getManifest(ref, opt...)
-		if !desc.MediaType.IsIndex() {
-			return desc.Digest.String(), nil
-		}
 		if err != nil {
 			return "", err
+		}
+		if !desc.MediaType.IsIndex() {
+			return desc.Digest.String(), nil
 		}
 		img, err := desc.Image()
 		if err != nil {


### PR DESCRIPTION
This allows to use crane.Digest on images with a v1 schema.

Fixes #906 