### PR TITLE
Adding OS version to Crane for better Windows support.

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -38,6 +38,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 	verbose := false
 	insecure := false
 	platform := &platformValue{}
+	var osVersion string
 
 	root := &cobra.Command{
 		Use:               use,
@@ -60,6 +61,10 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 					binary = filepath.Base(os.Args[0])
 				}
 				options = append(options, crane.WithUserAgent(fmt.Sprintf("%s/%s", binary, Version)))
+			}
+
+			if osVersion != "" {
+				platform.platform.OSVersion = osVersion
 			}
 
 			options = append(options, crane.WithPlatform(platform.platform))
@@ -111,6 +116,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
 	root.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow image references to be fetched without TLS")
 	root.PersistentFlags().Var(platform, "platform", "Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64).")
+	root.PersistentFlags().StringVar(&osVersion, "osversion", "", "Specifies the OS version.")
 
 	return root
 }

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -11,6 +11,7 @@ crane [flags]
 ```
   -h, --help                help for crane
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -21,6 +21,7 @@ crane append [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -16,6 +16,7 @@ crane auth [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -24,6 +24,7 @@ crane auth get [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -26,6 +26,7 @@ crane auth login [OPTIONS] [SERVER] [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_blob.md
+++ b/cmd/crane/doc/crane_blob.md
@@ -22,6 +22,7 @@ crane blob ubuntu@sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac3
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -16,6 +16,7 @@ crane catalog [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -16,6 +16,7 @@ crane config IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -16,6 +16,7 @@ crane copy SRC DST [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -16,6 +16,7 @@ crane delete IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -17,6 +17,7 @@ crane digest IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -26,6 +26,7 @@ crane export IMAGE TARBALL [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_flatten.md
+++ b/cmd/crane/doc/crane_flatten.md
@@ -17,6 +17,7 @@ crane flatten [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -16,6 +16,7 @@ crane ls REPO [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -16,6 +16,7 @@ crane manifest IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -20,6 +20,7 @@ crane mutate [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -18,6 +18,7 @@ crane pull IMAGE TARBALL [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -16,6 +16,7 @@ crane push TARBALL IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -21,6 +21,7 @@ crane rebase [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_tag.md
+++ b/cmd/crane/doc/crane_tag.md
@@ -35,6 +35,7 @@ crane tag ubuntu v1
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -19,6 +19,7 @@ crane validate [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/cmd/crane/doc/crane_version.md
+++ b/cmd/crane/doc/crane_version.md
@@ -23,6 +23,7 @@ crane version [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
+      --osversion string    Specifies the OS version.
       --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -214,7 +214,7 @@ func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error)
 			return r.childDescriptor(childDesc, platform)
 		}
 	}
-	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.OS, platform.Architecture, r.Ref)
+	return nil, fmt.Errorf("no child with platform %+v in index %s", platform, r.Ref)
 }
 
 func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {


### PR DESCRIPTION
Windows images present some unique challenges and one of those challenges is being able to pull a specific OS version. This especially comes into play when working with a manifest like the k8s.gcr.io/pause:3.6 which doesn't offer tags specific to Windows OS version. 

Here is an example use case:

```
crane pull --platform windows/amd64 --osversion 10.0.17763.2114 k8s.gcr.io/pause:3.6 windows-1809.tar
```

Without the version specified Windows Server 2022 would have been pulled.