### PR TITLE
Implement crane.Head

### DIFF
--- a/pkg/crane/digest.go
+++ b/pkg/crane/digest.go
@@ -39,7 +39,7 @@ func Digest(ref string, opt ...Option) (string, error) {
 		}
 		return digest.String(), nil
 	}
-	desc, err := head(ref, opt...)
+	desc, err := Head(ref, opt...)
 	if err != nil {
 		logs.Warn.Printf("HEAD request failed, falling back on GET: %v", err)
 		rdesc, err := getManifest(ref, opt...)

--- a/pkg/crane/get.go
+++ b/pkg/crane/get.go
@@ -44,7 +44,9 @@ func getManifest(r string, opt ...Option) (*remote.Descriptor, error) {
 	return remote.Get(ref, o.remote...)
 }
 
-func head(r string, opt ...Option) (*v1.Descriptor, error) {
+// Head performs a HEAD request for a manifest and returns a content descriptor
+// based on the registry's response.
+func Head(r string, opt ...Option) (*v1.Descriptor, error) {
 	o := makeOptions(opt...)
 	ref, err := name.ParseReference(r, o.name...)
 	if err != nil {


### PR DESCRIPTION
This returns a v1.Descriptor, so it's possible to detect the media type,
digest, and size of a remote artifact.