### PR TITLE
Plumb context through crane and gcrane

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -45,6 +45,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			options = append(options, crane.WithContext(cmd.Context()))
 			// TODO(jonjohnsonjr): crane.Verbose option?
 			if verbose {
 				logs.Debug.SetOutput(os.Stderr)

--- a/cmd/crane/main.go
+++ b/cmd/crane/main.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/google/go-containerregistry/cmd/crane/cmd"
+	"github.com/google/go-containerregistry/internal/signal"
 	"github.com/google/go-containerregistry/pkg/logs"
 )
 
@@ -27,7 +29,10 @@ func init() {
 }
 
 func main() {
-	if err := cmd.Root.Execute(); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	if err := cmd.Root.ExecuteContext(ctx); err != nil {
+		cancel()
 		os.Exit(1)
 	}
 }

--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/gcrane"
@@ -33,13 +32,11 @@ func NewCmdCopy() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cc *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
+			ctx := cc.Context()
 			if recursive {
-				// We should wire this up to signal handlers and make sure we
-				// respect the cancellation downstream.
-				ctx := context.TODO()
-				return gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs), gcrane.WithUserAgent(userAgent()))
+				return gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs), gcrane.WithUserAgent(userAgent()), gcrane.WithContext(ctx))
 			} else {
-				return gcrane.Copy(src, dst, gcrane.WithUserAgent(userAgent()))
+				return gcrane.Copy(src, dst, gcrane.WithUserAgent(userAgent()), gcrane.WithContext(ctx))
 			}
 		},
 	}

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/gcrane"
@@ -30,8 +31,8 @@ func NewCmdGc() *cobra.Command {
 		Use:   "gc",
 		Short: "List images that are not tagged",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return gc(args[0], recursive)
+		RunE: func(cc *cobra.Command, args []string) error {
+			return gc(cc.Context(), args[0], recursive)
 		},
 	}
 
@@ -40,7 +41,7 @@ func NewCmdGc() *cobra.Command {
 	return cmd
 }
 
-func gc(root string, recursive bool) error {
+func gc(ctx context.Context, root string, recursive bool) error {
 	repo, err := name.NewRepository(root)
 	if err != nil {
 		return err
@@ -49,7 +50,7 @@ func gc(root string, recursive bool) error {
 	auth := google.WithAuthFromKeychain(gcrane.Keychain)
 
 	if recursive {
-		return google.Walk(repo, printUntaggedImages, auth, google.WithUserAgent(userAgent()))
+		return google.Walk(repo, printUntaggedImages, auth, google.WithUserAgent(userAgent()), google.WithContext(ctx))
 	}
 
 	tags, err := google.List(repo, auth, google.WithUserAgent(userAgent()))

--- a/cmd/gcrane/cmd/gc.go
+++ b/cmd/gcrane/cmd/gc.go
@@ -47,13 +47,17 @@ func gc(ctx context.Context, root string, recursive bool) error {
 		return err
 	}
 
-	auth := google.WithAuthFromKeychain(gcrane.Keychain)
-
-	if recursive {
-		return google.Walk(repo, printUntaggedImages, auth, google.WithUserAgent(userAgent()), google.WithContext(ctx))
+	opts := []google.Option{
+		google.WithAuthFromKeychain(gcrane.Keychain),
+		google.WithUserAgent(userAgent()),
+		google.WithContext(ctx),
 	}
 
-	tags, err := google.List(repo, auth, google.WithUserAgent(userAgent()))
+	if recursive {
+		return google.Walk(repo, printUntaggedImages, opts...)
+	}
+
+	tags, err := google.List(repo, opts...)
 	return printUntaggedImages(repo, tags, err)
 }
 

--- a/cmd/gcrane/cmd/list.go
+++ b/cmd/gcrane/cmd/list.go
@@ -60,11 +60,17 @@ func ls(ctx context.Context, root string, recursive, j bool) error {
 		return err
 	}
 
-	if recursive {
-		return google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()), google.WithContext(ctx))
+	opts := []google.Option{
+		google.WithAuthFromKeychain(gcrane.Keychain),
+		google.WithUserAgent(userAgent()),
+		google.WithContext(ctx),
 	}
 
-	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()), google.WithContext(ctx))
+	if recursive {
+		return google.Walk(repo, printImages(j), opts...)
+	}
+
+	tags, err := google.List(repo, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gcrane/cmd/list.go
+++ b/cmd/gcrane/cmd/list.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -42,8 +43,8 @@ func NewCmdList() *cobra.Command {
 		Use:   "ls REPO",
 		Short: "List the contents of a repo",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return ls(args[0], recursive, json)
+		RunE: func(cc *cobra.Command, args []string) error {
+			return ls(cc.Context(), args[0], recursive, json)
 		},
 	}
 
@@ -53,17 +54,17 @@ func NewCmdList() *cobra.Command {
 	return cmd
 }
 
-func ls(root string, recursive, j bool) error {
+func ls(ctx context.Context, root string, recursive, j bool) error {
 	repo, err := name.NewRepository(root)
 	if err != nil {
 		return err
 	}
 
 	if recursive {
-		return google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()))
+		return google.Walk(repo, printImages(j), google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()), google.WithContext(ctx))
 	}
 
-	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()))
+	tags, err := google.List(repo, google.WithAuthFromKeychain(gcrane.Keychain), google.WithUserAgent(userAgent()), google.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -15,10 +15,12 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/google/go-containerregistry/cmd/crane/cmd"
 	gcmd "github.com/google/go-containerregistry/cmd/gcrane/cmd"
+	"github.com/google/go-containerregistry/internal/signal"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -60,7 +62,10 @@ func main() {
 		root.AddCommand(cmd)
 	}
 
-	if err := root.Execute(); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	if err := root.ExecuteContext(ctx); err != nil {
+		cancel()
 		os.Exit(1)
 	}
 }

