### PR TITLE
doc: add homebrew install

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -15,6 +15,14 @@ Install manually:
 GO111MODULE=on go get -u github.com/google/go-containerregistry/cmd/crane
 ```
 
+### Install via brew
+
+If you're macOS user and using [Homebrew](https://brew.sh/), you can install via brew command:
+
+```sh
+$ brew install crane
+```
+
 ## Images
 
 You can also use crane as docker image


### PR DESCRIPTION
relates to #914

```
$ brew install crane
Updating Homebrew...
==> Downloading https://homebrew.bintray.com/bottles/crane-0.4.0.mojave.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/cc13961cd45cac3656448c7a3598a9805911ee6e76f5552aa26b3a14c55f57ba?response
######################################################################## 100.0%
==> Pouring crane-0.4.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/crane/0.4.0: 5 files, 8.8MB
```