### PR TITLE
Update goreleaser config to include arm version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ archives:
     windows: Windows
     386: i386
     amd64: x86_64
-  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This is shamelessly yanked from the default `name_template:` value: https://goreleaser.com/customization/archive/ (which it appears was adjusted here just to remove project version from the filenames).

I decided not to include the 32bit MIPS bit too because honestly, I'm not sure why folks would be doing 32bit MIPS.

![image](https://user-images.githubusercontent.com/161631/116477910-1dfec880-a832-11eb-9259-dfcaa21ea467.png)

(This should result in filenames like `go-containerregistry_Linux_armv6.tar.gz` instead of `go-containerregistry_Linux_arm.tar.gz`, since `goarm:` upstream defaults to `[6]`.)