### PR TITLE
Handle remote.WriteManifest manifests concurrently

### DIFF
--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -114,3 +114,10 @@ func WithContext(ctx context.Context) Option {
 		o.Remote = append(o.Remote, remote.WithContext(ctx))
 	}
 }
+
+// WithJobs sets the number of concurrent jobs to run.
+func WithJobs(jobs int) Option {
+	return func(o *Options) {
+		o.Remote = append(o.Remote, remote.WithJobs(jobs))
+	}
+}

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -62,6 +62,7 @@ func makeOptions(opts ...Option) *options {
 func WithJobs(jobs int) Option {
 	return func(o *options) {
 		o.jobs = jobs
+		o.crane = append(o.crane, crane.WithJobs(jobs))
 	}
 }
 


### PR DESCRIPTION
This speeds up writing an image index quite a bit in the happy path.

Also propagate jobs through crane options