### PR TITLE
Fix RunE error handling

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -43,6 +43,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 		Short:             short,
 		Run:               func(cmd *cobra.Command, _ []string) { cmd.Usage() },
 		DisableAutoGenTag: true,
+		SilenceUsage:      true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// TODO(jonjohnsonjr): crane.Verbose option?
 			if verbose {

--- a/cmd/crane/cmd/validate.go
+++ b/cmd/crane/cmd/validate.go
@@ -47,6 +47,7 @@ func NewCmdValidate(options *[]crane.Option) *cobra.Command {
 
 				if err := validate.Image(img); err != nil {
 					fmt.Printf("FAIL: %s: %v\n", flag, err)
+					return err
 				} else {
 					fmt.Printf("PASS: %s\n", flag)
 				}

--- a/cmd/crane/main.go
+++ b/cmd/crane/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/google/go-containerregistry/cmd/crane/cmd"
@@ -29,7 +28,6 @@ func init() {
 
 func main() {
 	if err := cmd.Root.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/google/go-containerregistry/cmd/crane/cmd"
@@ -62,7 +61,6 @@ func main() {
 	}
 
 	if err := root.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
crane validate should exit with a non-zero status code if validation
fails.

We should not double-print error messages, because RunE does that for
us.

Disable usage message on errors, as that obfuscates the error. Invalid
commands still print usage.