### PR TITLE
Make retrying transport and http errors configurable 

### DIFF
--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -57,19 +57,21 @@ func newLister(repo name.Repository, options ...Option) (*lister, error) {
 		}
 	}
 
-	// Wrap the transport in something that logs requests and responses.
-	// It's expensive to generate the dumps, so skip it if we're writing
-	// to nothing.
-	if logs.Enabled(logs.Debug) {
-		l.transport = transport.NewLogger(l.transport)
-	}
+	if _, ok := l.transport.(*transport.Transport); ok {
+		// Wrap the transport in something that logs requests and responses.
+		// It's expensive to generate the dumps, so skip it if we're writing
+		// to nothing.
+		if logs.Enabled(logs.Debug) {
+			l.transport = transport.NewLogger(l.transport)
+		}
 
-	// Wrap the transport in something that can retry network flakes.
-	l.transport = transport.NewRetry(l.transport)
+		// Wrap the transport in something that can retry network flakes.
+		l.transport = transport.NewRetry(l.transport)
 
-	// Wrap this last to prevent transport.New from double-wrapping.
-	if l.userAgent != "" {
-		l.transport = transport.NewUserAgent(l.transport, l.userAgent)
+		// Wrap this last to prevent transport.New from double-wrapping.
+		if l.userAgent != "" {
+			l.transport = transport.NewUserAgent(l.transport, l.userAgent)
+		}
 	}
 
 	scopes := []string{repo.Scope(transport.PullScope)}

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -57,7 +57,9 @@ func newLister(repo name.Repository, options ...Option) (*lister, error) {
 		}
 	}
 
