### PR TITLE
Use t.Setenv instead of os.Setenv

### DIFF
--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -45,7 +45,7 @@ func setupConfigDir(t *testing.T) string {
 
 	fresh = fresh + 1
 	p := fmt.Sprintf("%s/%d", tmpdir, fresh)
-	os.Setenv("DOCKER_CONFIG", p)
+	t.Setenv("DOCKER_CONFIG", p)
 	if err := os.Mkdir(p, 0777); err != nil {
 		t.Fatalf("mkdir %q: %v", p, err)
 	}

--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -190,9 +190,7 @@ func TestKeychainGCRandAR(t *testing.T) {
 	}
 
 	// Env should fail.
-	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
-		t.Fatalf("unexpected err os.Setenv: %v", err)
-	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("cases[%d]", i), func(t *testing.T) {
@@ -225,9 +223,7 @@ func TestKeychainGCRandAR(t *testing.T) {
 }
 
 func TestKeychainError(t *testing.T) {
-	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
-		t.Fatalf("unexpected err os.Setenv: %v", err)
-	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 
 	GetGcloudCmd = newGcloudCmdMock("badoutput")
 
@@ -255,9 +251,7 @@ func TestTokenSourceAuthError(t *testing.T) {
 }
 
 func TestNewEnvAuthenticatorFailure(t *testing.T) {
-	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null"); err != nil {
-		t.Fatalf("unexpected err os.Setenv: %v", err)
-	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 
 	// Expect error.
 	_, err := NewEnvAuthenticator()


### PR DESCRIPTION
[`T.Setenv`](https://pkg.go.dev/testing#T.Setenv) was added in Go 1.17. Since `os.Setenv` has side effects, this removes the need for `defer`ring `os.Setenv(prev)` -- or in our case, not resetting the env var.

More info: https://github.com/golang/go/issues/41260