### PR TITLE
Don't consider go.mod as generated, because it's not

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,4 @@
 
 **/zz_deepcopy_generated.go linguist-generated=true
 cmd/crane/doc/crane*.md linguist-generated=true
-go.mod linguist-generated=true
 go.sum linguist-generated=true


### PR DESCRIPTION
[I recommended this in a code review in September 2019](https://github.com/google/go-containerregistry/pull/462#discussion_r328430853). What a fool I was then.