### PR TITLE
implement catalog tests

### DIFF
--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-// TODO(jonjohnsonjr): Test crane.Catalog behavior.
 // TODO(jonjohnsonjr): Test crane.Copy failures.
 func TestCraneRegistry(t *testing.T) {
 	// Set up a fake registry.
@@ -194,6 +193,15 @@ func TestCraneRegistry(t *testing.T) {
 	}
 	if err := compare.Images(dstPulled, copied); err != nil {
 		t.Fatal(err)
+	}
+
+	// List Catalog
+	repos, err := crane.Catalog(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("wanted 2 repos, got %d", len(repos))
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -47,6 +47,9 @@ func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
 	if isTags(req) {
 		return r.manifests.handleTags(resp, req)
 	}
+	if isCatalog(req) {
+		return r.manifests.handleCatalog(resp, req)
+	}
 	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
 		return &regError{

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -390,6 +390,13 @@ func TestCalls(t *testing.T) {
 			URL:         "/v2/foo/tags/list?n=1000",
 			Code:        http.StatusNotFound,
 		},
+		{
+			Description: "list repos",
+			Manifests:   map[string]string{"foo/manifests/latest": "foo", "bar/manifests/latest": "bar"},
+			Method:      "GET",
+			URL:         "/v2/_catalog?n=1000",
+			Code:        http.StatusOK,
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
as a continuation of in intention of the work here: https://github.com/google/go-containerregistry/pull/915

This PR implements the `Catalog` tests

Feedbacks are welcome

/assign @jonjohnsonjr 