### PR TITLE
Fix install instructions for crane

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -14,7 +14,7 @@ Download [latest release](https://github.com/google/go-containerregistry/release
 Install manually:
 
 ```
-go install github.com/google/go-containerregistry/cmd/crane
+go install github.com/google/go-containerregistry/cmd/crane@latest
 ```
 
 ### Install via brew

--- a/cmd/gcrane/README.md
+++ b/cmd/gcrane/README.md
@@ -16,7 +16,7 @@ Download [latest release](https://github.com/google/go-containerregistry/release
 Install manually:
 
 ```
-go install github.com/google/go-containerregistry/cmd/gcrane
+go install github.com/google/go-containerregistry/cmd/gcrane@latest
 ```
 
 ## Commands


### PR DESCRIPTION
When running the specified command you get - 
```
$ go install github.com/google/go-containerregistry/cmd/crane                                                                                                                                                                  ✘ 127

go install: version is required when current directory is not in a module
	Try 'go install github.com/google/go-containerregistry/cmd/crane@latest' to install the latest version
```