### PR TITLE
Refactor pkg/v1/daemon

### DIFF
--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -17,8 +17,11 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/internal/compare"
@@ -29,48 +32,109 @@ import (
 
 var imagePath = "../tarball/testdata/test_image_1.tar"
 
-type MockImageSaver struct {
+type MockClient struct {
 	Client
 	path       string
 	negotiated bool
+
+	wantCtx context.Context
+
+	loadErr  error
+	loadBody io.ReadCloser
+
+	saveErr  error
+	saveBody io.ReadCloser
 }
 
-func (m *MockImageSaver) NegotiateAPIVersion(ctx context.Context) {
+func (m *MockClient) NegotiateAPIVersion(ctx context.Context) {
 	m.negotiated = true
 }
 
-func (m *MockImageSaver) ImageSave(_ context.Context, _ []string) (io.ReadCloser, error) {
+func (m *MockClient) ImageSave(_ context.Context, _ []string) (io.ReadCloser, error) {
 	if !m.negotiated {
 		return nil, errors.New("you forgot to call NegotiateAPIVersion before calling ImageSave")
-
 	}
-	return os.Open(m.path)
+
+	if m.path != "" {
+		return os.Open(m.path)
+	}
+
+	return m.saveBody, m.saveErr
 }
 
 func TestImage(t *testing.T) {
-	for _, opts := range [][]ImageOption{{
-		WithBufferedOpener(),
-		WithClient(&MockImageSaver{path: imagePath}),
+	for _, tc := range []struct {
+		name         string
+		buffered     bool
+		client       *MockClient
+		wantResponse string
+		wantErr      string
+	}{{
+		name: "success",
+		client: &MockClient{
+			path: imagePath,
+		},
 	}, {
-		WithUnbufferedOpener(),
-		WithClient(&MockImageSaver{path: imagePath}),
+		name: "save err",
+		client: &MockClient{
+			saveBody: ioutil.NopCloser(strings.NewReader("Loaded")),
+			saveErr:  fmt.Errorf("locked and loaded"),
+		},
+		wantErr: "locked and loaded",
+	}, {
+		name: "read err",
+		client: &MockClient{
+			saveBody: ioutil.NopCloser(&errReader{fmt.Errorf("goodbye, world")}),
+		},
+		wantErr: "goodbye, world",
 	}} {
-		img, err := tarball.ImageFromPath(imagePath, nil)
-		if err != nil {
-			t.Fatalf("error loading test image: %s", err)
+		run := func(t *testing.T) {
+			opts := []Option{WithClient(tc.client)}
+			if tc.buffered {
+				opts = append(opts, WithBufferedOpener())
+			} else {
+				opts = append(opts, WithUnbufferedOpener())
+			}
+			img, err := tarball.ImageFromPath(imagePath, nil)
+			if err != nil {
+				t.Fatalf("error loading test image: %s", err)
+			}
+
+			tag, err := name.NewTag("unused", name.WeakValidation)
+			if err != nil {
+				t.Fatalf("error creating test name: %s", err)
+			}
+
+			dmn, err := Image(tag, opts...)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Errorf("Error loading daemon image: %s", err)
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("wanted %s to contain %s", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err := compare.Images(img, dmn); err != nil {
+				t.Errorf("compare.Images: %v", err)
+			}
 		}
 
-		tag, err := name.NewTag("unused", name.WeakValidation)
-		if err != nil {
-			t.Fatalf("error creating test name: %s", err)
-		}
+		tc.buffered = true
+		t.Run(tc.name+" buffered", run)
 
-		dmn, err := Image(tag, opts...)
-		if err != nil {
-			t.Fatalf("Error loading daemon image: %s", err)
-		}
-		if err := compare.Images(img, dmn); err != nil {
-			t.Errorf("compare.Images: %v", err)
-		}
+		tc.buffered = false
+		t.Run(tc.name+" unbuffered", run)
+	}
+}
+
+func TestImageDefaultClient(t *testing.T) {
+	wantErr := fmt.Errorf("bad client")
+	defaultClient = func() (Client, error) {
+		return nil, wantErr
+	}
+
+	_, err := Image(name.MustParseReference("unused"))
+	if err != wantErr {
+		t.Errorf("Image(): want %v; got %v", wantErr, err)
 	}
 }

--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -19,34 +19,71 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
+type Option func(*options)
+
+type options struct {
+	ctx      context.Context
+	client   Client
+	buffered bool
+}
+
+var defaultClient = func() (Client, error) {
+	return client.NewClientWithOpts(client.FromEnv)
+}
+
+func makeOptions(opts ...Option) (*options, error) {
+	o := &options{
+		buffered: true,
+		ctx:      context.Background(),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.client == nil {
+		client, err := defaultClient()
+		if err != nil {
+			return nil, err
+		}
+		o.client = client
+	}
+	o.client.NegotiateAPIVersion(o.ctx)
+
+	return o, nil
+}
+
 // WithBufferedOpener buffers the image.
-func WithBufferedOpener() ImageOption {
-	return func(i *imageOpener) error {
-		return i.setBuffered(true)
+func WithBufferedOpener() Option {
+	return func(o *options) {
+		o.buffered = true
 	}
 }
 
 // WithUnbufferedOpener streams the image to avoid buffering.
-func WithUnbufferedOpener() ImageOption {
-	return func(i *imageOpener) error {
-		return i.setBuffered(false)
+func WithUnbufferedOpener() Option {
+	return func(o *options) {
+		o.buffered = false
 	}
-}
-
-func (i *imageOpener) setBuffered(buffer bool) error {
-	i.buffered = buffer
-	return nil
 }
 
 // WithClient is a functional option to allow injecting a docker client.
 //
 // By default, github.com/docker/docker/client.FromEnv is used.
-func WithClient(client Client) ImageOption {
-	return func(i *imageOpener) error {
-		i.client = client
-		return nil
+func WithClient(client Client) Option {
+	return func(o *options) {
+		o.client = client
+	}
+}
+
+// WithContext is a functional option to pass through a context.Context.
+//
+// By default, context.Background() is used.
+func WithContext(ctx context.Context) Option {
+	return func(o *options) {
+		o.ctx = ctx
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/857

Use options for everything, including injecting clients for testing.

Add WithContext option.

Un-thunkify some of daemon.Image to make it a bit clearer.

Add more test coverage: actually caught one bug where we were returning
the wrong error if we failed to read from the daemon response body.