### PR TITLE
Remove Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # go-containerregistry
 
-[![Travis Build Status](https://travis-ci.org/google/go-containerregistry.svg?branch=main)](https://travis-ci.org/google/go-containerregistry)
 [![GitHub Actions Build Status](https://github.com/google/go-containerregistry/workflows/Build/badge.svg)](https://github.com/google/go-containerregistry/actions?query=workflow%3ABuild)
 [![GoDoc](https://godoc.org/github.com/google/go-containerregistry?status.svg)](https://godoc.org/github.com/google/go-containerregistry)
 [![Go Report Card](https://goreportcard.com/badge/google/go-containerregistry)](https://goreportcard.com/report/google/go-containerregistry)
 [![Code Coverage](https://codecov.io/gh/google/go-containerregistry/branch/main/graph/badge.svg)](https://codecov.io/gh/google/go-containerregistry)
-
 
 ## Introduction
 


### PR DESCRIPTION
We don't use Travis anymore, and Travis kicked off Codecov runs, so those also show up as `unknown`.