### PR TITLE
Add --fast flag to crane validate

### DIFF
--- a/cmd/crane/cmd/validate.go
+++ b/cmd/crane/cmd/validate.go
@@ -26,7 +26,10 @@ import (
 
 // NewCmdValidate creates a new cobra.Command for the validate subcommand.
 func NewCmdValidate(options *[]crane.Option) *cobra.Command {
-	var tarballPath, remoteRef string
+	var (
+		tarballPath, remoteRef string
+		fast                   bool
+	)
 
 	validateCmd := &cobra.Command{
 		Use:   "validate",
@@ -45,7 +48,11 @@ func NewCmdValidate(options *[]crane.Option) *cobra.Command {
 					return fmt.Errorf("failed to read image %s: %v", flag, err)
 				}
 
-				if err := validate.Image(img); err != nil {
+				opt := []validate.Option{}
+				if fast {
+					opt = append(opt, validate.Fast)
+				}
+				if err := validate.Image(img, opt...); err != nil {
 					fmt.Printf("FAIL: %s: %v\n", flag, err)
 					return err
 				} else {
@@ -57,6 +64,7 @@ func NewCmdValidate(options *[]crane.Option) *cobra.Command {
 	}
 	validateCmd.Flags().StringVar(&tarballPath, "tarball", "", "Path to tarball to validate")
 	validateCmd.Flags().StringVar(&remoteRef, "remote", "", "Name of remote image to validate")
+	validateCmd.Flags().BoolVar(&fast, "fast", false, "Skip downloading/digesting layers")
 
 	return validateCmd
 }

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -13,6 +13,7 @@ crane validate [flags]
 ### Options
 
 ```
+      --fast             Skip downloading/digesting layers
   -h, --help             help for validate
       --remote string    Name of remote image to validate
       --tarball string   Path to tarball to validate

--- a/pkg/v1/layout/image.go
+++ b/pkg/v1/layout/image.go
@@ -17,6 +17,7 @@ package layout
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -84,20 +85,20 @@ func (li *layoutImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error)
 	}
 
 	if h == manifest.Config.Digest {
-		return partial.CompressedLayer(&compressedBlob{
+		return &compressedBlob{
 			path: li.path,
 			desc: manifest.Config,
-		}), nil
+		}, nil
 	}
 
 	for _, desc := range manifest.Layers {
 		if h == desc.Digest {
 			switch desc.MediaType {
 			case types.OCILayer, types.DockerLayer:
-				return partial.CompressedToLayer(&compressedBlob{
+				return &compressedBlob{
 					path: li.path,
 					desc: desc,
-				})
+				}, nil
 			default:
 				// TODO: We assume everything is a compressed blob, but that might not be true.
 				// TODO: Handle foreign layers.
@@ -128,4 +129,10 @@ func (b *compressedBlob) Size() (int64, error) {
 
 func (b *compressedBlob) MediaType() (types.MediaType, error) {
 	return b.desc.MediaType, nil
+}
+
+// See partial.Exists.
+func (b *compressedBlob) Exists() (bool, error) {
+	_, err := os.Stat(b.path.blobPath(b.desc.Digest))
+	return err == nil, err
 }

--- a/pkg/v1/layout/image.go
+++ b/pkg/v1/layout/image.go
@@ -134,5 +134,8 @@ func (b *compressedBlob) MediaType() (types.MediaType, error) {
 // See partial.Exists.
 func (b *compressedBlob) Exists() (bool, error) {
 	_, err := os.Stat(b.path.blobPath(b.desc.Digest))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
 	return err == nil, err
 }

--- a/pkg/v1/layout/image_test.go
+++ b/pkg/v1/layout/image_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
@@ -98,6 +99,12 @@ func TestImage(t *testing.T) {
 	// Fixture is a DockerLayer
 	if got, want := mediaType, types.DockerLayer; got != want {
 		t.Fatalf("MediaType(); want: %q got: %q", want, got)
+	}
+
+	if ok, err := partial.Exists(layers[0]); err != nil {
+		t.Fatal(err)
+	} else if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
 	}
 }
 

--- a/pkg/v1/partial/README.md
+++ b/pkg/v1/partial/README.md
@@ -64,3 +64,19 @@ there are cases where it is very helpful to know the layer size, e.g. when
 writing the uncompressed layer into a tarball.
 
 See [`#655`](https://github.com/google/go-containerregistry/pull/655).
+
+### [`partial.Exists`](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/partial#Exists)
+
+We generally don't care about the existence of something as granular as a
+layer, and would rather ensure all the invariants of an image are upheld via
+the `validate` package. However, there are situations where we want to do a
+quick smoke test to ensure that the underlying storage engine hasn't been
+corrupted by something e.g. deleting files or blobs. Thus, we've exposed an
+optional `Exists` method that does an existence check without actually reading
+any bytes.
+
+The `remote` package implements this via `HEAD` requests.
+
+The `layout` package implements this via `os.Stat`.
+
+See [`#838`](https://github.com/google/go-containerregistry/pull/838).

--- a/pkg/v1/partial/compressed_test.go
+++ b/pkg/v1/partial/compressed_test.go
@@ -79,6 +79,14 @@ func TestRemote(t *testing.T) {
 	if diff := cmp.Diff(d, m.Layers[0].Digest); diff != "" {
 		t.Errorf("mismatched digest: %v", diff)
 	}
+
+	ok, err := partial.Exists(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
+	}
 }
 
 type noDiffID struct {

--- a/pkg/v1/partial/uncompressed_test.go
+++ b/pkg/v1/partial/uncompressed_test.go
@@ -214,4 +214,21 @@ func TestUncompressed(t *testing.T) {
 	if _, err := partial.Descriptor(img); err != nil {
 		t.Fatalf("partial.Descriptor: %v", err)
 	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	layer, err := partial.UncompressedToLayer(&fastpathLayer{layers[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := partial.Exists(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
+	}
 }

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -301,27 +301,9 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 		return wd.Descriptor()
 	}
 
-	// Otherwise, try to unwrap any partial implementations to see
-	// if the wrapped struct implements Descriptor.
-	if ule, ok := d.(*uncompressedLayerExtender); ok {
-		if wd, ok := ule.UncompressedLayer.(withDescriptor); ok {
-			return wd.Descriptor()
-		}
-	}
-	if cle, ok := d.(*compressedLayerExtender); ok {
-		if wd, ok := cle.CompressedLayer.(withDescriptor); ok {
-			return wd.Descriptor()
-		}
-	}
-	if uie, ok := d.(*uncompressedImageExtender); ok {
-		if wd, ok := uie.UncompressedImageCore.(withDescriptor); ok {
-			return wd.Descriptor()
-		}
-	}
-	if cie, ok := d.(*compressedImageExtender); ok {
-		if wd, ok := cie.CompressedImageCore.(withDescriptor); ok {
-			return wd.Descriptor()
-		}
+	// Otherwise, attempt to unwrap the original implementation.
+	if wd, ok := unwrap(d).(withDescriptor); ok {
+		return wd.Descriptor()
 	}
 
 	// If all else fails, compute the descriptor from the individual methods.
@@ -358,17 +340,11 @@ func UncompressedSize(l v1.Layer) (int64, error) {
 		return wus.UncompressedSize()
 	}
 
+	// Otherwise, attempt to unwrap the original implementation.
 	// Otherwise, try to unwrap any partial implementations to see
 	// if the wrapped struct implements UncompressedSize.
-	if ule, ok := l.(*uncompressedLayerExtender); ok {
-		if wus, ok := ule.UncompressedLayer.(withUncompressedSize); ok {
-			return wus.UncompressedSize()
-		}
-	}
-	if cle, ok := l.(*compressedLayerExtender); ok {
-		if wus, ok := cle.CompressedLayer.(withUncompressedSize); ok {
-			return wus.UncompressedSize()
-		}
+	if wus, ok := unwrap(l).(withUncompressedSize); ok {
+		return wus.UncompressedSize()
 	}
 
 	// The layer doesn't implement UncompressedSize, we need to compute it.
@@ -379,4 +355,52 @@ func UncompressedSize(l v1.Layer) (int64, error) {
 	defer rc.Close()
 
 	return io.Copy(ioutil.Discard, rc)
+}
+
+type withExists interface {
+	Exists() (bool, error)
+}
+
+// Exists checks to see if a layer exists. This is a hack to work around the
+// mistakes of the partial package. Don't use this.
+func Exists(l v1.Layer) (bool, error) {
+	// If the layer implements Exists itself, return that.
+	if we, ok := l.(withExists); ok {
+		return we.Exists()
+	}
+
+	// Otherwise, attempt to unwrap the original implementation.
+	if we, ok := unwrap(l).(withExists); ok {
+		return we.Exists()
+	}
+
+	// The layer doesn't implement Exists, so we hope that calling Compressed()
+	// is enough to trigger an error if the layer does not exist.
+	rc, err := l.Compressed()
+	if err != nil {
+		return false, err
+	}
+	defer rc.Close()
+
+	// We may want to try actually reading a single byte, but if we need to do
+	// that, we should just fix this hack.
+	return true, nil
+}
+
+// Recursively unwrap our wrappers so that we can check for the original implementation.
+// We might want to expose this?
+func unwrap(i interface{}) interface{} {
+	if ule, ok := i.(*uncompressedLayerExtender); ok {
+		return unwrap(ule.UncompressedLayer)
+	}
+	if cle, ok := i.(*compressedLayerExtender); ok {
+		return unwrap(cle.CompressedLayer)
+	}
+	if uie, ok := i.(*uncompressedImageExtender); ok {
+		return unwrap(uie.UncompressedImageCore)
+	}
+	if cie, ok := i.(*compressedImageExtender); ok {
+		return unwrap(cie.CompressedImageCore)
+	}
+	return i
 }

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -297,11 +297,6 @@ type Describable interface {
 // UncompressedToImage.
 func Descriptor(d Describable) (*v1.Descriptor, error) {
 	// If Describable implements Descriptor itself, return that.
-	if wd, ok := d.(withDescriptor); ok {
-		return wd.Descriptor()
-	}
-
-	// Otherwise, attempt to unwrap the original implementation.
 	if wd, ok := unwrap(d).(withDescriptor); ok {
 		return wd.Descriptor()
 	}
@@ -336,13 +331,6 @@ type withUncompressedSize interface {
 // for streaming layers.
 func UncompressedSize(l v1.Layer) (int64, error) {
 	// If the layer implements UncompressedSize itself, return that.
-	if wus, ok := l.(withUncompressedSize); ok {
-		return wus.UncompressedSize()
-	}
-
-	// Otherwise, attempt to unwrap the original implementation.
-	// Otherwise, try to unwrap any partial implementations to see
-	// if the wrapped struct implements UncompressedSize.
 	if wus, ok := unwrap(l).(withUncompressedSize); ok {
 		return wus.UncompressedSize()
 	}
@@ -365,11 +353,6 @@ type withExists interface {
 // mistakes of the partial package. Don't use this.
 func Exists(l v1.Layer) (bool, error) {
 	// If the layer implements Exists itself, return that.
-	if we, ok := l.(withExists); ok {
-		return we.Exists()
-	}
-
-	// Otherwise, attempt to unwrap the original implementation.
 	if we, ok := unwrap(l).(withExists); ok {
 		return we.Exists()
 	}

--- a/pkg/v1/partial/with_test.go
+++ b/pkg/v1/partial/with_test.go
@@ -203,6 +203,10 @@ func (l *fastpathLayer) UncompressedSize() (int64, error) {
 	return 100, nil
 }
 
+func (l *fastpathLayer) Exists() (bool, error) {
+	return true, nil
+}
+
 func TestUncompressedSize(t *testing.T) {
 	randLayer, err := random.Layer(1024, types.DockerLayer)
 	if err != nil {
@@ -215,5 +219,28 @@ func TestUncompressedSize(t *testing.T) {
 	}
 	if got, want := us, int64(100); got != want {
 		t.Errorf("UncompressedSize() = %d != %d", got, want)
+	}
+}
+
+func TestExists(t *testing.T) {
+	randLayer, err := random.Layer(1024, types.DockerLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fpl := &fastpathLayer{randLayer}
+	ok, err := partial.Exists(fpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
+	}
+
+	ok, err = partial.Exists(randLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
 	}
 }

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -402,3 +402,23 @@ func (f *fetcher) headBlob(h v1.Hash) (*http.Response, error) {
 
 	return resp, nil
 }
+
+func (f *fetcher) blobExists(h v1.Hash) (bool, error) {
+	u := f.url("blobs", h.String())
+	req, err := http.NewRequest(http.MethodHead, u.String(), nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := f.Client.Do(req.WithContext(f.context))
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound); err != nil {
+		return false, err
+	}
+
+	return resp.StatusCode == http.StatusOK, nil
+}

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -223,12 +223,7 @@ func (rl *remoteImageLayer) Descriptor() (*v1.Descriptor, error) {
 
 // See partial.Exists.
 func (rl *remoteImageLayer) Exists() (bool, error) {
-	resp, err := rl.ri.headBlob(rl.digest)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-	return true, nil
+	return rl.ri.blobExists(rl.digest)
 }
 
 // LayerByDigest implements partial.CompressedLayer

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -221,6 +221,16 @@ func (rl *remoteImageLayer) Descriptor() (*v1.Descriptor, error) {
 	return partial.BlobDescriptor(rl, rl.digest)
 }
 
+// See partial.Exists.
+func (rl *remoteImageLayer) Exists() (bool, error) {
+	resp, err := rl.ri.headBlob(rl.digest)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	return true, nil
+}
+
 // LayerByDigest implements partial.CompressedLayer
 func (r *remoteImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
 	return &remoteImageLayer{

--- a/pkg/v1/remote/layer.go
+++ b/pkg/v1/remote/layer.go
@@ -59,10 +59,7 @@ func (rl *remoteLayer) MediaType() (types.MediaType, error) {
 
 // See partial.Exists.
 func (rl *remoteLayer) Exists() (bool, error) {
-	if _, err := rl.Size(); err != nil {
-		return false, err
-	}
-	return true, nil
+	return rl.blobExists(rl.digest)
 }
 
 // Layer reads the given blob reference from a registry as a Layer. A blob

--- a/pkg/v1/remote/layer.go
+++ b/pkg/v1/remote/layer.go
@@ -43,6 +43,7 @@ func (rl *remoteLayer) Size() (int64, error) {
 	if err != nil {
 		return -1, err
 	}
+	defer resp.Body.Close()
 	return resp.ContentLength, nil
 }
 
@@ -54,6 +55,14 @@ func (rl *remoteLayer) Digest() (v1.Hash, error) {
 // MediaType implements v1.Layer
 func (rl *remoteLayer) MediaType() (types.MediaType, error) {
 	return types.DockerLayer, nil
+}
+
+// See partial.Exists.
+func (rl *remoteLayer) Exists() (bool, error) {
+	if _, err := rl.Size(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // Layer reads the given blob reference from a registry as a Layer. A blob

--- a/pkg/v1/remote/layer_test.go
+++ b/pkg/v1/remote/layer_test.go
@@ -78,6 +78,12 @@ func TestRemoteLayer(t *testing.T) {
 	if err := validate.Layer(got); err != nil {
 		t.Errorf("validate.Layer: %v", err)
 	}
+
+	if ok, err := partial.Exists(got); err != nil {
+		t.Fatal(err)
+	} else if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
+	}
 }
 
 func TestRemoteLayerDescriptor(t *testing.T) {
@@ -133,5 +139,10 @@ func TestRemoteLayerDescriptor(t *testing.T) {
 
 	if got, want := desc.URLs[0], "example.com"; got != want {
 		t.Errorf("layer[0].urls[0] = %s != %s", got, want)
+	}
+	if ok, err := partial.Exists(layers[0]); err != nil {
+		t.Fatal(err)
+	} else if got, want := ok, true; got != want {
+		t.Errorf("Exists() = %t != %t", got, want)
 	}
 }

--- a/pkg/v1/remote/mount.go
+++ b/pkg/v1/remote/mount.go
@@ -34,6 +34,11 @@ func (ml *MountableLayer) Descriptor() (*v1.Descriptor, error) {
 	return partial.Descriptor(ml.Layer)
 }
 
+// Exists is a hack. See partial.Exists.
+func (ml *MountableLayer) Exists() (bool, error) {
+	return partial.Exists(ml.Layer)
+}
+
 // mountableImage wraps the v1.Layer references returned by the embedded v1.Image
 // in MountableLayer's so that remote.Write might attempt to mount them from their
 // source repository.

--- a/pkg/v1/validate/index.go
+++ b/pkg/v1/validate/index.go
@@ -27,10 +27,10 @@ import (
 )
 
 // Index validates that idx does not violate any invariants of the index format.
-func Index(idx v1.ImageIndex) error {
+func Index(idx v1.ImageIndex, opt ...Option) error {
 	errs := []string{}
 
-	if err := validateChildren(idx); err != nil {
+	if err := validateChildren(idx, opt...); err != nil {
 		errs = append(errs, fmt.Sprintf("validating children: %v", err))
 	}
 
@@ -48,7 +48,7 @@ type withLayer interface {
 	Layer(v1.Hash) (v1.Layer, error)
 }
 
-func validateChildren(idx v1.ImageIndex) error {
+func validateChildren(idx v1.ImageIndex, opt ...Option) error {
 	manifest, err := idx.IndexManifest()
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func validateChildren(idx v1.ImageIndex) error {
 			if err != nil {
 				return err
 			}
-			if err := Index(idx); err != nil {
+			if err := Index(idx, opt...); err != nil {
 				errs = append(errs, fmt.Sprintf("failed to validate index Manifests[%d](%s): %v", i, desc.Digest, err))
 			}
 			if err := validateMediaType(idx, desc.MediaType); err != nil {
@@ -73,7 +73,7 @@ func validateChildren(idx v1.ImageIndex) error {
 			if err != nil {
 				return err
 			}
-			if err := Image(img); err != nil {
+			if err := Image(img, opt...); err != nil {
 				errs = append(errs, fmt.Sprintf("failed to validate image Manifests[%d](%s): %v", i, desc.Digest, err))
 			}
 			if err := validateMediaType(img, desc.MediaType); err != nil {
@@ -86,7 +86,7 @@ func validateChildren(idx v1.ImageIndex) error {
 				if err != nil {
 					return fmt.Errorf("failed to get layer Manifests[%d]: %v", i, err)
 				}
-				if err := Layer(layer); err != nil {
+				if err := Layer(layer, opt...); err != nil {
 					lerr := fmt.Sprintf("failed to validate layer Manifests[%d](%s): %v", i, desc.Digest, err)
 					if desc.MediaType.IsDistributable() {
 						errs = append(errs, lerr)

--- a/pkg/v1/validate/layer.go
+++ b/pkg/v1/validate/layer.go
@@ -26,11 +26,24 @@ import (
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 )
 
 // Layer validates that the values return by its methods are consistent with the
 // contents returned by Compressed and Uncompressed.
-func Layer(layer v1.Layer) error {
+func Layer(layer v1.Layer, opt ...Option) error {
+	o := makeOptions(opt...)
+	if o.fast {
+		ok, err := partial.Exists(layer)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("layer does not exist")
+		}
+		return nil
+	}
+
 	cl, err := computeLayer(layer)
 	if err != nil {
 		return err

--- a/pkg/v1/validate/options.go
+++ b/pkg/v1/validate/options.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+// Option is a functional option for validate.
+type Option func(*options)
+
+type options struct {
+	fast bool
+}
+
+func makeOptions(opts ...Option) options {
+	opt := options{
+		fast: false,
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// Fast causes validate to skip reading and digesting layer bytes.
+func Fast(o *options) {
+	o.fast = true
+}


### PR DESCRIPTION
Fixes #838 

Add validate.Fast option
Add Exists to remote layers
Add Exists to layout
Add Exists to partial

Simplify some of our typechecking logic with unwrap().

Stop double-wrapping layoutImage layers.