--- a/internal/signal/go116.go
+++ b/internal/signal/go116.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC All Rights Reserved.
+// Copyright 2021 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crane
+// +build go1.16
+
+package signal
 
 import (
 	"context"
-
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"os"
+	"os/signal"
 )
 
-// Catalog returns the repositories in a registry's catalog.
-func Catalog(src string, opt ...Option) (res []string, err error) {
-	o := makeOptions(opt...)
-	reg, err := name.NewRegistry(src, o.name...)
-	if err != nil {
-		return nil, err
-	}
-
-	// This context gets overridden by remote.WithContext, which is set by
-	// crane.WithContext.
-	return remote.Catalog(context.Background(), reg, o.remote...)
+// NotifyContext just calls go 1.16's signal.NotifyContext.
+// We can remove this once we bump the minimum go version to 1.16.
+func NotifyContext(parent context.Context, signals ...os.Signal) (ctx context.Context, stop context.CancelFunc) {
+	return signal.NotifyContext(parent, signals...)
 }

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -15,6 +15,7 @@
 package crane
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -95,5 +96,12 @@ func WithAuth(auth authn.Authenticator) Option {
 func WithUserAgent(ua string) Option {
 	return func(o *options) {
 		o.remote = append(o.remote, remote.WithUserAgent(ua))
+	}
+}
+
+// WithContext is a functional option for setting the context.
+func WithContext(ctx context.Context) Option {
+	return func(o *options) {
+		o.remote = append(o.remote, remote.WithContext(ctx))
 	}
 }

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -15,6 +15,7 @@
 package gcrane
 
 import (
+	"context"
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -69,5 +70,14 @@ func WithUserAgent(ua string) Option {
 		o.remote = append(o.remote, remote.WithUserAgent(ua))
 		o.google = append(o.google, google.WithUserAgent(ua))
 		o.crane = append(o.crane, crane.WithUserAgent(ua))
+	}
+}
+
+// WithContext is a functional option for setting the context.
+func WithContext(ctx context.Context) Option {
+	return func(o *options) {
+		o.remote = append(o.remote, remote.WithContext(ctx))
+		o.google = append(o.google, google.WithContext(ctx))
+		o.crane = append(o.crane, crane.WithContext(ctx))
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/912

Also, use signal.NotifyContext for cancelling the ctx.

Also, don't log errors twice now that we're using RunE.