### PR TITLE
feat: ability to set page size for tags list and catalog calls

### DIFF
--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -91,9 +91,10 @@ func Catalog(ctx context.Context, target name.Registry, options ...Option) ([]st
 		Scheme: target.Scheme(),
 		Host:   target.RegistryStr(),
 		Path:   "/v2/_catalog",
-		// ECR returns an error if n > 1000:
-		// https://github.com/google/go-containerregistry/issues/1091
-		RawQuery: "n=1000",
+	}
+
+	if o.pageSize > 0 {
+		uri.RawQuery = fmt.Sprintf("n=%d", o.pageSize)
 	}
 
 	client := http.Client{Transport: tr}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -55,9 +55,10 @@ func List(repo name.Repository, options ...Option) ([]string, error) {
 		Scheme: repo.Registry.Scheme(),
 		Host:   repo.Registry.RegistryStr(),
 		Path:   fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
-		// ECR returns an error if n > 1000:
-		// https://github.com/google/go-containerregistry/issues/681
-		RawQuery: "n=1000",
+	}
+
+	if o.pageSize > 0 {
+		uri.RawQuery = fmt.Sprintf("n=%d", o.pageSize)
 	}
 
 	client := http.Client{Transport: tr}


### PR DESCRIPTION
I recently found that the GitHub Container Registry doesn't support pagination, so I'm limited to 1000 tags when using the library (rel https://github.community/t/pagination-when-listing-image-tags-does-not-work/194586).

I've added an option that allows disabling the default limit of 1000 tags when requesting image tags.