### PR TITLE
Add crane flatten

### DIFF
--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -1,0 +1,135 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdFlatten creates a new cobra.Command for the flatten subcommand.
+func NewCmdFlatten(options *[]crane.Option) *cobra.Command {
+	var newRef string
+
+	flattenCmd := &cobra.Command{
+		Use:   "flatten",
+		Short: "Flatten an image's layers into a single layer",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			// Pull image and get config.
+			ref := args[0]
+
+			desc, err := crane.Head(ref, *options...)
+			if err != nil {
+				log.Fatalf("checking %s: %v", ref, err)
+			}
+			if desc.MediaType.IsIndex() {
+				log.Fatalf("flattening an index is not yet supported")
+			}
+
+			old, err := crane.Pull(ref, *options...)
+			if err != nil {
+				log.Fatalf("pulling %s: %v", ref, err)
+			}
+
+			m, err := old.Manifest()
+			if err != nil {
+				log.Fatalf("reading manifest: %v", err)
+			}
+
+			cf, err := old.ConfigFile()
+			if err != nil {
+				log.Fatalf("getting config: %v", err)
+			}
+			cf = cf.DeepCopy()
+
+			oldHistory, err := json.Marshal(cf.History)
+			if err != nil {
+				log.Fatalf("marshal history")
+			}
+
+			// Clear layer-specific config file information.
+			cf.RootFS.DiffIDs = []v1.Hash{}
+			cf.History = []v1.History{}
+
+			img, err := mutate.ConfigFile(empty.Image, cf)
+			if err != nil {
+				log.Fatalf("mutating config: %v", err)
+			}
+
+			// TODO: Make compression configurable?
+			layer := stream.NewLayer(mutate.Extract(old), stream.WithCompressionLevel(gzip.BestCompression))
+
+			img, err = mutate.Append(img, mutate.Addendum{
+				Layer: layer,
+				History: v1.History{
+					CreatedBy: fmt.Sprintf("crane flatten %s", ref),
+					Comment:   string(oldHistory),
+				},
+			})
+			if err != nil {
+				log.Fatalf("appending layers: %v", err)
+			}
+
+			// Retain any annotations from the original image.
+			if len(m.Annotations) != 0 {
+				img = mutate.Annotations(img, m.Annotations).(v1.Image)
+			}
+
+			// If the new ref isn't provided, write over the original image.
+			// If that ref was provided by digest (e.g., output from
+			// another crane command), then strip that and push the
+			// mutated image by digest instead.
+			if newRef == "" {
+				newRef = ref
+			}
+			r, err := name.ParseReference(newRef)
+			if err != nil {
+				log.Fatalf("parsing %s: %v", newRef, err)
+			}
+			if _, ok := r.(name.Digest); ok {
+				// If we're pushing by digest, we need to upload the layer first.
+				if err := crane.Upload(layer, r.Context().String(), *options...); err != nil {
+					log.Fatalf("uploading layer: %v", err)
+				}
+				digest, err := img.Digest()
+				if err != nil {
+					log.Fatalf("digesting new image: %v", err)
+				}
+				newRef = r.Context().Digest(digest.String()).String()
+			}
+			if err := crane.Push(img, newRef, *options...); err != nil {
+				log.Fatalf("pushing %s: %v", newRef, err)
+			}
+			digest, err := img.Digest()
+			if err != nil {
+				log.Fatalf("digesting new image: %v", err)
+			}
+			fmt.Println(r.Context().Digest(digest.String()))
+		},
+	}
+	flattenCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to flattened image. If not provided, push by digest to the original image repository.")
+	return flattenCmd
+}

