### PR TITLE
feat(daemon): avoid multiple initialization

### DIFF
--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -28,6 +28,7 @@ import (
 )
 
 type image struct {
+	mu           sync.Mutex
 	ref          name.Reference
 	opener       *imageOpener
 	tarballImage v1.Image
@@ -99,6 +100,9 @@ func Image(ref name.Reference, options ...Option) (v1.Image, error) {
 }
 
 func (i *image) initialize() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	// Don't re-initialize tarball if already initialized.
 	if i.tarballImage == nil {
 		var err error


### PR DESCRIPTION
## Description
For example, if `LayerByDiffID` of `daemon.Image` is called twice in parallel, `initialize` might be called twice at the same time. Then, `tarball.Image` might be called twice. It is not efficient, so this PR locks `initialize()` before checking `i.tarballImage` for nil so that it will not be initialized twice.

Please let me know if you prefer `sync.Once`. Note that we need to keep `err` in the `image` struct like `imageOpener`.
https://github.com/google/go-containerregistry/blob/c3aee497b158a4c0e4da6584668637ac6b0b13a3/pkg/v1/daemon/image.go#L46

## Related PR
https://github.com/google/go-containerregistry/pull/1121