### PR TITLE
Add MustParseReference

### DIFF
--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -47,3 +47,12 @@ func ParseReference(s string, opts ...Option) (Reference, error) {
 	return nil, NewErrBadName("could not parse reference: " + s)
 
 }
+
+// MustParseReference behaves like ParseReference, but panics instead of returning an error.
+func MustParseReference(s string, opts ...Option) Reference {
+	ref, err := ParseReference(s, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -116,3 +116,38 @@ func TestParseReference(t *testing.T) {
 		}
 	}
 }
+
+func TestMustParseReference(t *testing.T) {
+	goodWeakValidationNames := append(goodWeakValidationTagNames, goodWeakValidationDigestNames...)
+	for _, name := range goodWeakValidationNames {
+		func() {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Errorf("MustParseReference(%q, WeakValidation); panic: %v", name, err)
+				}
+			}()
+			MustParseReference(name, WeakValidation)
+		}()
+	}
+
+	goodStrictValidationNames := append(goodStrictValidationTagNames, goodStrictValidationDigestNames...)
+	for _, name := range goodStrictValidationNames {
+		func() {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Errorf("MustParseReference(%q, StrictValidation); panic: %v", name, err)
+				}
+			}()
+			MustParseReference(name, StrictValidation)
+		}()
+	}
+
+	badNames := append(badTagNames, badDigestNames...)
+	for _, name := range badNames {
+		func() {
+			defer func() { recover() }()
+			ref := MustParseReference(name, WeakValidation)
+			t.Errorf("MustParseReference(%q, WeakValidation) should panic, got: %#v", name, ref)
+		}()
+	}
+}


### PR DESCRIPTION
Makes testing and initializing other `const`ish References less annoying