### PR TITLE
ci: test/build with go 1.14/1.15/1.16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request: 
+  pull_request:
     branches: ['main']
 
 jobs:
@@ -10,11 +10,15 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x, 1.16.x]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: ${{ matrix.go-version }}
 
       - run: |
           go build ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
 
   test:
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x, 1.16.x]
+
     name: Unit Tests
     runs-on: ubuntu-latest
 
@@ -16,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: ${{ matrix.go-version }}
 
       - run: go test -coverprofile=coverage.txt -covermode=atomic -race ./...
 


### PR DESCRIPTION
Follow up on the comment: https://github.com/google/go-containerregistry/pull/943#issuecomment-824153837

we keep the go mod pinned to 1.14 but maybe we can test with 1.14/1.15/1.16 to make sure both three is green

/assign @jonjohnsonjr 