### PR TITLE
Buffer the output of gzip.Writer to avoid stalling

### DIFF
--- a/pkg/v1/stream/layer.go
+++ b/pkg/v1/stream/layer.go
@@ -15,6 +15,7 @@
 package stream
 
 import (
+	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -130,6 +131,7 @@ type compressedReader struct {
 
 	h, zh hash.Hash // collects digests of compressed and uncompressed stream.
 	pr    io.Reader
+	bw    *bufio.Writer
 	count *countWriter
 
 	l *Layer // stream.Layer to update upon Close.
@@ -144,7 +146,14 @@ func newCompressedReader(l *Layer) (*compressedReader, error) {
 	// capture compressed digest, and a countWriter to capture compressed
 	// size.
 	pr, pw := io.Pipe()
-	zw, err := gzip.NewWriterLevel(io.MultiWriter(pw, zh, count), l.compression)
+
+	// Write compressed bytes to be read by the pipe.Reader, hashed by zh, and counted by count.
+	mw := io.MultiWriter(pw, zh, count)
+
+	// Buffer the output of the gzip writer so we don't have to wait on pr to keep writing.
+	// 64K ought to be small enough for anybody.
+	bw := bufio.NewWriterSize(mw, 2<<16)
+	zw, err := gzip.NewWriterLevel(bw, l.compression)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +161,7 @@ func newCompressedReader(l *Layer) (*compressedReader, error) {
 	cr := &compressedReader{
 		closer: newMultiCloser(zw, l.blob),
 		pr:     pr,
+		bw:     bw,
 		h:      h,
 		zh:     zh,
 		count:  count,
@@ -180,6 +190,11 @@ func (cr *compressedReader) Close() error {
 
 	// Close the inner ReadCloser.
 	if err := cr.closer.Close(); err != nil {
+		return err
+	}
+
+	// Flush the buffer.
+	if err := cr.bw.Flush(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use a bufio.Writer to buffer gzipped output while we are reading from
the other end of an io.Pipe to allow gzip to keep compressing its input.

A 64K buffer was chosen for its humor value. The default size of
bufio.Writer was too small when testing against a local registry.
Increasing beyond 64K didn't seem to have any noticeable effect. It
might make sense to make this smaller, but I don't see a reason to worry
about it ATM.

Fixes https://github.com/google/go-containerregistry/issues/920

In local testing, this improved write speed from ~8MB/s to ~30MB/s. Against an actual registry (Docker Hub or GCR), this seems to improve things by ~30%.