### PR TITLE
Enable golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,15 @@
+run:
+  timeout: 5m
+
+  skip-dirs:
+    - internal
+    - pkg/registry
+
+linters:
+  enable:
+    - asciicheck
+    - depguard
+    - stylecheck
+    - unconvert
+  disable:
+    - errcheck

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -118,7 +118,7 @@ func (i *image) Layers() ([]v1.Layer, error) {
 	return i.tarballImage.Layers()
 }
 
-func (i image) MediaType() (types.MediaType, error) {
+func (i *image) MediaType() (types.MediaType, error) {
 	if err := i.initialize(); err != nil {
 		return "", err
 	}
@@ -140,49 +140,49 @@ func (i *image) ConfigName() (v1.Hash, error) {
 	return v1.NewHash(res.ID)
 }
 
-func (i image) ConfigFile() (*v1.ConfigFile, error) {
+func (i *image) ConfigFile() (*v1.ConfigFile, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
 	return i.tarballImage.ConfigFile()
 }
 
-func (i image) RawConfigFile() ([]byte, error) {
+func (i *image) RawConfigFile() ([]byte, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
 	return i.tarballImage.RawConfigFile()
 }
 
-func (i image) Digest() (v1.Hash, error) {
+func (i *image) Digest() (v1.Hash, error) {
 	if err := i.initialize(); err != nil {
 		return v1.Hash{}, err
 	}
 	return i.tarballImage.Digest()
 }
 
-func (i image) Manifest() (*v1.Manifest, error) {
+func (i *image) Manifest() (*v1.Manifest, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
 	return i.tarballImage.Manifest()
 }
 
-func (i image) RawManifest() ([]byte, error) {
+func (i *image) RawManifest() ([]byte, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
 	return i.tarballImage.RawManifest()
 }
 
-func (i image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+func (i *image) LayerByDigest(h v1.Hash) (v1.Layer, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}
 	return i.tarballImage.LayerByDigest(h)
 }
 
-func (i image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
+func (i *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
 	if err := i.initialize(); err != nil {
 		return nil, err
 	}

--- a/pkg/v1/google/auth.go
+++ b/pkg/v1/google/auth.go
@@ -95,7 +95,7 @@ func NewJSONKeyAuthenticator(serviceAccountJSON string) authn.Authenticator {
 // tokens by using the Google SDK to produce JWT tokens from a Service Account.
 // More information: https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON
 func NewTokenAuthenticator(serviceAccountJSON string, scope string) (authn.Authenticator, error) {
-	ts, err := googauth.JWTAccessTokenSourceFromJSON([]byte(serviceAccountJSON), string(scope))
+	ts, err := googauth.JWTAccessTokenSourceFromJSON([]byte(serviceAccountJSON), scope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -229,7 +229,7 @@ func (m *ManifestInfo) UnmarshalJSON(data []byte) error {
 	}
 
 	if raw.Size != "" {
-		size, err := strconv.ParseUint(string(raw.Size), 10, 64)
+		size, err := strconv.ParseUint(raw.Size, 10, 64)
 		if err != nil {
 			return err
 		}
@@ -237,7 +237,7 @@ func (m *ManifestInfo) UnmarshalJSON(data []byte) error {
 	}
 
 	if raw.Created != "" {
-		created, err := strconv.ParseInt(string(raw.Created), 10, 64)
+		created, err := strconv.ParseInt(raw.Created, 10, 64)
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ func (m *ManifestInfo) UnmarshalJSON(data []byte) error {
 	}
 
 	if raw.Uploaded != "" {
-		uploaded, err := strconv.ParseInt(string(raw.Uploaded), 10, 64)
+		uploaded, err := strconv.ParseInt(raw.Uploaded, 10, 64)
 		if err != nil {
 			return err
 		}

--- a/pkg/v1/remote/transport/transport_test.go
+++ b/pkg/v1/remote/transport/transport_test.go
@@ -133,7 +133,7 @@ func TestTransportSelectionBearer(t *testing.T) {
 				if !strings.HasPrefix(hdr, "Basic ") {
 					t.Errorf("Header.Get(Authorization); got %v, want Basic prefix", hdr)
 				}
-				if got, want := r.FormValue("scope"), testReference.Scope(string(PullScope)); got != want {
+				if got, want := r.FormValue("scope"), testReference.Scope(PullScope); got != want {
 					t.Errorf("FormValue(scope); got %v, want %v", got, want)
 				}
 				// Check that we get the default value (we didn't specify it above)

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -404,7 +404,7 @@ func (w *writer) incrProgress(written int64) {
 	}
 	w.updates <- v1.Update{
 		Total:    w.lastUpdate.Total,
-		Complete: atomic.AddInt64(&w.lastUpdate.Complete, int64(written)),
+		Complete: atomic.AddInt64(&w.lastUpdate.Complete, written),
 	}
 }
 


### PR DESCRIPTION
This previously wasn't linting anything, despite it being in our (copied from Knative forever ago) [Code Style check](https://github.com/google/go-containerregistry/runs/4083873412?check_suite_focus=true), because the repo didn't have a `.golangci.yaml`.

I've disabled most linters that either didn't run for me locally, or had a bunch of false positives. If we feel like fixing these later we can.

cc @mattmoor thanks for catching this.