### PR TITLE
Use name.MustParseReference in some tests

### DIFF
--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -42,14 +42,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-func mustRepo(s string) name.Repository {
-	repo, err := name.NewRepository(s)
-	if err != nil {
-		panic(err)
-	}
-	return repo
-}
-
 type fakeXCR struct {
 	h     http.Handler
 	repos map[string]google.Tags
@@ -206,15 +198,15 @@ func TestCopy(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	c := copier{
-		srcRepo: mustRepo("xcr.io/foo"),
-		dstRepo: mustRepo("xcr.io/bar"),
+		srcRepo: name.MustParseReference("xcr.io/foo").Context(),
+		dstRepo: name.MustParseReference("xcr.io/bar").Context(),
 	}
 
-	got, err := c.rename(mustRepo("xcr.io/foo/sub/repo"))
+	got, err := c.rename(name.MustParseReference("xcr.io/foo/sub/repo").Context())
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	want := mustRepo("xcr.io/bar/sub/repo")
+	want := name.MustParseReference("xcr.io/bar/sub/repo").Context()
 
 	if want.String() != got.String() {
 		t.Errorf("%s != %s", want, got)

--- a/pkg/v1/remote/check_e2e_test.go
+++ b/pkg/v1/remote/check_e2e_test.go
@@ -28,12 +28,12 @@ func TestCheckPushPermission_Real(t *testing.T) {
 	// Tests should not run in an environment where these registries can
 	// be pushed to.
 	for _, r := range []name.Reference{
-		mustNewTag(t, "ubuntu"),
-		mustNewTag(t, "google/cloud-sdk"),
-		mustNewTag(t, "microsoft/dotnet:sdk"),
-		mustNewTag(t, "gcr.io/non-existent-project/made-up"),
-		mustNewTag(t, "gcr.io/google-containers/foo"),
-		mustNewTag(t, "quay.io/username/reponame"),
+		name.MustParseReference("ubuntu"),
+		name.MustParseReference("google/cloud-sdk"),
+		name.MustParseReference("microsoft/dotnet:sdk"),
+		name.MustParseReference("gcr.io/non-existent-project/made-up"),
+		name.MustParseReference("gcr.io/google-containers/foo"),
+		name.MustParseReference("quay.io/username/reponame"),
 	} {
 		t.Run(r.String(), func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Retrying https://github.com/google/go-containerregistry/pull/965 since CI seems to be stuck

In addition to these usages, `pkg/v1/remote` tests also have [`mustNewTag`](https://github.com/google/go-containerregistry/blob/bea57adbec389354c16a3db17a81759529dd8ff5/pkg/v1/remote/write_test.go#L49), which regularly takes a var string to be able to be derived from a dynamically-generated in-memory host.