--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -105,7 +105,7 @@ func NewCmdFlatten(options *[]crane.Option) *cobra.Command {
 			img, err = mutate.Append(img, mutate.Addendum{
 				Layer: layer,
 				History: v1.History{
-					CreatedBy: fmt.Sprintf("crane flatten %s", ref),
+					CreatedBy: fmt.Sprintf("%s flatten %s", cmd.Parent().Use, desc.Digest),
 					Comment:   string(oldHistory),
 				},
 			})

--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -65,7 +65,7 @@ func NewCmdFlatten(options *[]crane.Option) *cobra.Command {
 			if err != nil {
 				log.Fatalf("checking %s: %v", ref, err)
 			}
-			if desc.MediaType.IsIndex() {
+			if !cmd.Parent().PersistentFlags().Changed("platform") && desc.MediaType.IsIndex() {
 				log.Fatalf("flattening an index is not yet supported")
 			}
 

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -93,6 +93,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 		NewCmdDelete(&options),
 		NewCmdDigest(&options),
 		NewCmdExport(&options),
+		NewCmdFlatten(&options),
 		NewCmdList(&options),
 		NewCmdManifest(&options),
 		NewCmdOptimize(&options),

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -26,6 +26,7 @@ crane [flags]
 * [crane delete](crane_delete.md)	 - Delete an image reference from its registry
 * [crane digest](crane_digest.md)	 - Get the digest of an image
 * [crane export](crane_export.md)	 - Export contents of a remote image as a tarball
+* [crane flatten](crane_flatten.md)	 - Flatten an image's layers into a single layer
 * [crane ls](crane_ls.md)	 - List the tags in a repo
 * [crane manifest](crane_manifest.md)	 - Get the manifest of an image
 * [crane mutate](crane_mutate.md)	 - Modify image labels and annotations

--- a/cmd/crane/doc/crane_flatten.md
+++ b/cmd/crane/doc/crane_flatten.md
@@ -1,0 +1,27 @@
+## crane flatten
+
+Flatten an image's layers into a single layer
+
+```
+crane flatten [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for flatten
+  -t, --tag string   New tag to apply to flattened image. If not provided, push by digest to the original image repository.
+```
+
+### Options inherited from parent commands
+
+```
+      --insecure            Allow image references to be fetched without TLS
+      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+  -v, --verbose             Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane](crane.md)	 - Crane is a tool for managing container images
+

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -210,6 +210,15 @@ func TestCraneRegistry(t *testing.T) {
 	if len(repos) != 2 {
 		t.Fatalf("wanted 2 repos, got %d", len(repos))
 	}
+
+	// Test pushing layer
+	layer, err = img.LayerByDigest(manifest.Layers[1].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crane.Upload(layer, dst); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCraneCopyIndex(t *testing.T) {
@@ -531,6 +540,7 @@ func TestBadInputs(t *testing.T) {
 		err  error
 	}{
 		{"Push(_, invalid)", crane.Push(nil, invalid)},
+		{"Upload(_, invalid)", crane.Upload(nil, invalid)},
 		{"Delete(invalid)", crane.Delete(invalid)},
 		{"Delete: 404", crane.Delete(valid404)},
 		{"Save(_, invalid)", crane.Save(nil, invalid, "")},

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -52,3 +52,14 @@ func Push(img v1.Image, dst string, opt ...Option) error {
 	}
 	return remote.Write(tag, img, o.remote...)
 }
+
+// Upload pushes the v1.Layer to a given repo.
+func Upload(layer v1.Layer, repo string, opt ...Option) error {
+	o := makeOptions(opt...)
+	ref, err := name.NewRepository(repo, o.name...)
+	if err != nil {
+		return fmt.Errorf("parsing repo %q: %v", repo, err)
+	}
+
+	return remote.WriteLayer(ref, layer, o.remote...)
+}


### PR DESCRIPTION
This is adapted from #735 but changes the UX a bit to match what we've come to expect from crane.

Add pkg/crane.Upload as well, for uploading a layer.

Closes https://github.com/google/go-containerregistry/pull/1103

---

```
$ crane manifest gcr.io/kaniko-project/executor | jq .
```
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 3707,
    "digest": "sha256:1c812ffa8ec16797474d59cdb7667439e6bc26eb6054f7257b9016bdbc452d11"
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 14219823,
      "digest": "sha256:94ed89128ee0d8b28f7cf724c516e51c041424c4bd5bb125fecfeeb76307eb9c"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 4523491,
      "digest": "sha256:a804545c4b2ee9188580e438a3b56db29aad1af748ec2ec0c3d1d5e5fc55b538"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 2964519,
      "digest": "sha256:0f9a0bccd2dc597ec892a7f3e255b14c7c1fd0800cd173f2126a2dda3e519f91"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 6563884,
      "digest": "sha256:5d7f42cbc20d9b6bcf306b4402940b4aabc0e655273ee6832814fcc99c3ebfee"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 357642,
      "digest": "sha256:16f9858f396996c895a2ad07bdca08f3ec724e5485688e3cda31f8c3fca014c5"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 153,
      "digest": "sha256:f5f0d1ae165026c9094a1fca5f5f9f488cd19fffb6d0d7a7bc94e8c486fab7ad"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 540,
      "digest": "sha256:cc48692dd99f82f2708b30beed23974456ff65c9b3c1b5394e17df7fd39460ac"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 132,
      "digest": "sha256:b9a35a76a8f42260e1a25d274acc94dedac2b8d85b117d428e8491b5ea526184"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 339,
      "digest": "sha256:f68c2840c45f74cc7e3fedc214f88ac76252fd1f5e6e16008fa01d74c08d8f85"
    }
  ]
}
```
```
$ crane flatten gcr.io/kaniko-project/executor -t gcr.io/jonjohnson-test/kaniko:flattened
2021/08/11 17:03:23 pushed blob: sha256:90a1ce29e3c1e97127cbd84238973006c669f79c4608974e4d23dd96dfaa246a
2021/08/11 17:03:25 pushed blob: sha256:748697bc98d140e2fef5aaac09361e65ee9ec230d0dd3860d42b991150d47e06
2021/08/11 17:03:26 gcr.io/jonjohnson-test/kaniko:flattened: digest: sha256:e55cacb041826deefc92f2740d3bc4742c8b9597e587efa43fa4b7fe89127f64 size: 429
gcr.io/jonjohnson-test/kaniko@sha256:e55cacb041826deefc92f2740d3bc4742c8b9597e587efa43fa4b7fe89127f64
```
```
$ crane manifest gcr.io/jonjohnson-test/kaniko:flattened | jq .
```
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 3419,
    "digest": "sha256:748697bc98d140e2fef5aaac09361e65ee9ec230d0dd3860d42b991150d47e06"
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 28533261,
      "digest": "sha256:90a1ce29e3c1e97127cbd84238973006c669f79c4608974e4d23dd96dfaa246a"
    }
  ]
}
```
Note that we preserve the original history in `comment` and what was flattened in the `created_by` comment. I'm not sure if we actually want to include the original image ref, or if we should just include the original image digest here to make this more reproducible.
```
$ crane config gcr.io/jonjohnson-test/kaniko:flattened | jq .
```
```json
{
  "architecture": "amd64",
  "created": "2021-05-19T20:00:47.261095682Z",
  "history": [
    {
      "created": "0001-01-01T00:00:00Z",
      "created_by": "crane flatten sha256:6ecc43ae139ad8cfa11604b592aaedddcabff8cef469eda303f1fb5afe5e3034",
      "comment": "[{\"created\":\"2021-05-19T20:00:46.895205234Z\",\"created_by\":\"COPY /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:46.929792602Z\",\"created_by\":\"COPY /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:46.958575143Z\",\"created_by\":\"COPY /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/docker-credential-ecr-login /kaniko/docker-credential-ecr-login # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:46.994104887Z\",\"created_by\":\"COPY /go/src/github.com/chrismellard/docker-credential-acr-env/build/docker-credential-acr-env /kaniko/docker-credential-acr # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.010924888Z\",\"created_by\":\"COPY /ca-certificates.crt /kaniko/ssl/certs/ # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.026599082Z\",\"created_by\":\"COPY /kaniko/.docker /kaniko/.docker # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.03965574Z\",\"created_by\":\"COPY files/nsswitch.conf /etc/nsswitch.conf # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV HOME=/root\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV USER=root\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV PATH=/usr/local/bin:/kaniko\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV SSL_CERT_DIR=/kaniko/ssl/certs\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV DOCKER_CONFIG=/kaniko/.docker/\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"ENV DOCKER_CREDENTIAL_GCR_CONFIG=/kaniko/.config/gcloud/docker_credential_gcr_config.json\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-05-19T20:00:47.051870289Z\",\"created_by\":\"WORKDIR /workspace\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.261095682Z\",\"created_by\":\"RUN docker-credential-gcr config --token-source=env # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"},{\"created\":\"2021-05-19T20:00:47.261095682Z\",\"created_by\":\"ENTRYPOINT [\\\"/kaniko/executor\\\"]\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true}]"
    }
  ],
  "os": "linux",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:67bf165867562b1841e1255e879e60340484743d8a3bceddb93c488c0379e0d1"
    ]
  },
  "config": {
    "Entrypoint": [
      "/kaniko/executor"
    ],
    "Env": [
      "PATH=/usr/local/bin:/kaniko",
      "HOME=/root",
      "USER=root",
      "SSL_CERT_DIR=/kaniko/ssl/certs",
      "DOCKER_CONFIG=/kaniko/.docker/",
      "DOCKER_CREDENTIAL_GCR_CONFIG=/kaniko/.config/gcloud/docker_credential_gcr_config.json"
    ],
    "WorkingDir": "/workspace"
  }
}
```

