### PR TITLE
spelling: entrypoing->entrypoint

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -120,7 +120,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	}
 	mutateCmd.Flags().StringSliceVarP(&anntns, "annotation", "a", nil, "New annotations to add")
 	mutateCmd.Flags().StringSliceVarP(&lbls, "label", "l", nil, "New labels to add")
-	mutateCmd.Flags().StringVar(&entrypoint, "entrypoint", "", "New entrypoing to set")
+	mutateCmd.Flags().StringVar(&entrypoint, "entrypoint", "", "New entrypoint to set")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	return mutateCmd
 }

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -10,7 +10,7 @@ crane mutate [flags]
 
 ```
   -a, --annotation strings   New annotations to add
-      --entrypoint string    New entrypoing to set
+      --entrypoint string    New entrypoint to set
   -h, --help                 help for mutate
   -l, --label strings        New labels to add
   -t, --tag string           New tag to apply to mutated image. If not provided, push by digest to the original image repository.


### PR DESCRIPTION
Just reading the docs and found a spelling mistake - this is especially funny because I've used "entrypoing" so many times (accidentally) in commands it must be the case that our fingers have similar deviance!  :laughing: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>