### PR TITLE
Add --set-base-image-annotations flag to crane append

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -63,7 +63,7 @@ func NewCmdAppend(options *[]crane.Option) *cobra.Command {
 				}
 				var baseName string
 				if _, ok := ref.(name.Tag); ok {
-					baseName = ref.String()
+					baseName = ref.Name()
 				}
 
 				baseDigest, err := base.Digest()

--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -61,13 +61,17 @@ func NewCmdAppend(options *[]crane.Option) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("parsing ref %q: %v", baseRef, err)
 				}
+				var baseName string
+				if _, ok := ref.(name.Tag); ok {
+					baseName = ref.String()
+				}
 
 				baseDigest, err := base.Digest()
 				if err != nil {
 					return err
 				}
 				img = mutate.Annotations(img, map[string]string{
-					specsv1.AnnotationBaseImageName:   ref.String(),
+					specsv1.AnnotationBaseImageName:   baseName,
 					specsv1.AnnotationBaseImageDigest: baseDigest.String(),
 				}).(v1.Image)
 			}
@@ -97,7 +101,7 @@ func NewCmdAppend(options *[]crane.Option) *cobra.Command {
 	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
 	appendCmd.Flags().StringSliceVarP(&newLayers, "new_layer", "f", []string{}, "Path to tarball to append to image")
 	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
-	appendCmd.Flags().BoolVar(&annotate, "annotate", false, "If true, annotate the resulting image as being based on the base image")
+	appendCmd.Flags().BoolVar(&annotate, "set-base-image-annotations", false, "If true, annotate the resulting image as being based on the base image")
 
 	appendCmd.MarkFlagRequired("new_tag")
 	appendCmd.MarkFlagRequired("new_layer")

--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -61,19 +61,18 @@ func NewCmdAppend(options *[]crane.Option) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("parsing ref %q: %v", baseRef, err)
 				}
-				var baseName string
-				if _, ok := ref.(name.Tag); ok {
-					baseName = ref.Name()
-				}
 
 				baseDigest, err := base.Digest()
 				if err != nil {
 					return err
 				}
-				img = mutate.Annotations(img, map[string]string{
-					specsv1.AnnotationBaseImageName:   baseName,
+				anns := map[string]string{
 					specsv1.AnnotationBaseImageDigest: baseDigest.String(),
-				}).(v1.Image)
+				}
+				if _, ok := ref.(name.Tag); ok {
+					anns[specsv1.AnnotationBaseImageName] = ref.Name()
+				}
+				img = mutate.Annotations(img, anns).(v1.Image)
 			}
 
 			if outFile != "" {

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -9,12 +9,12 @@ crane append [flags]
 ### Options
 
 ```
-      --annotate            If true, annotate the resulting image as being based on the base image
-  -b, --base string         Name of base image to append to
-  -h, --help                help for append
-  -f, --new_layer strings   Path to tarball to append to image
-  -t, --new_tag string      Tag to apply to resulting image
-  -o, --output string       Path to new tarball of resulting image
+  -b, --base string                  Name of base image to append to
+  -h, --help                         help for append
+  -f, --new_layer strings            Path to tarball to append to image
+  -t, --new_tag string               Tag to apply to resulting image
+  -o, --output string                Path to new tarball of resulting image
+      --set-base-image-annotations   If true, annotate the resulting image as being based on the base image
 ```
 
 ### Options inherited from parent commands

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -9,6 +9,7 @@ crane append [flags]
 ### Options
 
 ```
+      --annotate            If true, annotate the resulting image as being based on the base image
   -b, --base string         Name of base image to append to
   -h, --help                help for append
   -f, --new_layer strings   Path to tarball to append to image

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -537,10 +537,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2-0.20210708142037-083f635f2b04 h1:FAcfLZ/aXS6exuOySekrOT/GjKPt6988dxiF/ENj828=
-github.com/opencontainers/image-spec v1.0.2-0.20210708142037-083f635f2b04/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7 h1:axgApq2XShTLwQii2zAnIkMPlhGVHbAXHUcHezu5G/k=
 github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,10 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20210708142037-083f635f2b04 h1:FAcfLZ/aXS6exuOySekrOT/GjKPt6988dxiF/ENj828=
+github.com/opencontainers/image-spec v1.0.2-0.20210708142037-083f635f2b04/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7 h1:axgApq2XShTLwQii2zAnIkMPlhGVHbAXHUcHezu5G/k=
+github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
@@ -53,4 +53,10 @@ const (
 
 	// AnnotationDescription is the annotation key for the human-readable description of the software packaged in the image.
 	AnnotationDescription = "org.opencontainers.image.description"
+
+	// AnnotationBaseImageDigest is the annotation key for the digest of the image's base image.
+	AnnotationBaseImageDigest = "org.opencontainers.image.base.digest"
+
+	// AnnotationBaseImageName is the annotation key for the image reference of the image's base image.
+	AnnotationBaseImageName = "org.opencontainers.image.base.name"
 )

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -89,8 +89,19 @@ type Image struct {
 	// Architecture is the CPU architecture which the binaries in this image are built to run on.
 	Architecture string `json:"architecture"`
 
+	// Variant is the variant of the specified CPU architecture which image binaries are intended to run on.
+	Variant string `json:"variant,omitempty"`
+
 	// OS is the name of the operating system which the image is built to run on.
 	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -34,6 +34,10 @@ const (
 	// referenced by the manifest.
 	MediaTypeImageLayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
 
+	// MediaTypeImageLayerZstd is the media type used for zstd compressed
+	// layers referenced by the manifest.
+	MediaTypeImageLayerZstd = "application/vnd.oci.image.layer.v1.tar+zstd"
+
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
 	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar"
@@ -42,6 +46,11 @@ const (
 	// gzipped layers referenced by the manifest but with distribution
 	// restrictions.
 	MediaTypeImageLayerNonDistributableGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+
+	// MediaTypeImageLayerNonDistributableZstd is the media type for zstd
+	// compressed layers referenced by the manifest but with distribution
+	// restrictions.
+	MediaTypeImageLayerNonDistributableZstd = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/klauspost/compress/zstd/internal/xxhash
 ## explicit
 # github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/go-digest
-# github.com/opencontainers/image-spec v1.0.1
+# github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1


### PR DESCRIPTION
This flag instructs crane append to annotate the resulting image with
information about the base image (name and current digest). This flag is
false by default.