### PR TITLE
Make `mutate` constructs immutable.

### DIFF
--- a/pkg/legacy/tarball/write_test.go
+++ b/pkg/legacy/tarball/write_test.go
@@ -382,9 +382,15 @@ func TestMultiWriteMismatchedHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting image config: %v", err)
 	}
+
 	// Set the history such that number of history entries != layers. This
 	// should trigger an error during the image write.
 	cfg.History = make([]v1.History, 1)
+	img, err = mutate.ConfigFile(img, cfg)
+	if err != nil {
+		t.Fatalf("mutate.ConfigFile() = %v", err)
+	}
+
 	tag, err := name.NewTag("gcr.io/foo/bar:latest", name.StrictValidation)
 	if err != nil {
 		t.Fatalf("Error creating test tag: %v", err)

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -30,13 +30,14 @@ type image struct {
 	base v1.Image
 	adds []Addendum
 
-	computed    bool
-	configFile  *v1.ConfigFile
-	manifest    *v1.Manifest
-	annotations map[string]string
-	mediaType   *types.MediaType
-	diffIDMap   map[v1.Hash]v1.Layer
-	digestMap   map[v1.Hash]v1.Layer
+	computed        bool
+	configFile      *v1.ConfigFile
+	manifest        *v1.Manifest
+	annotations     map[string]string
+	mediaType       *types.MediaType
+	configMediaType *types.MediaType
+	diffIDMap       map[v1.Hash]v1.Layer
+	digestMap       map[v1.Hash]v1.Layer
 }
 
 var _ v1.Image = (*image)(nil)
@@ -135,6 +136,11 @@ func (i *image) compute() error {
 		manifest.Config.Data = rcfg
 	}
 
+	// If the user wants to mutate the media type of the config
+	if i.configMediaType != nil {
+		manifest.Config.MediaType = *i.configMediaType
+	}
+
 	// With OCI media types, this should not be set, see discussion:
 	// https://github.com/opencontainers/image-spec/pull/795
 	if i.mediaType != nil {
@@ -210,7 +216,7 @@ func (i *image) ConfigFile() (*v1.ConfigFile, error) {
 	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return i.configFile, nil
+	return i.configFile.DeepCopy(), nil
 }
 
 // RawConfigFile returns the serialized bytes of ConfigFile()
@@ -242,7 +248,7 @@ func (i *image) Manifest() (*v1.Manifest, error) {
 	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return i.manifest, nil
+	return i.manifest.DeepCopy(), nil
 }
 
 // RawManifest returns the serialized bytes of Manifest()

--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -197,7 +197,7 @@ func (i *index) IndexManifest() (*v1.IndexManifest, error) {
 	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return i.manifest, nil
+	return i.manifest.DeepCopy(), nil
 }
 
 // RawManifest returns the serialized bytes of Manifest()

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -459,6 +459,14 @@ func MediaType(img v1.Image, mt types.MediaType) v1.Image {
 	}
 }
 
+// ConfigMediaType modifies the MediaType() of the given image's Config.
+func ConfigMediaType(img v1.Image, mt types.MediaType) v1.Image {
+	return &image{
+		base:            img,
+		configMediaType: &mt,
+	}
+}
+
 // IndexMediaType modifies the MediaType() of the given index.
 func IndexMediaType(idx v1.ImageIndex, mt types.MediaType) v1.ImageIndex {
 	return &index{


### PR DESCRIPTION
I noticed that `cosign` was taking advantage of a bug in the mutate package
where the `Manifest()` returns a mutable copy of it's internal state, which
allowed them to permanently alter the result of `Manifest()`.  This mutability
violates the philosophy of our abstractions, and should not be allowed, so
this change ensures that each of the methods returning state in the `mutate`
package return a `.DeepCopy()` instead.  In `image` this included the
`configFile`, and `manifest`.  In `index` this included the `indexManifest`.
I have added tests that when the returned copies are mutated, a subsequent
invocation of the getter will return a pristine copy.

Since I'm not completely heartless, I am also adding a new
`mutate.ConfigMediaType` method to enable `cosign` to perform the alteration
they want, now that the trick they were using will no longer work.

Related: https://github.com/sigstore/cosign/issues/718