### PR TITLE
Create a k8schain directly from pull secrets

### DIFF
--- a/pkg/authn/k8schain/k8schain_test.go
+++ b/pkg/authn/k8schain/k8schain_test.go
@@ -184,7 +184,7 @@ func TestFromPullSecrets(t *testing.T) {
 	specificUser, specificPass := "very", "specific"
 
 	pullSecrets := []corev1.Secret{
-		corev1.Secret{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns",


### PR DESCRIPTION
The k8schain package creates a new keychain by resolving Kubernets
secrets from service accounts and other image pull secrets specified by
name. The k8s client gets the full secret content for these named
resources.

Sometimes it's desirable to pull the content of a secret from a cache,
or to watch a resource for changes in a controller. In this situation
it would be helpful to create a k8schain directly from resolved secrets,
without making calls to the k8s api server.

This change refactors the existing k8schain.New() method to separate the
resolution of secrets from the creation of the keychain. This is only a
refactoring of existing behavior to shortcut the k8s api lookups. There
is no change in existing behavior for the keychain.

Added:

    k8schain.NewFromPullSecrets(context.Context, []corev1.Secret) (authn.Keychain, error)

Signed-off-by: Scott Andrews <andrewssc@vmware.com>