### PR TITLE
Rework gcrane options

### DIFF
--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -38,11 +38,11 @@ func NewCmdCopy() *cobra.Command {
 				// We should wire this up to signal handlers and make sure we
 				// respect the cancellation downstream.
 				ctx := context.TODO()
-				if err := gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs)); err != nil {
+				if err := gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs), gcrane.WithUserAgent(userAgent())); err != nil {
 					log.Fatal(err)
 				}
 			} else {
-				if err := gcrane.Copy(src, dst); err != nil {
+				if err := gcrane.Copy(src, dst, gcrane.WithUserAgent(userAgent())); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -50,13 +50,13 @@ func gc(root string, recursive bool) {
 	auth := google.WithAuthFromKeychain(gcrane.Keychain)
 
 	if recursive {
-		if err := google.Walk(repo, printUntaggedImages, auth); err != nil {
+		if err := google.Walk(repo, printUntaggedImages, auth, google.WithUserAgent(userAgent())); err != nil {
 			log.Fatalln(err)
 		}
 		return
 	}
 
-	tags, err := google.List(repo, auth)
+	tags, err := google.List(repo, auth, google.WithUserAgent(userAgent()))
 	if err := printUntaggedImages(repo, tags, err); err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/gcrane/cmd/list.go
+++ b/cmd/gcrane/cmd/list.go
@@ -18,12 +18,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path"
 
+	"github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/spf13/cobra"
 )
+
+func userAgent() string {
+	if cmd.Version != "" {
+		return path.Join("gcrane", cmd.Version)
+	}
+
+	return "gcrane"
+}
 
 // NewCmdList creates a new cobra.Command for the ls subcommand.
 func NewCmdList() *cobra.Command {
@@ -51,13 +61,13 @@ func ls(root string, recursive, j bool) {
 	}
 
 	if recursive {
-		if err := google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain)); err != nil {
+		if err := google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent())); err != nil {
 			log.Fatalln(err)
 		}
 		return
 	}
 
-	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain))
+	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -16,18 +16,34 @@ package gcrane
 
 import (
 	"runtime"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // Option is a functional option for gcrane operations.
 type Option func(*options)
 
 type options struct {
-	jobs int
+	jobs   int
+	remote []remote.Option
+	google []google.Option
+	crane  []crane.Option
 }
 
 func makeOptions(opts ...Option) *options {
 	o := &options{
 		jobs: runtime.GOMAXPROCS(0),
+		remote: []remote.Option{
+			remote.WithAuthFromKeychain(Keychain),
+		},
+		google: []google.Option{
+			google.WithAuthFromKeychain(Keychain),
+		},
+		crane: []crane.Option{
+			crane.WithAuthFromKeychain(Keychain),
+		},
 	}
 
 	for _, option := range opts {
@@ -43,5 +59,15 @@ func makeOptions(opts ...Option) *options {
 func WithJobs(jobs int) Option {
 	return func(o *options) {
 		o.jobs = jobs
+	}
+}
+
+// WithUserAgent adds the given string to the User-Agent header for any HTTP
+// requests.
+func WithUserAgent(ua string) Option {
+	return func(o *options) {
+		o.remote = append(o.remote, remote.WithUserAgent(ua))
+		o.google = append(o.google, google.WithUserAgent(ua))
+		o.crane = append(o.crane, crane.WithUserAgent(ua))
 	}
 }

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -29,9 +29,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-// ListerOption is a functional option for List and Walk.
+// Option is a functional option for List and Walk.
 // TODO: Can we somehow reuse the remote options here?
-type ListerOption func(*lister) error
+type Option func(*lister) error
 
 type lister struct {
 	auth      authn.Authenticator
@@ -42,7 +42,7 @@ type lister struct {
 	userAgent string
 }
 
-func newLister(repo name.Repository, options ...ListerOption) (*lister, error) {
+func newLister(repo name.Repository, options ...Option) (*lister, error) {
 	l := &lister{
 		auth:      authn.Anonymous,
 		transport: http.DefaultTransport,
@@ -195,7 +195,7 @@ type Tags struct {
 }
 
 // List calls /tags/list for the given repository.
-func List(repo name.Repository, options ...ListerOption) (*Tags, error) {
+func List(repo name.Repository, options ...Option) (*Tags, error) {
 	l, err := newLister(repo, options...)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func List(repo name.Repository, options ...ListerOption) (*Tags, error) {
 // TODO: Do we want a SkipDir error, as in filepath.WalkFunc?
 type WalkFunc func(repo name.Repository, tags *Tags, err error) error
 
-func walk(repo name.Repository, tags *Tags, walkFn WalkFunc, options ...ListerOption) error {
+func walk(repo name.Repository, tags *Tags, walkFn WalkFunc, options ...Option) error {
 	if tags == nil {
 		// This shouldn't happen.
 		return fmt.Errorf("tags nil for %q", repo)
@@ -249,7 +249,7 @@ func walk(repo name.Repository, tags *Tags, walkFn WalkFunc, options ...ListerOp
 }
 
 // Walk recursively descends repositories, calling walkFn.
-func Walk(root name.Repository, walkFn WalkFunc, options ...ListerOption) error {
+func Walk(root name.Repository, walkFn WalkFunc, options ...Option) error {
 	tags, err := List(root, options...)
 	if err != nil {
 		return walkFn(root, nil, err)

--- a/pkg/v1/google/options.go
+++ b/pkg/v1/google/options.go
@@ -24,7 +24,7 @@ import (
 
 // WithTransport is a functional option for overriding the default transport
 // on a remote image
-func WithTransport(t http.RoundTripper) ListerOption {
+func WithTransport(t http.RoundTripper) Option {
 	return func(l *lister) error {
 		l.transport = t
 		return nil
@@ -33,7 +33,7 @@ func WithTransport(t http.RoundTripper) ListerOption {
 
 // WithAuth is a functional option for overriding the default authenticator
 // on a remote image
-func WithAuth(auth authn.Authenticator) ListerOption {
+func WithAuth(auth authn.Authenticator) Option {
 	return func(l *lister) error {
 		l.auth = auth
 		return nil
@@ -42,7 +42,7 @@ func WithAuth(auth authn.Authenticator) ListerOption {
 
 // WithAuthFromKeychain is a functional option for overriding the default
 // authenticator on a remote image using an authn.Keychain
-func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
+func WithAuthFromKeychain(keys authn.Keychain) Option {
 	return func(l *lister) error {
 		auth, err := keys.Resolve(l.repo.Registry)
 		if err != nil {
@@ -58,7 +58,7 @@ func WithAuthFromKeychain(keys authn.Keychain) ListerOption {
 
 // WithContext is a functional option for overriding the default
 // context.Context for HTTP request to list remote images
-func WithContext(ctx context.Context) ListerOption {
+func WithContext(ctx context.Context) Option {
 	return func(l *lister) error {
 		l.ctx = ctx
 		return nil
@@ -69,7 +69,7 @@ func WithContext(ctx context.Context) ListerOption {
 // requests. This header will also include "go-containerregistry/${version}".
 //
 // If you want to completely overwrite the User-Agent header, use WithTransport.
-func WithUserAgent(ua string) ListerOption {
+func WithUserAgent(ua string) Option {
 	return func(l *lister) error {
 		l.userAgent = ua
 		return nil


### PR DESCRIPTION
This allows us to plumb a user-agent everywhere, and makes some things a
bit more consistent. This is getting unwieldy, but it works.

While working on https://github.com/google/go-containerregistry/pull/985 I noticed that we were dropping the useragent in a few places, which is upsetting. This should fix that.