### PR TITLE
Don't reuse errgroups, propagate contexts better

### DIFF
--- a/pkg/v1/remote/multi_write.go
+++ b/pkg/v1/remote/multi_write.go
@@ -15,6 +15,7 @@
 package remote
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -133,12 +134,13 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 
 	// Upload individual blobs and collect any errors.
 	blobChan := make(chan v1.Layer, 2*o.jobs)
-	g, ctx := errgroup.WithContext(o.context)
+	ctx := o.context
+	g, gctx := errgroup.WithContext(o.context)
 	for i := 0; i < o.jobs; i++ {
 		// Start N workers consuming blobs to upload.
 		g.Go(func() error {
 			for b := range blobChan {
-				if err := w.uploadOne(b); err != nil {
+				if err := w.uploadOne(gctx, b); err != nil {
 					return err
 				}
 			}
@@ -150,8 +152,8 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 		for _, b := range blobs {
 			select {
 			case blobChan <- b:
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-gctx.Done():
+				return gctx.Err()
 			}
 		}
 		return nil
@@ -160,7 +162,8 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 		return err
 	}
 
-	commitMany := func(m map[name.Reference]Taggable) error {
+	commitMany := func(ctx context.Context, m map[name.Reference]Taggable) error {
+		g, ctx := errgroup.WithContext(ctx)
 		// With all of the constituent elements uploaded, upload the manifests
 		// to commit the images and indexes, and collect any errors.
 		type task struct {
@@ -172,7 +175,7 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 			// Start N workers consuming tasks to upload manifests.
 			g.Go(func() error {
 				for t := range taskChan {
-					if err := w.commitManifest(t.i, t.ref); err != nil {
+					if err := w.commitManifest(ctx, t.i, t.ref); err != nil {
 						return err
 					}
 				}
@@ -189,19 +192,19 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 	}
 	// Push originally requested image manifests. These have no
 	// dependencies.
-	if err := commitMany(images); err != nil {
+	if err := commitMany(ctx, images); err != nil {
 		return err
 	}
 	// Push new manifests from lowest levels up.
 	for i := len(newManifests) - 1; i >= 0; i-- {
-		if err := commitMany(newManifests[i]); err != nil {
+		if err := commitMany(ctx, newManifests[i]); err != nil {
 			return err
 		}
 	}
 	// Push originally requested index manifests, which might depend on
 	// newly discovered manifests.
 
-	return commitMany(indexes)
+	return commitMany(ctx, indexes)
 }
 
 // addIndexBlobs adds blobs to the set of blobs we intend to upload, and

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -647,6 +647,7 @@ func TestUploadOne(t *testing.T) {
 	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
 	streamPath := "/path/to/upload"
 	commitPath := "/path/to/commit"
+	ctx := context.Background()
 
 	uploaded := false
 	w, closer, err := setupWriter(expectedRepo, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -705,11 +706,11 @@ func TestUploadOne(t *testing.T) {
 		Layer:     l,
 		Reference: w.repo.Digest(h.String()),
 	}
-	if err := w.uploadOne(ml); err != nil {
+	if err := w.uploadOne(ctx, ml); err != nil {
 		t.Errorf("uploadOne() = %v", err)
 	}
 	// Hit the existing blob path.
-	if err := w.uploadOne(l); err != nil {
+	if err := w.uploadOne(ctx, l); err != nil {
 		t.Errorf("uploadOne() = %v", err)
 	}
 }
@@ -719,6 +720,7 @@ func TestUploadOneStreamedLayer(t *testing.T) {
 	initiatePath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
 	streamPath := "/path/to/upload"
 	commitPath := "/path/to/commit"
+	ctx := context.Background()
 
 	w, closer, err := setupWriter(expectedRepo, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -754,7 +756,7 @@ func TestUploadOneStreamedLayer(t *testing.T) {
 	wantDigest := "sha256:3d7c465be28d9e1ed810c42aeb0e747b44441424f566722ba635dc93c947f30e"
 	wantDiffID := "sha256:27dd1f61b867b6a0f6e9d8a41c43231de52107e53ae424de8f847b821db4b711"
 	l := stream.NewLayer(newBlob())
-	if err := w.uploadOne(l); err != nil {
+	if err := w.uploadOne(ctx, l); err != nil {
 		t.Fatalf("uploadOne: %v", err)
 	}
 
@@ -777,6 +779,7 @@ func TestUploadOneStreamedLayer(t *testing.T) {
 
 func TestCommitImage(t *testing.T) {
 	img := setupImage(t)
+	ctx := context.Background()
 
 	expectedRepo := "foo/bar"
 	expectedPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
@@ -813,7 +816,7 @@ func TestCommitImage(t *testing.T) {
 	}
 	defer closer.Close()
 
-	if err := w.commitManifest(img, w.repo.Tag("latest")); err != nil {
+	if err := w.commitManifest(ctx, img, w.repo.Tag("latest")); err != nil {
 		t.Error("commitManifest() = ", err)
 	}
 }


### PR DESCRIPTION
When you Wait() on an errgroup, the underlying context gets cancelled,
so calling Wait() twice will break if you correctly propagate contexts.
We weren't propagating contexts correctly, so this kind of worked
before, but if we actually want to leverage contexts better we should
fix this :)