### PR TITLE
Avoid race in progress_test.go

### DIFF
--- a/pkg/v1/remote/progress_test.go
+++ b/pkg/v1/remote/progress_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -238,7 +239,10 @@ func TestMultiWrite_Progress_Retry(t *testing.T) {
 	// Set up a fake registry.
 	handler := registry.New()
 	numOfInternalServerErrors := 0
+	var mu sync.Mutex
 	registryThatFailsOnFirstUpload := http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
 		if strings.Contains(request.URL.Path, "/manifests/") && numOfInternalServerErrors < 1 {
 			numOfInternalServerErrors++
 			responseWriter.WriteHeader(500)


### PR DESCRIPTION
```
$ go test -race ./pkg/v1/remote -run=TestMultiWrite_Progress_Retry -count=10
ok  	github.com/google/go-containerregistry/pkg/v1/remote	60.598s
```