### PR TITLE
Enable gosec, exempt tests, ignore others

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,12 @@ run:
     - internal
     - pkg/registry
 
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - gosec
+
 linters:
   enable:
   - asciicheck
@@ -12,6 +18,7 @@ linters:
   - depguard
   - errorlint
   - gofmt
+  - gosec
   - goimports
   - importas
   - prealloc

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -71,7 +71,9 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 			options = append(options, crane.WithPlatform(platform.platform))
 
 			transport := remote.DefaultTransport.Clone()
-			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: insecure, //nolint: gosec
+			}
 
 			var rt http.RoundTripper = transport
 			// Add any http headers if they are set in the config file.

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -299,7 +299,7 @@ func extract(img v1.Image, w io.Writer) error {
 			if !tombstone {
 				tarWriter.WriteHeader(header)
 				if header.Size > 0 {
-					if _, err := io.Copy(tarWriter, tarReader); err != nil {
+					if _, err := io.CopyN(tarWriter, tarReader, header.Size); err != nil {
 						return err
 					}
 				}
@@ -409,7 +409,8 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 		}
 
 		if header.Typeflag == tar.TypeReg {
-			if _, err = io.Copy(tarWriter, tarReader); err != nil {
+			// TODO(#1168): This should be lazy, and not buffer the entire layer contents.
+			if _, err = io.CopyN(tarWriter, tarReader, header.Size); err != nil {
 				return nil, fmt.Errorf("writing layer file: %w", err)
 			}
 		}

--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -81,7 +81,7 @@ func Image(byteSize, layers int64) (v1.Image, error) {
 
 // Layer returns a layer with pseudo-randomly generated content.
 func Layer(byteSize int64, mt types.MediaType) (v1.Layer, error) {
-	fileName := fmt.Sprintf("random_file_%d.txt", mrand.Int())
+	fileName := fmt.Sprintf("random_file_%d.txt", mrand.Int()) //nolint: gosec
 
 	// Hash the contents as we write it out to the buffer.
 	var b bytes.Buffer

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -236,7 +236,7 @@ func extractFileFromTar(opener Opener, filePath string) (io.ReadCloser, error) {
 		if hdr.Name == filePath {
 			if hdr.Typeflag == tar.TypeSymlink || hdr.Typeflag == tar.TypeLink {
 				currentDir := filepath.Dir(filePath)
-				return extractFileFromTar(opener, path.Join(currentDir, hdr.Linkname))
+				return extractFileFromTar(opener, path.Join(currentDir, path.Clean(hdr.Linkname)))
 			}
 			close = false
 			return tarFile{


### PR DESCRIPTION
Better than nothing, and it should prevent future `gosec` findings from sneaking in at least.