### PR TITLE
Pass Options when recursively calling writeIndex

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -523,7 +523,7 @@ func (w *writer) writeIndex(ctx context.Context, ref name.Reference, ii v1.Image
 			if err != nil {
 				return err
 			}
-			if err := w.writeIndex(ctx, ref, ii); err != nil {
+			if err := w.writeIndex(ctx, ref, ii, options...); err != nil {
 				return err
 			}
 		case types.OCIManifestSchema1, types.DockerManifestSchema2:


### PR DESCRIPTION
Noticed while pushing nested indexes, we lose authentication options
when attempting to upload a nested index with `WriteIndex`.

This PR ensures options are maintained and passed to recursive calls
to `writeIndex`.