### PR TITLE
crane digest: fallback to GET when HEAD fails

### DIFF
--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -14,6 +14,8 @@
 
 package crane
 
+import "github.com/google/go-containerregistry/pkg/logs"
+
 // Digest returns the sha256 hash of the remote image at ref.
 func Digest(ref string, opt ...Option) (string, error) {
 	o := makeOptions(opt...)
@@ -39,7 +41,12 @@ func Digest(ref string, opt ...Option) (string, error) {
 	}
 	desc, err := head(ref, opt...)
 	if err != nil {
-		return "", err
+		logs.Warn.Printf("HEAD request failed, falling back on GET: %v", err)
+		rdesc, err := getManifest(ref, opt...)
+		if err != nil {
+			return "", err
+		}
+		return rdesc.Digest.String(), nil
 	}
 	return desc.Digest.String(), nil
 }

--- a/pkg/crane/digest_test.go
+++ b/pkg/crane/digest_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crane
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestDigest_MissingDigest(t *testing.T) {
+	response := []byte("doesn't matter")
+	digest := "sha256:477c34d98f9e090a4441cf82d2f1f03e64c8eb730e8c1ef39a8595e685d4df65" // Digest of "doesn't matter"
+	getCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", string(types.DockerManifestSchema2))
+		if r.Method == http.MethodGet {
+			getCalled = true
+			w.Header().Set("Docker-Content-Digest", digest)
+		}
+		// This will automatically set the Content-Length header.
+		w.Write(response)
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	got, err := Digest(fmt.Sprintf("%s/repo:latest", u.Host))
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("Digest: got %q, want %q", got, digest)
+	}
+	if !getCalled {
+		t.Errorf("Digest: expected GET to be called")
+	}
+}

--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -87,7 +87,7 @@ func Hasher(name string) (hash.Hash, error) {
 func (h *Hash) parse(unquoted string) error {
 	parts := strings.Split(unquoted, ":")
 	if len(parts) != 2 {
-		return fmt.Errorf("too many parts in hash: %s", unquoted)
+		return fmt.Errorf("cannot parse hash: %q", unquoted)
 	}
 
 	rest := strings.TrimLeft(parts[1], "0123456789abcdef")

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -324,14 +324,26 @@ func (f *fetcher) headManifest(ref name.Reference, acceptable []types.MediaType)
 		return nil, err
 	}
 
-	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
+	mth := resp.Header.Get("Content-Type")
+	if mth == "" {
+		return nil, fmt.Errorf("HEAD %s: response did not include Content-Type header", u.String())
+	}
+	mediaType := types.MediaType(mth)
 
-	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	lh := resp.Header.Get("Content-Length")
+	if lh == "" {
+		return nil, fmt.Errorf("HEAD %s: response did not include Content-Length header", u.String())
+	}
+	size, err := strconv.ParseInt(lh, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
-	digest, err := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
+	dh := resp.Header.Get("Docker-Content-Digest")
+	if dh == "" {
+		return nil, fmt.Errorf("HEAD %s: response did not include Docker-Content-Digest header", u.String())
+	}
+	digest, err := v1.NewHash(dh)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Before

```
$ crane digest registry.access.redhat.com/ubi8/ubi-minimal
2021/03/20 10:19:50 No matching credentials were found for "registry.access.redhat.com/ubi8/ubi-minimal", falling back on anonymous
2021/03/20 10:19:51 computing digest: too many parts in hash: 
```

_My, what a very unhelpful error message that is!_ 🤔 

### After

```
$ go run ./cmd/crane digest registry.access.redhat.com/ubi8/ubi-minimal
2021/03/20 10:20:10 No matching credentials were found for "registry.access.redhat.com/ubi8/ubi-minimal", falling back on anonymous
2021/03/20 10:20:10 HEAD request failed, falling back on GET: response did not include Docker-Content-Digest header
2021/03/20 10:20:10 No matching credentials were found for "registry.access.redhat.com/ubi8/ubi-minimal", falling back on anonymous
sha256:fdfb0770bff33e0f97d78583efd68b546a19d0a4b0ac23eef25ef261bca3e975
```

This should also make `crane digest` work against registries that don't support `HEAD` at all, or that don't include all the necessary descriptor information in response headers, though neglecting `Docker-Content-Digest` is probably by far the most common omission.

If this lgty in general I can add some tests.