### PR TITLE
Implement WriteIndex _not_ in terms of Write

### DIFF
--- a/pkg/v1/remote/multi_write.go
+++ b/pkg/v1/remote/multi_write.go
@@ -80,7 +80,7 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) error {
 	for _, l := range blobs {
 		ls = append(ls, l)
 	}
-	scopes := scopesForUploadingImage(repo, ls)
+	scopes := scopesForUploadingImage(repo, ls).slice(repo.Scope(transport.PushScope))
 	tr, err := transport.NewWithContext(o.context, repo.Registry, o.auth, o.transport, scopes)
 	if err != nil {
 		return err

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -942,8 +942,7 @@ func TestDockerhubScopes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		scopes := scopesForUploadingImage(dst.Context(), []v1.Layer{ml})
-
+		scopes := scopesForUploadingImage(dst.Context(), []v1.Layer{ml}).slice(src.Scope(transport.PushScope))
 		if len(scopes) != 2 {
 			t.Errorf("Should have two scopes (src and dst), got %d", len(scopes))
 		} else if diff := cmp.Diff(want, scopes[1]); diff != "" {
@@ -1106,7 +1105,7 @@ func TestScopesForUploadingImage(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := scopesForUploadingImage(tc.reference.Context(), tc.layers)
+		actual := scopesForUploadingImage(tc.reference.Context(), tc.layers).slice(tc.expected[0])
 
 		if want, got := tc.expected[0], actual[0]; want != got {
 			t.Errorf("TestScopesForUploadingImage() %s: Wrong first scope; want %v, got %v", tc.name, want, got)


### PR DESCRIPTION
Previously, `remote.WriteIndex` called `remote.Write` as a convenience to recalculate pull scopes for mountable layers. `remote.MultiWrite` did it the better way, by walking the tree from the index and collecting all unique layers and requesting those scopes upfront.

Now `remote.WriteIndex` does the right thing too, and walks the tree to collect mountable matching layers. The result is fewer auth handshakes, and one all-encompassing upfront auth handshake.

Since this involves possibly collecting more scopes, and duplicates should be avoided, some work was put in to define a private stringset type. Because some registries only inspect the first requested scope, we make sure to prepend the repo's Push scope to the slice before translating it from the map form.

This work helps unblock progress reporting for `remote.WriteIndex` since it's much clearer now where progress channels should be setup and closed.