### PR TITLE
Clean filepaths in mutate.Extract

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -263,6 +263,10 @@ func extract(img v1.Image, w io.Writer) error {
 				return fmt.Errorf("reading tar: %v", err)
 			}
 
+			// Some tools prepend everything with "./", so if we don't Clean the
+			// name, we may have duplicate entries, which angers tar-split.
+			header.Name = filepath.Clean(header.Name)
+
 			basename := filepath.Base(header.Name)
 			dirname := filepath.Dir(header.Name)
 			tombstone := strings.HasPrefix(basename, whiteoutPrefix)


### PR DESCRIPTION
When flattening a filesystem, we have to clean filepaths so that
we don't have duplicate filepaths in the resulting image, as per the OCI
spec (and tar-split throwing a fit if we don't do this).