### PR TITLE
Fix gcrane top-level listing

### DIFF
--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -127,7 +127,7 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 			return nil, err
 		}
 
-		if len(parsed.Manifests) != 0 {
+		if len(parsed.Manifests) != 0 || len(parsed.Children) != 0 {
 			// We're dealing with GCR, just return directly.
 			return &parsed, nil
 		}

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -105,6 +105,13 @@ func TestList(t *testing.T) {
 			Tags: []string{"foo", "bar", "baz"},
 		},
 	}, {
+		name:         "just children",
+		responseBody: []byte(`{"child":["hello", "world"]}`),
+		wantErr:      false,
+		wantTags: &Tags{
+			Children: []string{"hello", "world"},
+		},
+	}, {
 		name:         "not json",
 		responseBody: []byte("notjson"),
 		wantErr:      true,


### PR DESCRIPTION
Accidentally dropped top-level repo listing in gcrane for paginating
responses.