### PR TITLE
Accept - to read stdin in crane append

### DIFF
--- a/pkg/crane/append.go
+++ b/pkg/crane/append.go
@@ -40,6 +40,10 @@ func Append(base v1.Image, paths ...string) (v1.Image, error) {
 }
 
 func getLayer(path string) (v1.Layer, error) {
+	if path == "-" {
+		return stream.NewLayer(os.Stdin), nil
+	}
+
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```sh
$ tar -zcf - README.md | go run ./cmd/crane append --new_tag gcr.io/my/image -f -
2021/02/04 16:10:34 base unspecified, using empty image
2021/02/04 16:10:37 pushed blob: sha256:a4ccf662849a6fb1ca1f0f78e885ef1f9e8451ca26a592a8a68fdd0ae852e33a
2021/02/04 16:10:38 pushed blob: sha256:4c547a613ff49535a5bed3bd4ef3a8e516cd974f5a2726aeac496169f3d98b45
2021/02/04 16:10:38 gcr.io/my/image: digest: sha256:d27fd0abc62064b0421d4e8c7e3aa7cf015923791180248604e55b055defaf07 size: 424
```

```sh
$ echo hello | go run ./cmd/crane append -t gcr.io/my/image -f -
2021/02/04 16:09:39 base unspecified, using empty image
2021/02/04 16:09:42 pushed blob: sha256:8d32a8a939a5dad485b09f4ea25a2a9541fdef13674b2df3354e1e16361974a2
2021/02/04 16:09:42 existing blob: sha256:a554b8f018d2b4d54796c5836dff281c9fed0731b00feeb31a35a65ebb9f7bfb
2021/02/04 16:09:42 gcr.io/my/image: digest: sha256:91d92533b3e68755a9aabd54e4fb289f839f84191a85e27efd2437bba842fbd6 size: 422
```

Partially addresses #932 