### PR TITLE
Feat(crane) support push tarball contains more than one image

### DIFF
--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -41,7 +41,7 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 			}
 			images, err := crane.LoadMulti(path, *options...)
 			if err != nil {
-				return fmt.Errorf("loading %s as tarball: %#v", path, err)
+				return fmt.Errorf("loading %s as tarball: %v", path, err)
 			}
 			return crane.MultiPush(images, target, concurrent, *options...)
 		},

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -35,7 +35,7 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 			if strings.Contains(target, "/") {
 				image, err := crane.Load(path, *options...)
 				if err != nil {
-					return fmt.Errorf("loading %s as tarball: %#v", path, err)
+					return fmt.Errorf("loading %s as tarball: %v", path, err)
 				}
 				return crane.Push(image, target, *options...)
 			}

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -16,16 +16,23 @@ package crane
 
 import (
 	"fmt"
-
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"sync"
 )
 
 // Load reads the tarball at path as a v1.Image.
 func Load(path string, opt ...Option) (v1.Image, error) {
 	return LoadTag(path, "")
+}
+
+// LoadMulti read the tarball from path as a map[name.Tag]v1.Image
+func LoadMulti(path string, opt ...Option) (map[name.Reference]v1.Image, error) {
+	o := makeOptions(opt...)
+	return tarball.MultiImageFromPath(path, o.name...)
 }
 
 // LoadTag reads a tag from the tarball at path as a v1.Image.
@@ -51,6 +58,63 @@ func Push(img v1.Image, dst string, opt ...Option) error {
 		return fmt.Errorf("parsing reference %q: %v", dst, err)
 	}
 	return remote.Write(tag, img, o.remote...)
+}
+
+// MultiPush pushes the map[name.Reference]v1.Image to a registry as dst.
+func MultiPush(images map[name.Reference]v1.Image, dst string, concurrent int, opt ...Option) error {
+	var wg sync.WaitGroup
+	parallelsChan := make(chan bool, concurrent)
+	resChan := make(chan pushResult)
+	total := len(images)
+	fmt.Printf("invoke MultiPush for totally %d images\n", total)
+	current := 1
+	go func() {
+		for res := range resChan {
+			if res.err == nil {
+				fmt.Printf("INFO [%d/%d] push image %s/%s Successfully!\n", current, total, dst, res.image)
+				current++
+				continue
+			}
+			fmt.Printf("push image [%s] to registry error: %s\n", res.image, res.err)
+		}
+	}()
+	for t, i := range images {
+		parallelsChan <- true
+		wg.Add(1)
+		var target string
+		if tag, ok := t.(name.Tag); ok {
+			target = fmt.Sprintf("%s/%s:%s", target, tag.RepositoryStr(), tag.TagStr())
+		}
+		if digest, ok := t.(name.Digest); ok {
+			target = fmt.Sprintf("%s/%s:i-was-a-digest@%s", target, digest.RepositoryStr(), digest.DigestStr())
+		}
+		if target == "" {
+			logs.Progress.Fatalf("error type for name.Reference %T", t)
+		}
+		go writeHelper(&wg, parallelsChan, resChan, target, i, opt...)
+	}
+	wg.Wait()
+	return nil
+}
+
+type pushResult struct {
+	err   error
+	image string
+}
+
+func writeHelper(wg *sync.WaitGroup, concurrency chan bool, resCh chan pushResult, dst string, img v1.Image, options ...Option) {
+	o := makeOptions(options...)
+	tag, err := name.ParseReference(dst, o.name...)
+	if err != nil {
+		panic(err)
+	}
+	res := pushResult{image: dst}
+	defer func() {
+		resCh <- res
+		wg.Done()
+		<-concurrency
+	}()
+	res.err = remote.Write(tag, img, o.remote...)
 }
 
 // Upload pushes the v1.Layer to a given repo.

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -66,16 +66,16 @@ func MultiPush(images map[name.Reference]v1.Image, dst string, concurrent int, o
 	parallelsChan := make(chan bool, concurrent)
 	resChan := make(chan pushResult)
 	total := len(images)
-	fmt.Printf("invoke MultiPush for totally %d images\n", total)
+	logs.Progress.Printf("pushing totally %d images\n", total)
 	current := 1
 	go func() {
 		for res := range resChan {
 			if res.err == nil {
-				fmt.Printf("INFO [%d/%d] push image %s/%s Successfully!\n", current, total, dst, res.image)
+				logs.Progress.Printf("INFO [%d/%d] push image %s/%s Successfully!\n", current, total, dst, res.image)
 				current++
 				continue
 			}
-			fmt.Printf("push image [%s] to registry error: %s\n", res.image, res.err)
+			logs.Progress.Printf("push image [%s] to registry error: %s\n", res.image, res.err)
 		}
 	}()
 	for t, i := range images {

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -138,15 +138,19 @@ func MultiImage(opener Opener, opt ...name.Option) (map[name.Reference]v1.Image,
 		if len(manifest.RepoTags) < 1 {
 			return nil, fmt.Errorf("no any repo tags in manifest config %s", manifest.Config)
 		}
-		tag, err := name.ParseReference(manifest.RepoTags[0], opt...)
+		ref, err := name.ParseReference(manifest.RepoTags[0], opt...)
 		if err != nil {
 			return nil, err
 		}
-		v1Image, err := Image(opener, nil)
+		t, _ := name.NewTag(ref.String())
 		if err != nil {
 			return nil, err
 		}
-		out[tag] = v1Image
+		v1Image, err := Image(opener, &t)
+		if err != nil {
+			return nil, err
+		}
+		out[ref] = v1Image
 	}
 	return out, nil
 }


### PR DESCRIPTION
[Issue here: Support crane push tarBall contains more than one image?](https://github.com/google/go-containerregistry/issues/1109)
This is my first contribution to the open source repo. Bear with me 🥺 .

- [x] add command mpush for pushing tarball contains more than one image
- [x] merge command mpush and command push

.....Please don't hesitate to ask any questions that may exist