### PR TITLE
Verify size in verify.ReadCloser

### DIFF
--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -27,19 +27,24 @@ import (
 )
 
 type verifyReader struct {
-	inner    io.Reader
-	hasher   hash.Hash
-	expected v1.Hash
+	inner             io.Reader
+	hasher            hash.Hash
+	expected          v1.Hash
+	gotSize, wantSize int64
 }
 
 // Read implements io.Reader
 func (vc *verifyReader) Read(b []byte) (int, error) {
 	n, err := vc.inner.Read(b)
+	vc.gotSize += int64(n)
 	if err == io.EOF {
+		if vc.gotSize != vc.wantSize {
+			return n, fmt.Errorf("error verifying size; got %d, want %d", vc.gotSize, vc.wantSize)
+		}
 		got := hex.EncodeToString(vc.hasher.Sum(make([]byte, 0, vc.hasher.Size())))
 		if want := vc.expected.Hex; got != want {
-			return n, fmt.Errorf("error verifying %s checksum; got %q, want %q",
-				vc.expected.Algorithm, got, want)
+			return n, fmt.Errorf("error verifying %s checksum after reading %d bytes; got %q, want %q",
+				vc.expected.Algorithm, vc.gotSize, got, want)
 		}
 	}
 	return n, err
@@ -47,17 +52,22 @@ func (vc *verifyReader) Read(b []byte) (int, error) {
 
 // ReadCloser wraps the given io.ReadCloser to verify that its contents match
 // the provided v1.Hash before io.EOF is returned.
-func ReadCloser(r io.ReadCloser, h v1.Hash) (io.ReadCloser, error) {
+//
+// The reader will only be read up to size bytes, to prevent resource
+// exhaustion. If EOF is returned before size bytes are read, an error is
+// returned.
+func ReadCloser(r io.ReadCloser, size int64, h v1.Hash) (io.ReadCloser, error) {
 	w, err := v1.Hasher(h.Algorithm)
 	if err != nil {
 		return nil, err
 	}
-	r2 := io.TeeReader(r, w)
+	r2 := io.LimitReader(io.TeeReader(r, w), size)
 	return &and.ReadCloser{
 		Reader: &verifyReader{
 			inner:    r2,
 			hasher:   w,
 			expected: h,
+			wantSize: size,
 		},
 		CloseFunc: r.Close,
 	}, nil

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -334,10 +334,7 @@ func (f *fetcher) headManifest(ref name.Reference, acceptable []types.MediaType)
 	if lh == "" {
 		return nil, fmt.Errorf("HEAD %s: response did not include Content-Length header", u.String())
 	}
-	size, err := strconv.ParseInt(lh, 10, 64)
-	if err != nil {
-		return nil, err
-	}
+	size := resp.ContentLength
 
 	dh := resp.Header.Get("Docker-Content-Digest")
 	if dh == "" {

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/internal/verify"
@@ -330,11 +329,10 @@ func (f *fetcher) headManifest(ref name.Reference, acceptable []types.MediaType)
 	}
 	mediaType := types.MediaType(mth)
 
-	lh := resp.Header.Get("Content-Length")
-	if lh == "" {
-		return nil, fmt.Errorf("HEAD %s: response did not include Content-Length header", u.String())
-	}
 	size := resp.ContentLength
+	if size == -1 {
+		return nil, fmt.Errorf("GET %s: response did not include Content-Length header", u.String())
+	}
 
 	dh := resp.Header.Get("Docker-Content-Digest")
 	if dh == "" {
@@ -378,13 +376,9 @@ func (f *fetcher) fetchBlob(ctx context.Context, h v1.Hash) (io.ReadCloser, erro
 	}
 
 	// Verify up to the content-length header value.
-	lh := resp.Header.Get("Content-Length")
-	if lh == "" {
+	size := resp.ContentLength
+	if size == -1 {
 		return nil, fmt.Errorf("GET %s: response did not include Content-Length header", u.String())
-	}
-	size, err := strconv.ParseInt(lh, 10, 64)
-	if err != nil {
-		return nil, err
 	}
 
 	return verify.ReadCloser(resp.Body, size, h)

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -177,7 +177,7 @@ func (rl *remoteImageLayer) Compressed() (io.ReadCloser, error) {
 			continue
 		}
 
-		return verify.ReadCloser(resp.Body, rl.digest)
+		return verify.ReadCloser(resp.Body, d.Size, rl.digest)
 	}
 
 	return nil, lastErr


### PR DESCRIPTION
This prevents cases where a descriptor says it describes a 100-byte blob, but then serves 1TB blob, which could lead to resource exhaustion. Instead, we'll only read as many bytes as the descriptor claims there should be, and fail if the digest doesn't match after reading that many. This also verifies the content isn't shorter than described.

This adds a HEAD request to `remote.Layer` to fetch the size of the blob before reading and verifying it. If that's not acceptable we could work around it.