### PR TITLE
added support for overriding manifest annotations

### DIFF
--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -9,10 +9,11 @@ crane mutate [flags]
 ### Options
 
 ```
-      --entrypoint string   New entrypoing to set
-  -h, --help                help for mutate
-  -l, --label strings       New labels to add
-  -t, --tag string          New tag to apply to mutated image. If not provided, push by digest to the original image repository.
+  -a, --annotation strings   New annotations to add
+      --entrypoint string    New entrypoing to set
+  -h, --help                 help for mutate
+  -l, --label strings        New labels to add
+  -t, --tag string           New tag to apply to mutated image. If not provided, push by digest to the original image repository.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -30,12 +30,13 @@ type image struct {
 	base v1.Image
 	adds []Addendum
 
-	computed   bool
-	configFile *v1.ConfigFile
-	manifest   *v1.Manifest
-	mediaType  *types.MediaType
-	diffIDMap  map[v1.Hash]v1.Layer
-	digestMap  map[v1.Hash]v1.Layer
+	computed    bool
+	configFile  *v1.ConfigFile
+	manifest    *v1.Manifest
+	annotations map[string]string
+	mediaType   *types.MediaType
+	diffIDMap   map[v1.Hash]v1.Layer
+	digestMap   map[v1.Hash]v1.Layer
 }
 
 var _ v1.Image = (*image)(nil)
@@ -136,6 +137,16 @@ func (i *image) compute() error {
 			manifest.MediaType = ""
 		} else if strings.Contains(string(*i.mediaType), types.DockerVendorPrefix) {
 			manifest.MediaType = *i.mediaType
+		}
+	}
+
+	if i.annotations != nil {
+		if manifest.Annotations == nil {
+			manifest.Annotations = map[string]string{}
+		}
+
+		for k, v := range i.annotations {
+			manifest.Annotations[k] = v
 		}
 	}
 

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -113,6 +113,16 @@ func Config(base v1.Image, cfg v1.Config) (v1.Image, error) {
 	return ConfigFile(base, cf)
 }
 
+// Annotations mutates the provided v1.Image to have the provided annotations
+func Annotations(base v1.Image, annotations map[string]string) (v1.Image, error) {
+	image := &image{
+		base:        base,
+		annotations: annotations,
+	}
+
+	return image, nil
+}
+
 // ConfigFile mutates the provided v1.Image to have the provided v1.ConfigFile
 func ConfigFile(base v1.Image, cfg *v1.ConfigFile) (v1.Image, error) {
 	m, err := base.Manifest()

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -266,6 +266,27 @@ func TestMutateConfig(t *testing.T) {
 	}
 }
 
+func TestAnnotations(t *testing.T) {
+	source := sourceImage(t)
+
+	newAnnotations := map[string]string{
+		"im.the.first.annotation": "hello world",
+	}
+
+	result, err := mutate.Annotations(source, newAnnotations)
+	if err != nil {
+		t.Fatalf("failed to mutate annotations: %v", err)
+	}
+
+	if configDigestsAreEqual(t, source, result) {
+		t.Errorf("mutating the manifest annotations MUST mutate the config digest")
+	}
+
+	if err := validate.Image(result); err != nil {
+		t.Errorf("validate.Image() = %v", err)
+	}
+}
+
 func TestMutateCreatedAt(t *testing.T) {
 	source := sourceImage(t)
 	want := time.Now().Add(-2 * time.Minute)


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

Hello, this PR will add overriding manifest annotations support to crane's `mutate` command, it will work like the following picture:

![Screen Shot 2021-06-18 at 01 06 08](https://user-images.githubusercontent.com/16693043/122478052-61271d80-cfd1-11eb-979a-d9951700c08b.png)