### PR TITLE
Allow progress also when saving to docker daemon

### DIFF
--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -54,7 +54,7 @@ func Tag(src, dest name.Tag) error {
 }
 
 // Write saves the image into the daemon as the given tag.
-func Write(tag name.Tag, img v1.Image) (string, error) {
+func Write(tag name.Tag, img v1.Image, opts ...tarball.WriteOption) (string, error) {
 	cli, err := GetImageLoader()
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func Write(tag name.Tag, img v1.Image) (string, error) {
 
 	pr, pw := io.Pipe()
 	go func() {
-		pw.CloseWithError(tarball.Write(tag, img, pw))
+		pw.CloseWithError(tarball.Write(tag, img, pw, opts...))
 	}()
 
 	// write the image in docker save format first, then load it


### PR DESCRIPTION
The initial implementation only added progress to tarball

Fortunately the daemon Write uses a temporary tarball file