### PR TITLE
Do not forget CreatedBy in mutate.Canonical 

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -298,8 +298,13 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 	// Strip away timestamps from the config file
 	cfg.Created = v1.Time{Time: t}
 
-	for _, h := range cfg.History {
+	for i, h := range cfg.History {
 		h.Created = v1.Time{Time: t}
+		h.CreatedBy = ocf.History[i].CreatedBy
+		h.Comment = ocf.History[i].Comment
+		h.EmptyLayer = ocf.History[i].EmptyLayer
+		// Explicitly ignore Author field; which hinders reproducibility
+		cfg.History[i] = h
 	}
 
 	return ConfigFile(newImage, cfg)

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -453,6 +453,11 @@ func TestCanonical(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	for _, h := range cf.History {
+		if h.CreatedBy != "bazel build ..." {
+			t.Errorf("Invalid CreatedBy %q != %q", h.CreatedBy, "bazel build ...")
+		}
+	}
 	var want, got string
 	want = cf.Architecture
 	got = sourceCf.Architecture

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -454,7 +454,7 @@ func TestCanonical(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, h := range cf.History {
-		want = "bazel build ..."
+		want := "bazel build ..."
 		got := h.CreatedBy
 		if want != got {
 			t.Errorf("%q != %q", want, got)

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -454,8 +454,10 @@ func TestCanonical(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, h := range cf.History {
-		if h.CreatedBy != "bazel build ..." {
-			t.Errorf("%q != %q", h.CreatedBy, "bazel build ...")
+		want = "bazel build ..."
+		got := h.CreatedBy
+		if want != got {
+			t.Errorf("%q != %q", want, got)
 		}
 	}
 	var want, got string

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -455,7 +455,7 @@ func TestCanonical(t *testing.T) {
 	}
 	for _, h := range cf.History {
 		if h.CreatedBy != "bazel build ..." {
-			t.Errorf("Invalid CreatedBy %q != %q", h.CreatedBy, "bazel build ...")
+			t.Errorf("%q != %q", h.CreatedBy, "bazel build ...")
 		}
 	}
 	var want, got string


### PR DESCRIPTION
**Warning: breaking change.**

Kaniko uses this project and uses `mutate.Canonical` when the `--reproducible` flag is set. This is advertised as resetting the dates, so that the build becomes reproducible. However, it also resets the `CreatedBy` field, due to improper copying.

Example `docker history <img>` **without** `--reproducible`:
```
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
0c0d4077e9d6   292 years ago   COPY debug-page /app/debug-page                 1.51kB
<missing>      292 years ago   COPY --from=builder-dev /app/dist /app/dist     196kB
<missing>      292 years ago   COPY --from=builder-prod /app/node_modules /…   47.9MB
<missing>      292 years ago   COPY package.json config-localdev.json confi…   5.43kB
<missing>      292 years ago   WORKDIR /app                                    0B
<missing>      292 years ago   RUN apk add --update     libc6-compat     &&…   621kB
<missing>      8 months ago    /bin/sh -c #(nop)  CMD ["node"]                 0B
<missing>      8 months ago    /bin/sh -c #(nop)  ENTRYPOINT ["docker-entry…   0B
<missing>      8 months ago    /bin/sh -c #(nop) COPY file:238737301d473041…   116B
<missing>      8 months ago    /bin/sh -c apk add --no-cache --virtual .bui…   7.62MB
<missing>      8 months ago    /bin/sh -c #(nop)  ENV YARN_VERSION=1.22.4      0B
<missing>      8 months ago    /bin/sh -c addgroup -g 1000 node     && addu…   76.1MB
<missing>      8 months ago    /bin/sh -c #(nop)  ENV NODE_VERSION=12.18.3     0B
<missing>      11 months ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      11 months ago   /bin/sh -c #(nop) ADD file:b91adb67b670d3a6f…   5.61MB
```

Example `docker history <img>` **with** `--reproducible`:
```
IMAGE          CREATED         CREATED BY   SIZE      COMMENT
d6b5217acfb2   292 years ago                1.51kB
<missing>      292 years ago                196kB
<missing>      292 years ago                47.9MB
<missing>      292 years ago                5.43kB
<missing>      292 years ago                0B
<missing>      292 years ago                621kB
<missing>      292 years ago                116B
<missing>      292 years ago                7.62MB
<missing>      292 years ago                76.1MB
<missing>      292 years ago                5.61MB
```
