### PR TITLE
update to add that crane retains the digest

### DIFF
--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -24,7 +24,7 @@ func NewCmdCopy(options *[]crane.Option) *cobra.Command {
 	return &cobra.Command{
 		Use:     "copy SRC DST",
 		Aliases: []string{"cp"},
-		Short:   "Efficiently copy a remote image from src to dst",
+		Short:   "Efficiently copy a remote image from src to dst while retaining the digest value",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -22,7 +22,7 @@ crane [flags]
 * [crane blob](crane_blob.md)	 - Read a blob from the registry
 * [crane catalog](crane_catalog.md)	 - List the repos in a registry
 * [crane config](crane_config.md)	 - Get the config of an image
-* [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst
+* [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst while retaining the digest value
 * [crane delete](crane_delete.md)	 - Delete an image reference from its registry
 * [crane digest](crane_digest.md)	 - Get the digest of an image
 * [crane export](crane_export.md)	 - Export contents of a remote image as a tarball

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -1,6 +1,6 @@
 ## crane copy
 
-Efficiently copy a remote image from src to dst
+Efficiently copy a remote image from src to dst while retaining the digest value
 
 ```
 crane copy SRC DST [flags]


### PR DESCRIPTION
Found about this little secret on [Knative Slack channel](https://knative.slack.com/archives/C93E33SN8/p1622662578076900) that `crane copy` retains the digest value when copying images
Very important to know for some uses cases around security and secure supply chain