### PR TITLE
Add retry when commiting a manifest

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -407,6 +407,24 @@ func (w *writer) incrProgress(written int64) {
 	}
 }
 
+var shouldRetry retry.Predicate = func(err error) bool {
+	// Various failure modes here, as we're often reading from and writing to
+	// the network.
+	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE) {
+		logs.Warn.Printf("retrying %v", err)
+		return true
+	}
+	return false
+}
+
+// Try this three times, waiting 1s after first failure, 3s after second.
+var backoff = retry.Backoff{
+	Duration: 1.0 * time.Second,
+	Factor:   3.0,
+	Jitter:   0.1,
+	Steps:    3,
+}
+
 // uploadOne performs a complete upload of a single layer.
 func (w *writer) uploadOne(l v1.Layer) error {
 	var from, mount string
@@ -436,16 +454,6 @@ func (w *writer) uploadOne(l v1.Layer) error {
 	}
 
 	ctx := w.context
-
-	shouldRetry := func(err error) bool {
-		// Various failure modes here, as we're often reading from and writing to
-		// the network.
-		if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE) {
-			logs.Warn.Printf("retrying %v", err)
-			return true
-		}
-		return false
-	}
 
 	tryUpload := func() error {
 		location, mounted, err := w.initiateUpload(from, mount)
@@ -496,14 +504,6 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		}
 		logs.Progress.Printf("pushed blob: %s", digest)
 		return nil
-	}
-
-	// Try this three times, waiting 1s after first failure, 3s after second.
-	backoff := retry.Backoff{
-		Duration: 1.0 * time.Second,
-		Factor:   3.0,
-		Jitter:   0.1,
-		Steps:    3,
 	}
 
 	return retry.Retry(tryUpload, shouldRetry, backoff)
@@ -616,34 +616,38 @@ func unpackTaggable(t Taggable) ([]byte, *v1.Descriptor, error) {
 
 // commitManifest does a PUT of the image's manifest.
 func (w *writer) commitManifest(t Taggable, ref name.Reference) error {
-	raw, desc, err := unpackTaggable(t)
-	if err != nil {
-		return err
+	tryUpload := func() error {
+		raw, desc, err := unpackTaggable(t)
+		if err != nil {
+			return err
+		}
+
+		u := w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.repo.RepositoryStr(), ref.Identifier()))
+
+		// Make the request to PUT the serialized manifest
+		req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewBuffer(raw))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", string(desc.MediaType))
+
+		resp, err := w.client.Do(req.WithContext(w.context))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if err := transport.CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted); err != nil {
+			return err
+		}
+
+		// The image was successfully pushed!
+		logs.Progress.Printf("%v: digest: %v size: %d", ref, desc.Digest, desc.Size)
+		w.incrProgress(int64(len(raw)))
+		return nil
 	}
 
-	u := w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.repo.RepositoryStr(), ref.Identifier()))
-
-	// Make the request to PUT the serialized manifest
-	req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewBuffer(raw))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", string(desc.MediaType))
-
-	resp, err := w.client.Do(req.WithContext(w.context))
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := transport.CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted); err != nil {
-		return err
-	}
-
-	// The image was successfully pushed!
-	logs.Progress.Printf("%v: digest: %v size: %d", ref, desc.Digest, desc.Size)
-	w.incrProgress(int64(len(raw)))
-	return nil
+	return retry.Retry(tryUpload, shouldRetry, backoff)
 }
 
 func scopesForUploadingImage(repo name.Repository, layers []v1.Layer) []string {


### PR DESCRIPTION
- only retry on certain 'temporary' http status codes
- add tests to ensure retries do not occur on 'non-temp' http status
codes. And to make sure progress bar still works when retrying

Attempts to fix: https://github.com/google/go-containerregistry/issues/1038


Note:
Running `hack/presubmit.sh` resulted in the following:

```
~/workspace/go-containerregistry/pkg/authn/k8schain ~/workspace/go-containerregistry ~/workspace/go-containerregistry
go: github.com/google/go-containerregistry@v0.5.2-0.20210601193515-0ffa4a5c8691 requires
        cloud.google.com/go@v0.83.0: missing go.sum entry; to add it:
        go mod download cloud.google.com/go
~/workspace/go-containerregistry ~/workspace/go-containerregistry
```

This seems to me unrelated to the change in the PR... tried to go mod download  `cloud.google.com/go` but it still complains.

Authored-by: Dennis Leon <leonde@vmware.com>