### PR TITLE
Make the blob storage in pkg/registry pluggable.

### DIFF
--- a/pkg/registry/example_test.go
+++ b/pkg/registry/example_test.go
@@ -24,7 +24,7 @@ import (
 func Example() {
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
-	resp, _ := s.Client().Get(s.URL + "/v2/bar/blobs/sha256:...")
+	resp, _ := s.Client().Get(s.URL + "/v2/bar/blobs/sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
 	fmt.Println(resp.StatusCode)
 	// Output: 404
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,6 +27,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 type registry struct {
@@ -77,8 +79,10 @@ func New(opts ...Option) http.Handler {
 	r := &registry{
 		log: log.New(os.Stderr, "", log.LstdFlags),
 		blobs: blobs{
-			contents: map[string][]byte{},
-			uploads:  map[string][]byte{},
+			uploads: map[string][]byte{},
+			bh: &defaultBlobStore{
+				contents: map[v1.Hash][]byte{},
+			},
 		},
 		manifests: manifests{
 			manifests: map[string]map[string]manifest{},
@@ -100,5 +104,12 @@ func Logger(l *log.Logger) Option {
 	return func(r *registry) {
 		r.log = l
 		r.manifests.log = l
+	}
+}
+
+// WithBlobHandler overrides the default BlobHandler.
+func WithBlobHandler(bh BlobHandler) Option {
+	return func(r *registry) {
+		r.blobs.bh = bh
 	}
 }


### PR DESCRIPTION
With this change folks can use `registry.WithBlobHandler(...)` to substitute a custom blob handling layer.