### PR TITLE
Handle multiple www-authenticate headers

### DIFF
--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -130,19 +130,19 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 
 func pickFromMultipleChallenges(challenges []authchallenge.Challenge) authchallenge.Challenge {
 
- 	// It might happen there are multiple www-authenticate headers, e.g. `Negotiate` and `Basic`.
- 	// Picking simply the first one could result eventually in `unrecognized challenge` error,
+	// It might happen there are multiple www-authenticate headers, e.g. `Negotiate` and `Basic`.
+	// Picking simply the first one could result eventually in `unrecognized challenge` error,
 	// that's why we're looping through the challenges in search for one that can be handled.
- 	allowedSchemes := []string{"basic", "bearer"}
+	allowedSchemes := []string{"basic", "bearer"}
 
- 	for _, wac := range challenges {
- 		currentScheme := strings.ToLower(wac.Scheme)
- 		for _, allowed := range allowedSchemes {
- 			if allowed == currentScheme {
- 				return wac
- 			}
- 		}
- 	}
+	for _, wac := range challenges {
+		currentScheme := strings.ToLower(wac.Scheme)
+		for _, allowed := range allowedSchemes {
+			if allowed == currentScheme {
+				return wac
+			}
+		}
+	}
 
- 	return challenges[0]
- }
+	return challenges[0]
+}

--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -108,8 +108,8 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 			}, nil
 		case http.StatusUnauthorized:
 			if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
-				// If we hit more than one, I'm not even sure what to do.
-				wac := challenges[0]
+				// If we hit more than one, let's try to find one that we know how to handle.
+				wac := pickFromMultipleChallenges(challenges)
 				return &pingResp{
 					challenge:  challenge(wac.Scheme).Canonical(),
 					parameters: wac.Parameters,
@@ -127,3 +127,23 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 	}
 	return nil, errors.New(strings.Join(errs, "; "))
 }
+
+func pickFromMultipleChallenges(challenges []authchallenge.Challenge) authchallenge.Challenge {
+
+ 	// It might happen there are multiple www-authenticate headers, e.g. `Negotiate` and `Basic`.
+ 	// Picking simply the first one could result eventually in `unrecognized challenge` error,
+	// that's why we're looping through the challenges in search for one that can be handled.
+ 	allowedSchemes := []string{"basic", "bearer"}
+ 	var wac authchallenge.Challenge
+
+ 	for _, wac := range challenges {
+ 		currentScheme := strings.ToLower(wac.Scheme)
+ 		for _, allowed := range allowedSchemes {
+ 			if allowed == currentScheme {
+ 				return wac
+ 			}
+ 		}
+ 	}
+
+ 	return wac
+ }

--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -134,7 +134,6 @@ func pickFromMultipleChallenges(challenges []authchallenge.Challenge) authchalle
  	// Picking simply the first one could result eventually in `unrecognized challenge` error,
 	// that's why we're looping through the challenges in search for one that can be handled.
  	allowedSchemes := []string{"basic", "bearer"}
- 	var wac authchallenge.Challenge
 
  	for _, wac := range challenges {
  		currentScheme := strings.ToLower(wac.Scheme)
@@ -145,5 +144,5 @@ func pickFromMultipleChallenges(challenges []authchallenge.Challenge) authchalle
  		}
  	}
 
- 	return wac
+ 	return challenges[0]
  }


### PR DESCRIPTION
It might happen there are multiple `www-authenticate` headers returned from a registry, e.g. `Negotiate` and `Basic`. In the current code, in such situation the first challenge would be picked with no further checks, which would result eventually in `unrecognized challenge` error failing the whole build, even though `Basic` challenge could be used instead. `pickFromMultipleChallenges` function was added to loop through the challenges in search for a supported one.