### PR TITLE
go: update references to use go 1.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/go-containerregistry
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.57.0 // indirect


### PR DESCRIPTION
In the GH actions, it is already using go 1.15.x was missing to update go in two places.

/assign @jonjohnsonjr 