### PR TITLE
feat(daemon): generate config file from Docker Engine API

### DIFF
--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -20,6 +20,10 @@ import (
 	"io"
 	"io/ioutil"
 	"sync"
+	"time"
+
+	api "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -31,7 +35,9 @@ type image struct {
 	ref          name.Reference
 	opener       *imageOpener
 	tarballImage v1.Image
+	computed     bool
 	id           *v1.Hash
+	configFile   *v1.ConfigFile
 
 	once sync.Once
 	err  error
@@ -122,6 +128,28 @@ func (i *image) initialize() error {
 	return i.err
 }
 
+func (i *image) compute() error {
+	// Don't re-compute if already computed.
+	if i.computed {
+		return nil
+	}
+
+	inspect, _, err := i.opener.client.ImageInspectWithRaw(i.opener.ctx, i.ref.String())
+	if err != nil {
+		return err
+	}
+
+	configFile, err := i.computeConfigFile(inspect)
+	if err != nil {
+		return err
+	}
+
+	i.configFile = configFile
+	i.computed = true
+
+	return nil
+}
+
 func (i *image) Layers() ([]v1.Layer, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
@@ -155,16 +183,19 @@ func (i *image) ConfigName() (v1.Hash, error) {
 }
 
 func (i *image) ConfigFile() (*v1.ConfigFile, error) {
-	if err := i.initialize(); err != nil {
+	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return i.tarballImage.ConfigFile()
+	return i.configFile.DeepCopy(), nil
 }
 
 func (i *image) RawConfigFile() ([]byte, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
+
+	// RawConfigFile cannot be generated from "docker inspect" because Docker Engine API returns serialized data,
+	// and formatting information of the raw config such as indent and prefix will be lost.
 	return i.tarballImage.RawConfigFile()
 }
 
@@ -201,4 +232,121 @@ func (i *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 		return nil, err
 	}
 	return i.tarballImage.LayerByDiffID(h)
+}
+
+func (i *image) configHistory(author string) ([]v1.History, error) {
+	historyItems, err := i.opener.client.ImageHistory(i.opener.ctx, i.ref.String())
+	if err != nil {
+		return nil, err
+	}
+
+	var history []v1.History
+	for _, h := range historyItems {
+		history = append(history, v1.History{
+			Author: author,
+			Created: v1.Time{
+				Time: time.Unix(h.Created, 0).UTC(),
+			},
+			CreatedBy:  h.CreatedBy,
+			Comment:    h.Comment,
+			EmptyLayer: h.Size == 0,
+		})
+	}
+	return history, nil
+}
+
+func (i *image) diffIDs(rootFS api.RootFS) ([]v1.Hash, error) {
+	var diffIDs []v1.Hash
+	for _, l := range rootFS.Layers {
+		h, err := v1.NewHash(l)
+		if err != nil {
+			return nil, err
+		}
+		diffIDs = append(diffIDs, h)
+	}
+	return diffIDs, nil
+}
+
+func (i *image) computeConfigFile(inspect api.ImageInspect) (*v1.ConfigFile, error) {
+	diffIDs, err := i.diffIDs(inspect.RootFS)
+	if err != nil {
+		return nil, err
+	}
+
+	history, err := i.configHistory(inspect.Author)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := time.Parse(time.RFC3339Nano, inspect.Created)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.ConfigFile{
+		Architecture:  inspect.Architecture,
+		Author:        inspect.Author,
+		Container:     inspect.Container,
+		Created:       v1.Time{Time: created},
+		DockerVersion: inspect.DockerVersion,
+		History:       history,
+		OS:            inspect.Os,
+		RootFS: v1.RootFS{
+			Type:    inspect.RootFS.Type,
+			DiffIDs: diffIDs,
+		},
+		Config:    i.computeImageConfig(inspect.Config),
+		OSVersion: inspect.OsVersion,
+	}, nil
+
+}
+
+func (i *image) computeImageConfig(config *container.Config) v1.Config {
+	if config == nil {
+		return v1.Config{}
+	}
+
+	c := v1.Config{
+		AttachStderr:    config.AttachStderr,
+		AttachStdin:     config.AttachStdin,
+		AttachStdout:    config.AttachStdout,
+		Cmd:             config.Cmd,
+		Domainname:      config.Domainname,
+		Entrypoint:      config.Entrypoint,
+		Env:             config.Env,
+		Hostname:        config.Hostname,
+		Image:           config.Image,
+		Labels:          config.Labels,
+		OnBuild:         config.OnBuild,
+		OpenStdin:       config.OpenStdin,
+		StdinOnce:       config.StdinOnce,
+		Tty:             config.Tty,
+		User:            config.User,
+		Volumes:         config.Volumes,
+		WorkingDir:      config.WorkingDir,
+		ArgsEscaped:     config.ArgsEscaped,
+		NetworkDisabled: config.NetworkDisabled,
+		MacAddress:      config.MacAddress,
+		StopSignal:      config.StopSignal,
+		Shell:           config.Shell,
+	}
+
+	if config.Healthcheck != nil {
+		c.Healthcheck = &v1.HealthConfig{
+			Test:        config.Healthcheck.Test,
+			Interval:    config.Healthcheck.Interval,
+			Timeout:     config.Healthcheck.Timeout,
+			StartPeriod: config.Healthcheck.StartPeriod,
+			Retries:     config.Healthcheck.Retries,
+		}
+	}
+
+	if len(config.ExposedPorts) > 0 {
+		c.ExposedPorts = map[string]struct{}{}
+		for port := range c.ExposedPorts {
+			c.ExposedPorts[port] = struct{}{}
+		}
+	}
+
+	return c
 }

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -240,9 +240,9 @@ func (i *image) configHistory(author string) ([]v1.History, error) {
 		return nil, err
 	}
 
-	var history []v1.History
-	for _, h := range historyItems {
-		history = append(history, v1.History{
+	history := make([]v1.History, len(historyItems))
+	for j, h := range historyItems {
+		history[j] = v1.History{
 			Author: author,
 			Created: v1.Time{
 				Time: time.Unix(h.Created, 0).UTC(),
@@ -250,19 +250,19 @@ func (i *image) configHistory(author string) ([]v1.History, error) {
 			CreatedBy:  h.CreatedBy,
 			Comment:    h.Comment,
 			EmptyLayer: h.Size == 0,
-		})
+		}
 	}
 	return history, nil
 }
 
 func (i *image) diffIDs(rootFS api.RootFS) ([]v1.Hash, error) {
-	var diffIDs []v1.Hash
-	for _, l := range rootFS.Layers {
+	diffIDs := make([]v1.Hash, len(rootFS.Layers))
+	for j, l := range rootFS.Layers {
 		h, err := v1.NewHash(l)
 		if err != nil {
 			return nil, err
 		}
-		diffIDs = append(diffIDs, h)
+		diffIDs[j] = h
 	}
 	return diffIDs, nil
 }
@@ -298,7 +298,6 @@ func (i *image) computeConfigFile(inspect api.ImageInspect) (*v1.ConfigFile, err
 		Config:    i.computeImageConfig(inspect.Config),
 		OSVersion: inspect.OsVersion,
 	}, nil
-
 }
 
 func (i *image) computeImageConfig(config *container.Config) v1.Config {

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -99,7 +99,6 @@ func (m *MockClient) ImageHistory(_ context.Context, _ string) ([]api.HistoryRes
 			},
 		},
 	}, nil
-
 }
 
 func TestImage(t *testing.T) {

--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -79,6 +79,14 @@ func (m *MockClient) ImageInspectWithRaw(_ context.Context, _ string) (types.Ima
 		Size:         8,
 		VirtualSize:  8,
 		Config:       &container.Config{},
+		GraphDriver: types.GraphDriverData{
+			Data: map[string]string{
+				"MergedDir": "/var/lib/docker/overlay2/988ecd005d048fd47b241dd57687231859563ba65a1dfd01ae1771ebfc4cb7c5/merged",
+				"UpperDir":  "/var/lib/docker/overlay2/988ecd005d048fd47b241dd57687231859563ba65a1dfd01ae1771ebfc4cb7c5/diff",
+				"WorkDir":   "/var/lib/docker/overlay2/988ecd005d048fd47b241dd57687231859563ba65a1dfd01ae1771ebfc4cb7c5/work",
+			},
+			Name: "overlay2",
+		},
 		RootFS: types.RootFS{
 			Type: "layers",
 			Layers: []string{

--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	api "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 )
 
@@ -100,4 +101,5 @@ type Client interface {
 	ImageLoad(context.Context, io.Reader, bool) (types.ImageLoadResponse, error)
 	ImageTag(context.Context, string, string) error
 	ImageInspectWithRaw(context.Context, string) (types.ImageInspect, []byte, error)
+	ImageHistory(context.Context, string) ([]api.HistoryResponseItem, error)
 }


### PR DESCRIPTION
## Description
https://github.com/google/go-containerregistry/pull/1121 allows `daemon.Image` to get a config name without exporting a tar file. This PR also generates a config file from `docker inspect` and `docker history` without exporting. Note that `RawConfigFile()` cannot be emulated by Docker Engine API as far as I know.

I referred to this implementation.
https://github.com/google/go-containerregistry/blob/0e8b581974ddd6879e02df540662c394921387e7/pkg/v1/mutate/image.go#L52

In addition, I changed some value receivers to pointer receivers since we should not mix receiver types.

>Don't mix receiver types. Choose either pointers or struct types for all available methods.

https://github.com/golang/go/wiki/CodeReviewComments#receiver-type