### PR TITLE
Straighten out remote.List{WithContext}

### DIFF
--- a/pkg/v1/remote/list_test.go
+++ b/pkg/v1/remote/list_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -110,8 +111,8 @@ func TestCancelledList(t *testing.T) {
 	}
 
 	_, err = ListWithContext(ctx, repo)
-	if want, got := context.Canceled, err; got != want {
-		t.Errorf("wanted %v got %v", want, got)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf(`unexpected error; want "context canceled", got %v`, err)
 	}
 }
 


### PR DESCRIPTION
`ListWithContext` is kinda gross when we also have `List(..., remote.WithContext(ctx)` -- let's deprecate it.

edit: the rest is no longer relevant, but useful for context:
~This led a test to fail because the /v2/ request fails on a cancelled context, which I think is good because we shouldn't ignore the provided context for that ping request. In fixing that, I wanted to make the test check for whether the error `errors.Is(context.Canceled)`, but that was stymied by `transport.NewTransportWithContext` losing that information when it does it's little multi-error thing.~

```
    list_test.go:115: error was not context.Canceled, got Get "https://127.0.0.1:60957/v2/": context canceled; Get "http://127.0.0.1:60957/v2/": context canceled
```
Gross.

So we have a couple options:
1. change the test to just search the error message for the string "context canceled" and keep the http fallback multierror logic from before (probably safest)
2. ~don't return multiple errors, maybe `if logs.Enabled(logs.Debug) { logs.Debug.Printf("failed https, falling back to http") }`~
3. ~drop this whole thing, `ListWithContext` is fine the way it is, and ignoring context to do the ping is fine.~