### PR TITLE
feat(daemon): lazy image saving

### DIFF
--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -185,5 +185,5 @@ func (i image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
-	return i.tarballImage.LayerByDigest(h)
+	return i.tarballImage.LayerByDiffID(h)
 }

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -24,7 +24,14 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+type image struct {
+	ref          name.Reference
+	opener       *imageOpener
+	tarballImage v1.Image
+}
 
 type imageOpener struct {
 	ref name.Reference
@@ -85,5 +92,98 @@ func Image(ref name.Reference, options ...Option) (v1.Image, error) {
 		ctx:      o.ctx,
 	}
 
-	return tarball.Image(i.opener(), nil)
+	return &image{
+		ref:    ref,
+		opener: i,
+	}, nil
+}
+
+func (i *image) initialize() error {
+	// Don't re-initialize tarball if already initialized.
+	if i.tarballImage == nil {
+		var err error
+		i.tarballImage, err = tarball.Image(i.opener.opener(), nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *image) Layers() ([]v1.Layer, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.Layers()
+}
+
+func (i image) MediaType() (types.MediaType, error) {
+	if err := i.initialize(); err != nil {
+		return "", err
+	}
+	return i.tarballImage.MediaType()
+}
+
+func (i *image) Size() (int64, error) {
+	if err := i.initialize(); err != nil {
+		return 0, err
+	}
+	return i.tarballImage.Size()
+}
+
+func (i *image) ConfigName() (v1.Hash, error) {
+	res, _, err := i.opener.client.ImageInspectWithRaw(i.opener.ctx, i.ref.String())
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return v1.NewHash(res.ID)
+}
+
+func (i image) ConfigFile() (*v1.ConfigFile, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.ConfigFile()
+}
+
+func (i image) RawConfigFile() ([]byte, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.RawConfigFile()
+}
+
+func (i image) Digest() (v1.Hash, error) {
+	if err := i.initialize(); err != nil {
+		return v1.Hash{}, err
+	}
+	return i.tarballImage.Digest()
+}
+
+func (i image) Manifest() (*v1.Manifest, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.Manifest()
+}
+
+func (i image) RawManifest() ([]byte, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.RawManifest()
+}
+
+func (i image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.LayerByDigest(h)
+}
+
+func (i image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
+	if err := i.initialize(); err != nil {
+		return nil, err
+	}
+	return i.tarballImage.LayerByDigest(h)
 }

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-containerregistry/internal/compare"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
 
 var imagePath = "../tarball/testdata/test_image_1.tar"
@@ -124,6 +125,15 @@ func TestImage(t *testing.T) {
 			if err != nil {
 				if tc.wantErr == "" {
 					t.Errorf("compare.Images: %v", err)
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("wanted %s to contain %s", err.Error(), tc.wantErr)
+				}
+			}
+
+			err = validate.Image(dmn)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Errorf("validate.Image: %v", err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
 					t.Errorf("wanted %s to contain %s", err.Error(), tc.wantErr)
 				}

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/google/go-containerregistry/internal/compare"
 	"github.com/google/go-containerregistry/pkg/name"
-
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
@@ -60,6 +60,12 @@ func (m *MockClient) ImageSave(_ context.Context, _ []string) (io.ReadCloser, er
 	}
 
 	return m.saveBody, m.saveErr
+}
+
+func (m *MockClient) ImageInspectWithRaw(context.Context, string) (types.ImageInspect, []byte, error) {
+	return types.ImageInspect{
+		ID: "sha256:6e0b05049ed9c17d02e1a55e80d6599dbfcce7f4f4b022e3c673e685789c470e",
+	}, nil, nil
 }
 
 func TestImage(t *testing.T) {
@@ -114,8 +120,13 @@ func TestImage(t *testing.T) {
 				}
 				return
 			}
-			if err := compare.Images(img, dmn); err != nil {
-				t.Errorf("compare.Images: %v", err)
+			err = compare.Images(img, dmn)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Errorf("compare.Images: %v", err)
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("wanted %s to contain %s", err.Error(), tc.wantErr)
+				}
 			}
 		}
 

--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -99,4 +99,5 @@ type Client interface {
 	ImageSave(context.Context, []string) (io.ReadCloser, error)
 	ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error)
 	ImageTag(context.Context, string, string) error
+	ImageInspectWithRaw(context.Context, string) (types.ImageInspect, []byte, error)
 }


### PR DESCRIPTION
Fix https://github.com/google/go-containerregistry/issues/627

A faster way of getting an image ID is really useful for caching. We don't want to call `docker save` if we already have the image information in the cache. For example, in our case, we should skip scanning vulnerabilities of the image when the scan result exists in the cache. The cache key is an image ID, so it is enough to call `docker inspect` to know only the image ID.

This implementation is based on `computed()` as below.
https://github.com/google/go-containerregistry/blob/45aaa6c000ebf2acacad9beef7c82667ec51662c/pkg/v1/mutate/image.go#L51

The downside is that `daemon.Image` doesn't return an error and it might return an error when each method is called (https://github.com/knqyf263/go-containerregistry/commit/881e16e70fdf797d2b68b2e5267639d4dafaca8c).

I probably should add tests, but I'd like to hear your thought on this idea before working on tests 🙇 

I also want to replace `ConfigFile` with this approach in another PR because I think we can generate the config file from the result of `docker inspect` and `docker history`.