### PR TITLE
Re-enable codeql analysis

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -1,0 +1,25 @@
+name: Analyze
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    - uses: github/codeql-action/init@v1
+      with:
+        languages: go
+    - uses: github/codeql-action/autobuild@v1
+    - uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
These were dropped in #1016 and I don't remember why. The result is that code scanning alerts have been disabled since May: https://github.com/google/go-containerregistry/security/code-scanning