-	if _, ok := l.transport.(*transport.Transport); !ok {
+	// transport.Wrapper is a signal that consumers are opt-ing into providing their own transport without any additional wrapping.
+	// This is to allow consumers full control over the transports logic, such as providing retry logic.
+	if _, ok := l.transport.(*transport.Wrapper); !ok {
 		// Wrap the transport in something that logs requests and responses.
 		// It's expensive to generate the dumps, so skip it if we're writing
 		// to nothing.

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -57,7 +57,7 @@ func newLister(repo name.Repository, options ...Option) (*lister, error) {
 		}
 	}
 
-	if _, ok := l.transport.(*transport.Transport); ok {
+	if _, ok := l.transport.(*transport.Transport); !ok {
 		// Wrap the transport in something that logs requests and responses.
 		// It's expensive to generate the dumps, so skip it if we're writing
 		// to nothing.

--- a/pkg/v1/remote/multi_write.go
+++ b/pkg/v1/remote/multi_write.go
@@ -91,6 +91,8 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 		context:    o.context,
 		updates:    o.updates,
 		lastUpdate: &v1.Update{},
+		backoff:    o.retryBackoff,
+		predicate:  o.retryPredicate,
 	}
 
 	// Collect the total size of blobs and manifests we're about to write.

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -118,7 +118,7 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		}
 
 		// Wrap the transport in something that can retry network flakes.
-		o.transport = transport.NewRetry(o.transport, transport.WithRetryBackoff(o.retryBackoff), transport.WithRetryPredicate(o.retryPredicate))
+		o.transport = transport.NewRetry(o.transport)
 
 		// Wrap this last to prevent transport.New from double-wrapping.
 		if o.userAgent != "" {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -17,8 +17,12 @@ package remote
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"syscall"
+	"time"
 
+	"github.com/google/go-containerregistry/internal/retry"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -39,11 +43,34 @@ type options struct {
 	allowNondistributableArtifacts bool
 	updates                        chan<- v1.Update
 	pageSize                       int
+	retryBackoff                   Backoff
+	retryPredicate                 retry.Predicate
 }
 
 var defaultPlatform = v1.Platform{
 	Architecture: "amd64",
 	OS:           "linux",
+}
+
+// Backoff is an alias of retry.Backoff to expose this configuration option to consumers of this lib
+type Backoff = retry.Backoff
+
+var defaultRetryPredicate retry.Predicate = func(err error) bool {
+	// Various failure modes here, as we're often reading from and writing to
+	// the network.
+	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE) {
+		logs.Warn.Printf("retrying %v", err)
+		return true
+	}
+	return false
+}
+
+// Try this three times, waiting 1s after first failure, 3s after second.
+var defaultRetryBackoff = Backoff{
+	Duration: 1.0 * time.Second,
+	Factor:   3.0,
+	Jitter:   0.1,
+	Steps:    3,
 }
 
 const (
@@ -56,12 +83,14 @@ const (
 
 func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 	o := &options{
-		auth:      authn.Anonymous,
-		transport: http.DefaultTransport,
-		platform:  defaultPlatform,
-		context:   context.Background(),
-		jobs:      defaultJobs,
-		pageSize:  defaultPageSize,
+		auth:           authn.Anonymous,
+		transport:      http.DefaultTransport,
+		platform:       defaultPlatform,
+		context:        context.Background(),
+		jobs:           defaultJobs,
+		pageSize:       defaultPageSize,
+		retryPredicate: defaultRetryPredicate,
+		retryBackoff:   defaultRetryBackoff,
 	}
 
 	for _, option := range opts {
@@ -87,7 +116,7 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		}
 
 		// Wrap the transport in something that can retry network flakes.
-		o.transport = transport.NewRetry(o.transport)
+		o.transport = transport.NewRetry(o.transport, transport.WithRetryBackoff(o.retryBackoff), transport.WithRetryPredicate(o.retryPredicate))
 
 		// Wrap this last to prevent transport.New from double-wrapping.
 		if o.userAgent != "" {
@@ -211,6 +240,22 @@ func WithProgress(updates chan<- v1.Update) Option {
 func WithPageSize(size int) Option {
 	return func(o *options) error {
 		o.pageSize = size
+		return nil
+	}
+}
+
+// WithRetryBackoff sets the httpBackoff for retry HTTP operations.
+func WithRetryBackoff(backoff Backoff) Option {
+	return func(o *options) error {
+		o.retryBackoff = backoff
+		return nil
+	}
+}
+
+// WithRetryPredicate sets the predicate for retry HTTP operations.
+func WithRetryPredicate(predicate retry.Predicate) Option {
+	return func(o *options) error {
+		o.retryPredicate = predicate
 		return nil
 	}
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -107,7 +107,9 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		o.auth = auth
 	}
 
-	if _, ok := o.transport.(*transport.Transport); !ok {
+	// transport.Wrapper is a signal that consumers are opt-ing into providing their own transport without any additional wrapping.
+	// This is to allow consumers full control over the transports logic, such as providing retry logic.
+	if _, ok := o.transport.(*transport.Wrapper); !ok {
 		// Wrap the transport in something that logs requests and responses.
 		// It's expensive to generate the dumps, so skip it if we're writing
 		// to nothing.
@@ -129,6 +131,8 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 
 // WithTransport is a functional option for overriding the default transport
 // for remote operations.
+// If transport.Wrapper is provided, this signals that the consumer does *not* want any further wrapping to occur.
+// i.e. logging, retry and useragent
 //
 // The default transport its http.DefaultTransport.
 func WithTransport(t http.RoundTripper) Option {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -78,7 +78,7 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		o.auth = auth
 	}
 
-	if _, ok := o.transport.(*transport.Transport); ok {
+	if _, ok := o.transport.(*transport.Transport); !ok {
 		// Wrap the transport in something that logs requests and responses.
 		// It's expensive to generate the dumps, so skip it if we're writing
 		// to nothing.

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -78,19 +78,21 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		o.auth = auth
 	}
 
-	// Wrap the transport in something that logs requests and responses.
-	// It's expensive to generate the dumps, so skip it if we're writing
-	// to nothing.
-	if logs.Enabled(logs.Debug) {
-		o.transport = transport.NewLogger(o.transport)
-	}
+	if _, ok := o.transport.(*transport.Transport); ok {
+		// Wrap the transport in something that logs requests and responses.
+		// It's expensive to generate the dumps, so skip it if we're writing
+		// to nothing.
+		if logs.Enabled(logs.Debug) {
+			o.transport = transport.NewLogger(o.transport)
+		}
 
-	// Wrap the transport in something that can retry network flakes.
-	o.transport = transport.NewRetry(o.transport)
+		// Wrap the transport in something that can retry network flakes.
+		o.transport = transport.NewRetry(o.transport)
 
-	// Wrap this last to prevent transport.New from double-wrapping.
-	if o.userAgent != "" {
-		o.transport = transport.NewUserAgent(o.transport, o.userAgent)
+		// Wrap this last to prevent transport.New from double-wrapping.
+		if o.userAgent != "" {
+			o.transport = transport.NewUserAgent(o.transport, o.userAgent)
+		}
 	}
 
 	return o, nil

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -46,10 +46,10 @@ type Error struct {
 	Errors []Diagnostic `json:"errors,omitempty"`
 	// The http status code returned.
 	StatusCode int
+	// The request that failed.
+	Request *http.Request
 	// The raw body if we couldn't understand it.
 	rawBody string
-	// The request that failed.
-	request *http.Request
 }
 
 // Check that Error implements error
@@ -58,8 +58,8 @@ var _ error = (*Error)(nil)
 // Error implements error
 func (e *Error) Error() string {
 	prefix := ""
-	if e.request != nil {
-		prefix = fmt.Sprintf("%s %s: ", e.request.Method, redactURL(e.request.URL))
+	if e.Request != nil {
+		prefix = fmt.Sprintf("%s %s: ", e.Request.Method, redactURL(e.Request.URL))
 	}
 	return prefix + e.responseErr()
 }
@@ -68,7 +68,7 @@ func (e *Error) responseErr() string {
 	switch len(e.Errors) {
 	case 0:
 		if len(e.rawBody) == 0 {
-			if e.request != nil && e.request.Method == http.MethodHead {
+			if e.Request != nil && e.Request.Method == http.MethodHead {
 				return fmt.Sprintf("unexpected status code %d %s (HEAD responses have no body, use GET for details)", e.StatusCode, http.StatusText(e.StatusCode))
 			}
 			return fmt.Sprintf("unexpected status code %d %s", e.StatusCode, http.StatusText(e.StatusCode))
@@ -194,7 +194,7 @@ func CheckError(resp *http.Response, codes ...int) error {
 
 	structuredError.rawBody = string(b)
 	structuredError.StatusCode = resp.StatusCode
-	structuredError.request = resp.Request
+	structuredError.Request = resp.Request
 
 	return structuredError
 }

--- a/pkg/v1/remote/transport/logger.go
+++ b/pkg/v1/remote/transport/logger.go
@@ -55,7 +55,7 @@ func (t *logTransport) RoundTrip(in *http.Request) (out *http.Response, err erro
 	if err == nil {
 		logs.Debug.Println(string(b))
 	} else {
-		logs.Debug.Printf("Failed to dump Request %s %s: %v", in.Method, in.URL, err)
+		logs.Debug.Printf("Failed to dump request %s %s: %v", in.Method, in.URL, err)
 	}
 
 	// Restore the non-redacted headers.

--- a/pkg/v1/remote/transport/logger.go
+++ b/pkg/v1/remote/transport/logger.go
@@ -55,7 +55,7 @@ func (t *logTransport) RoundTrip(in *http.Request) (out *http.Response, err erro
 	if err == nil {
 		logs.Debug.Println(string(b))
 	} else {
-		logs.Debug.Printf("Failed to dump request %s %s: %v", in.Method, in.URL, err)
+		logs.Debug.Printf("Failed to dump Request %s %s: %v", in.Method, in.URL, err)
 	}
 
 	// Restore the non-redacted headers.

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -49,12 +49,6 @@ type options struct {
 // Backoff is an alias of retry.Backoff to expose this configuration option to consumers of this lib
 type Backoff = retry.Backoff
 
-// Temporary is implemented by several errors in the net package as well as our
-// transport.Error
-type Temporary interface {
-	Temporary() bool
-}
-
 // WithRetryBackoff sets the backoff for retry operations.
 func WithRetryBackoff(backoff Backoff) Option {
 	return func(o *options) {

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -49,7 +49,7 @@ type options struct {
 // Backoff is an alias of retry.Backoff to expose this configuration option to consumers of this lib
 type Backoff = retry.Backoff
 
-// This is implemented by several errors in the net package as well as our
+// Temporary is implemented by several errors in the net package as well as our
 // transport.Error
 type Temporary interface {
 	Temporary() bool

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -46,8 +46,17 @@ type options struct {
 	predicate retry.Predicate
 }
 
+// Backoff is an alias of retry.Backoff to expose this configuration option to consumers of this lib
+type Backoff = retry.Backoff
+
+// This is implemented by several errors in the net package as well as our
+// transport.Error
+type Temporary interface {
+	Temporary() bool
+}
+
 // WithRetryBackoff sets the backoff for retry operations.
-func WithRetryBackoff(backoff retry.Backoff) Option {
+func WithRetryBackoff(backoff Backoff) Option {
 	return func(o *options) {
 		o.backoff = backoff
 	}

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -101,3 +101,12 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 		return nil, fmt.Errorf("unrecognized challenge: %s", pr.challenge)
 	}
 }
+
+// Transport results in wrapping supplied transport with additional logic such as retries, useragent and debug logging
+type Transport struct {
+	inner http.RoundTripper
+}
+
+func (t *Transport) RoundTrip(in *http.Request) (*http.Response, error) {
+	return t.inner.RoundTrip(in)
+}

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -107,6 +107,7 @@ type Transport struct {
 	inner http.RoundTripper
 }
 
+// RoundTrip delegates to the inner RoundTripper
 func (t *Transport) RoundTrip(in *http.Request) (*http.Response, error) {
 	return t.inner.RoundTrip(in)
 }

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -105,10 +105,10 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 // Wrapper results in *not* wrapping supplied transport with additional logic such as retries, useragent and debug logging
 // Consumers are opt-ing into providing their own transport without any additional wrapping.
 type Wrapper struct {
-	Inner http.RoundTripper
+	inner http.RoundTripper
 }
 
 // RoundTrip delegates to the inner RoundTripper
 func (w *Wrapper) RoundTrip(in *http.Request) (*http.Response, error) {
-	return w.Inner.RoundTrip(in)
+	return w.inner.RoundTrip(in)
 }

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -102,7 +102,8 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 	}
 }
 
-// Transport results in wrapping supplied transport with additional logic such as retries, useragent and debug logging
+// Transport results in *not* wrapping supplied transport with additional logic such as retries, useragent and debug logging
+// Consumers are opt-ing into providing their own transport without any additional wrapping.
 type Transport struct {
 	inner http.RoundTripper
 }

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -69,9 +69,9 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 
 	switch pr.challenge.Canonical() {
 	case anonymous:
-		return t, nil
+		return &Wrapper{t}, nil
 	case basic:
-		return &basicTransport{inner: t, auth: auth, target: reg.RegistryStr()}, nil
+		return &Wrapper{&basicTransport{inner: t, auth: auth, target: reg.RegistryStr()}}, nil
 	case bearer:
 		// We require the realm, which tells us where to send our Basic auth to turn it into Bearer auth.
 		realm, ok := pr.parameters["realm"]
@@ -96,19 +96,19 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 		if err := bt.refresh(ctx); err != nil {
 			return nil, err
 		}
-		return bt, nil
+		return &Wrapper{bt}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized challenge: %s", pr.challenge)
 	}
 }
 
-// Transport results in *not* wrapping supplied transport with additional logic such as retries, useragent and debug logging
+// Wrapper results in *not* wrapping supplied transport with additional logic such as retries, useragent and debug logging
 // Consumers are opt-ing into providing their own transport without any additional wrapping.
-type Transport struct {
-	inner http.RoundTripper
+type Wrapper struct {
+	Inner http.RoundTripper
 }
 
 // RoundTrip delegates to the inner RoundTripper
-func (t *Transport) RoundTrip(in *http.Request) (*http.Response, error) {
-	return t.inner.RoundTrip(in)
+func (w *Wrapper) RoundTrip(in *http.Request) (*http.Response, error) {
+	return w.Inner.RoundTrip(in)
 }

--- a/pkg/v1/remote/transport/transport_test.go
+++ b/pkg/v1/remote/transport/transport_test.go
@@ -87,7 +87,7 @@ func TestTransportSelectionBasic(t *testing.T) {
 	}
 	if tpw, ok := tp.(*Wrapper); !ok {
 		t.Errorf("New(); got %T, want *Wrapper", tp)
-	} else if _, ok := tpw.Inner.(*basicTransport); !ok {
+	} else if _, ok := tpw.inner.(*basicTransport); !ok {
 		t.Errorf("New(); got %T, want *basicTransport", tp)
 	}
 }
@@ -157,7 +157,7 @@ func TestTransportSelectionBearer(t *testing.T) {
 	}
 	if tpw, ok := tp.(*Wrapper); !ok {
 		t.Errorf("New(); got %T, want *Wrapper", tp)
-	} else if _, ok := tpw.Inner.(*bearerTransport); !ok {
+	} else if _, ok := tpw.inner.(*bearerTransport); !ok {
 		t.Errorf("New(); got %T, want *bearerTransport", tp)
 	}
 }

--- a/pkg/v1/remote/transport/transport_test.go
+++ b/pkg/v1/remote/transport/transport_test.go
@@ -85,7 +85,9 @@ func TestTransportSelectionBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
-	if _, ok := tp.(*basicTransport); !ok {
+	if tpw, ok := tp.(*Wrapper); !ok {
+		t.Errorf("New(); got %T, want *Wrapper", tp)
+	} else if _, ok := tpw.Inner.(*basicTransport); !ok {
 		t.Errorf("New(); got %T, want *basicTransport", tp)
 	}
 }
@@ -153,7 +155,9 @@ func TestTransportSelectionBearer(t *testing.T) {
 	if err != nil {
 		t.Errorf("New() = %v", err)
 	}
-	if _, ok := tp.(*bearerTransport); !ok {
+	if tpw, ok := tp.(*Wrapper); !ok {
+		t.Errorf("New(); got %T, want *Wrapper", tp)
+	} else if _, ok := tpw.Inner.(*bearerTransport); !ok {
 		t.Errorf("New(); got %T, want *bearerTransport", tp)
 	}
 }

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -166,9 +166,11 @@ func setupWriterWithServer(server *httptest.Server, repo string) (*writer, close
 	}
 
 	return &writer{
-		repo:    tag.Context(),
-		client:  http.DefaultClient,
-		context: context.Background(),
+		repo:      tag.Context(),
+		client:    http.DefaultClient,
+		context:   context.Background(),
+		predicate: defaultRetryPredicate,
+		backoff:   defaultRetryBackoff,
 	}, server, nil
 }
 

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -914,7 +914,7 @@ func TestWriteWithErrors(t *testing.T) {
 		t.Error("Write() = nil; wanted error")
 	} else if se, ok := err.(*transport.Error); !ok {
 		t.Errorf("Write() = %T; wanted *remote.Error", se)
-	} else if diff := cmp.Diff(expectedError, se, cmpopts.IgnoreUnexported(transport.Error{})); diff != "" {
+	} else if diff := cmp.Diff(expectedError, se, cmpopts.IgnoreFields(transport.Error{}, "Request", "rawBody")); diff != "" {
 		t.Errorf("Write(); (-want +got) = %s", diff)
 	}
 


### PR DESCRIPTION
Related to https://github.com/google/go-containerregistry/issues/1114

Adds the following 4 options:
- WithRetryHTTPBackoff
- WithRetryHTTPPredicate
- WithRetryTransportBackoff
- WithRetryTransportPredicate

Went with a finer level API around configuring these (in my head) 2 groups of retry logic (low-level transport errors and higher level HTTP errors).

I was also aiming to keep the 'default' retry logic values the same (if these options are not provided).