### PR TITLE
Prevent test from hitting Docker Hub

### DIFF
--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -173,7 +173,7 @@ func TestCraneRegistry(t *testing.T) {
 	}
 
 	// Delete the non existing image
-	if err := crane.Delete("honk-image"); err == nil {
+	if err := crane.Delete(dst + ":honk-image"); err == nil {
 		t.Fatal("wanted err, got nil")
 	}
 


### PR DESCRIPTION
Was working without internet and noticed this took a long time.