### PR TITLE
Accept multiple entrypoint values in crane mutate

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         go-version: 1.17.x
 
-    - name: crane append to an image, pull it locally
+    - name: crane append to an image, set the entrypoint, run it locally
       shell: bash
       run: |
         set -euxo pipefail
@@ -36,8 +36,29 @@ jobs:
           platform=windows/amd64
         fi
 
-        docker pull $(go run ./cmd/crane append \
-            --platform ${platform} \
-            --base ${base} \
-            --new_tag localhost:1338/append-test \
-            --new_layer pkg/v1/tarball/testdata/content.tar)
+        CGO_ENABLED=0 go build -o app/crane ./cmd/crane
+        tar cvf crane.tar app
+
+        # This prevents Bash for Windows from mangling path names.
+        # It shouldn't be necessary in general unless you're using Bash for
+        # Windows.
+        export MSYS_NO_PATHCONV=1
+
+        img=$(./app/crane mutate \
+            --entrypoint=/app/crane,mutate \
+            $(./app/crane append \
+                --platform ${platform} \
+                --base ${base} \
+                --new_tag localhost:1338/append-test \
+                --new_layer crane.tar))
+
+        # Check the image's config.
+        ./app/crane config $img | jq
+
+        # Pull and inspect the image.
+        docker pull $img
+        docker inspect $img
+
+        # Remove the local image, re-pull and run it.
+        docker rmi $img
+        docker run $img --help

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,7 +46,6 @@ jobs:
 
         img=$(./app/crane mutate \
             --entrypoint=/app/crane,version \
-            --unset-cmd \
             $(./app/crane append \
                 --platform ${platform} \
                 --base ${base} \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,20 +45,13 @@ jobs:
         export MSYS_NO_PATHCONV=1
 
         img=$(./app/crane mutate \
-            --entrypoint=/app/crane,mutate \
+            --entrypoint=/app/crane,version \
             $(./app/crane append \
                 --platform ${platform} \
                 --base ${base} \
                 --new_tag localhost:1338/append-test \
                 --new_layer crane.tar))
 
-        # Check the image's config.
-        ./app/crane config $img | jq
-
-        # Pull and inspect the image.
-        docker pull $img
-        docker inspect $img
-
-        # Remove the local image, re-pull and run it.
-        docker rmi $img
+        # Run the image with and without args.
+        docker run $img 
         docker run $img --help

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,7 @@ jobs:
 
         img=$(./app/crane mutate \
             --entrypoint=/app/crane,version \
+            --unset-cmd \
             $(./app/crane append \
                 --platform ${platform} \
                 --base ${base} \

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -82,6 +82,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			// Set entrypoint.
 			if len(entrypoint) > 0 {
 				cfg.Config.Entrypoint = entrypoint
+				cfg.Config.Cmd = nil // unset cmd
 			}
 
 			// Mutate and write image.

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -54,7 +54,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 
 			img, err := crane.Pull(ref, *options...)
 			if err != nil {
-				return fmt.Errorf("pulling %s: %v", ref, err)
+				return fmt.Errorf("pulling %s: %w", ref, err)
 			}
 			cfg, err := img.ConfigFile()
 			if err != nil {
@@ -100,7 +100,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			// Mutate and write image.
 			img, err = mutate.Config(img, cfg.Config)
 			if err != nil {
-				return fmt.Errorf("mutating config: %v", err)
+				return fmt.Errorf("mutating config: %w", err)
 			}
 
 			img = mutate.Annotations(img, annotations).(v1.Image)
@@ -114,17 +114,17 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			}
 			digest, err := img.Digest()
 			if err != nil {
-				return fmt.Errorf("digesting new image: %v", err)
+				return fmt.Errorf("digesting new image: %w", err)
 			}
 			r, err := name.ParseReference(newRef)
 			if err != nil {
-				return fmt.Errorf("parsing %s: %v", newRef, err)
+				return fmt.Errorf("parsing %s: %w", newRef, err)
 			}
 			if _, ok := r.(name.Digest); ok {
 				newRef = r.Context().Digest(digest.String()).String()
 			}
 			if err := crane.Push(img, newRef, *options...); err != nil {
-				return fmt.Errorf("pushing %s: %v", newRef, err)
+				return fmt.Errorf("pushing %s: %w", newRef, err)
 			}
 			fmt.Println(r.Context().Digest(digest.String()))
 			return nil

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -15,8 +15,8 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"log"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -28,35 +28,37 @@ import (
 // NewCmdMutate creates a new cobra.Command for the mutate subcommand.
 func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var labels map[string]string
-	var entrypoint []string
-	var newRef string
 	var annotations map[string]string
+	var entrypoint, cmd []string
+	var unsetEntrypoint, unsetCmd bool
+
+	var newRef string
 
 	mutateCmd := &cobra.Command{
 		Use:   "mutate",
 		Short: "Modify image labels and annotations. The container must be pushed to a registry, and the manifest is updated there.",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			// Pull image and get config.
 			ref := args[0]
 
 			if len(annotations) != 0 {
 				desc, err := crane.Head(ref, *options...)
 				if err != nil {
-					log.Fatalf("checking %s: %v", ref, err)
+					return err
 				}
 				if desc.MediaType.IsIndex() {
-					log.Fatalf("mutating annotations on an index is not yet supported")
+					return errors.New("mutating annotations on an index is not yet supported")
 				}
 			}
 
 			img, err := crane.Pull(ref, *options...)
 			if err != nil {
-				log.Fatalf("pulling %s: %v", ref, err)
+				return fmt.Errorf("pulling %s: %v", ref, err)
 			}
 			cfg, err := img.ConfigFile()
 			if err != nil {
-				log.Fatalf("getting config: %v", err)
+				return err
 			}
 			cfg = cfg.DeepCopy()
 
@@ -65,30 +67,40 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				cfg.Config.Labels = map[string]string{}
 			}
 
-			err = validateKeyVals(labels)
-			if err != nil {
-				log.Fatal(err)
+			if err := validateKeyVals(labels); err != nil {
+				return err
 			}
 
 			for k, v := range labels {
 				cfg.Config.Labels[k] = v
 			}
 
-			err = validateKeyVals(annotations)
-			if err != nil {
-				log.Fatal(err)
+			if err := validateKeyVals(annotations); err != nil {
+				return err
 			}
 
-			// Set entrypoint.
-			if len(entrypoint) > 0 {
+			// Set/unset entrypoint.
+			if len(entrypoint) > 0 && unsetEntrypoint {
+				return errors.New("cannot specify both --entrypoint and --unset-entrypoint")
+			} else if len(entrypoint) > 0 {
 				cfg.Config.Entrypoint = entrypoint
-				cfg.Config.Cmd = nil // unset cmd
+			} else if unsetEntrypoint {
+				cfg.Config.Entrypoint = nil
+			}
+
+			// Set/unset cmd.
+			if len(cmd) > 0 && unsetCmd {
+				return errors.New("cannot specify both --cmd and --unset-cmd")
+			} else if len(cmd) > 0 {
+				cfg.Config.Cmd = cmd
+			} else if unsetCmd {
+				cfg.Config.Cmd = nil
 			}
 
 			// Mutate and write image.
 			img, err = mutate.Config(img, cfg.Config)
 			if err != nil {
-				log.Fatalf("mutating config: %v", err)
+				return fmt.Errorf("mutating config: %v", err)
 			}
 
 			img = mutate.Annotations(img, annotations).(v1.Image)
@@ -102,24 +114,28 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			}
 			digest, err := img.Digest()
 			if err != nil {
-				log.Fatalf("digesting new image: %v", err)
+				return fmt.Errorf("digesting new image: %v", err)
 			}
 			r, err := name.ParseReference(newRef)
 			if err != nil {
-				log.Fatalf("parsing %s: %v", newRef, err)
+				return fmt.Errorf("parsing %s: %v", newRef, err)
 			}
 			if _, ok := r.(name.Digest); ok {
 				newRef = r.Context().Digest(digest.String()).String()
 			}
 			if err := crane.Push(img, newRef, *options...); err != nil {
-				log.Fatalf("pushing %s: %v", newRef, err)
+				return fmt.Errorf("pushing %s: %v", newRef, err)
 			}
 			fmt.Println(r.Context().Digest(digest.String()))
+			return nil
 		},
 	}
 	mutateCmd.Flags().StringToStringVarP(&annotations, "annotation", "a", nil, "New annotations to add")
 	mutateCmd.Flags().StringToStringVarP(&labels, "label", "l", nil, "New labels to add")
 	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
+	mutateCmd.Flags().StringSliceVar(&cmd, "cmd", nil, "New cmd to set")
+	mutateCmd.Flags().BoolVar(&unsetEntrypoint, "unset-entrypoint", false, "If true, unset existing entrypoint")
+	mutateCmd.Flags().BoolVar(&unsetCmd, "unset-cmd", false, "If true, unset existing cmd")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	return mutateCmd
 }

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -83,7 +83,6 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			if len(entrypoint) > 0 {
 				cfg.Config.Entrypoint = entrypoint
 			}
-			cfg.Config.Cmd = nil // Unset cmd
 
 			// Mutate and write image.
 			img, err = mutate.Config(img, cfg.Config)

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -30,7 +30,6 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var labels map[string]string
 	var annotations map[string]string
 	var entrypoint, cmd []string
-	var unsetEntrypoint, unsetCmd bool
 
 	var newRef string
 
@@ -79,22 +78,15 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				return err
 			}
 
-			// Set/unset entrypoint.
-			if len(entrypoint) > 0 && unsetEntrypoint {
-				return errors.New("cannot specify both --entrypoint and --unset-entrypoint")
-			} else if len(entrypoint) > 0 {
+			// Set entrypoint.
+			if len(entrypoint) > 0 {
 				cfg.Config.Entrypoint = entrypoint
-			} else if unsetEntrypoint {
-				cfg.Config.Entrypoint = nil
+				cfg.Config.Cmd = nil // This matches Docker's behavior.
 			}
 
-			// Set/unset cmd.
-			if len(cmd) > 0 && unsetCmd {
-				return errors.New("cannot specify both --cmd and --unset-cmd")
-			} else if len(cmd) > 0 {
+			// Set cmd.
+			if len(cmd) > 0 {
 				cfg.Config.Cmd = cmd
-			} else if unsetCmd {
-				cfg.Config.Cmd = nil
 			}
 
 			// Mutate and write image.
@@ -134,8 +126,6 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	mutateCmd.Flags().StringToStringVarP(&labels, "label", "l", nil, "New labels to add")
 	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
 	mutateCmd.Flags().StringSliceVar(&cmd, "cmd", nil, "New cmd to set")
-	mutateCmd.Flags().BoolVar(&unsetEntrypoint, "unset-entrypoint", false, "If true, unset existing entrypoint")
-	mutateCmd.Flags().BoolVar(&unsetCmd, "unset-cmd", false, "If true, unset existing cmd")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	return mutateCmd
 }

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -28,7 +28,7 @@ import (
 // NewCmdMutate creates a new cobra.Command for the mutate subcommand.
 func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var labels map[string]string
-	var entrypoint string
+	var entrypoint []string
 	var newRef string
 	var annotations map[string]string
 
@@ -80,10 +80,10 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			}
 
 			// Set entrypoint.
-			if entrypoint != "" {
-				// NB: This doesn't attempt to do anything smart about splitting the string into multiple entrypoint elements.
-				cfg.Config.Entrypoint = []string{entrypoint}
+			if len(entrypoint) > 0 {
+				cfg.Config.Entrypoint = entrypoint
 			}
+			cfg.Config.Cmd = nil // Unset cmd
 
 			// Mutate and write image.
 			img, err = mutate.Config(img, cfg.Config)
@@ -119,7 +119,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	}
 	mutateCmd.Flags().StringToStringVarP(&annotations, "annotation", "a", nil, "New annotations to add")
 	mutateCmd.Flags().StringToStringVarP(&labels, "label", "l", nil, "New labels to add")
-	mutateCmd.Flags().StringVar(&entrypoint, "entrypoint", "", "New entrypoint to set")
+	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	return mutateCmd
 }

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -15,8 +15,6 @@ crane mutate [flags]
   -h, --help                        help for mutate
   -l, --label stringToString        New labels to add (default [])
   -t, --tag string                  New tag to apply to mutated image. If not provided, push by digest to the original image repository.
-      --unset-cmd                   If true, unset existing cmd
-      --unset-entrypoint            If true, unset existing entrypoint
 ```
 
 ### Options inherited from parent commands

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -10,7 +10,7 @@ crane mutate [flags]
 
 ```
   -a, --annotation stringToString   New annotations to add (default [])
-      --entrypoint string           New entrypoint to set
+      --entrypoint strings          New entrypoint to set
   -h, --help                        help for mutate
   -l, --label stringToString        New labels to add (default [])
   -t, --tag string                  New tag to apply to mutated image. If not provided, push by digest to the original image repository.

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -10,10 +10,13 @@ crane mutate [flags]
 
 ```
   -a, --annotation stringToString   New annotations to add (default [])
+      --cmd strings                 New cmd to set
       --entrypoint strings          New entrypoint to set
   -h, --help                        help for mutate
   -l, --label stringToString        New labels to add (default [])
   -t, --tag string                  New tag to apply to mutated image. If not provided, push by digest to the original image repository.
+      --unset-cmd                   If true, unset existing cmd
+      --unset-entrypoint            If true, unset existing entrypoint
 ```
 
 ### Options inherited from parent commands

--- a/internal/windows/windows.go
+++ b/internal/windows/windows.go
@@ -49,16 +49,18 @@ func Windows(layer v1.Layer) (v1.Layer, error) {
 	tarWriter := tar.NewWriter(w)
 	defer tarWriter.Close()
 
-	if err := tarWriter.WriteHeader(&tar.Header{
-		Name:     "Hives",
-		Typeflag: tar.TypeDir,
-		// Use a fixed Mode, so that this isn't sensitive to the directory and umask
-		// under which it was created. Additionally, windows can only set 0222,
-		// 0444, or 0666, none of which are executable.
-		Mode:   0555,
-		Format: tar.FormatPAX,
-	}); err != nil {
-		return nil, fmt.Errorf("writing Hives directory: %w", err)
+	for _, dir := range []string{"Files", "Hives"} {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name:     dir,
+			Typeflag: tar.TypeDir,
+			// Use a fixed Mode, so that this isn't sensitive to the directory and umask
+			// under which it was created. Additionally, windows can only set 0222,
+			// 0444, or 0666, none of which are executable.
+			Mode:   0555,
+			Format: tar.FormatPAX,
+		}); err != nil {
+			return nil, fmt.Errorf("writing %s directory: %w", dir, err)
+		}
 	}
 
 	for {


### PR DESCRIPTION
```
$ crane config $(
    go run ./cmd/crane mutate \
      --entrypoint=dotnet,craneapp.dll \
      phillipsj/craneapp:0.1.0 \
      -t gcr.io/imjasonh/craneapp:0.1.0) | jq .config.Entrypoint
...
[
  "dotnet",
  "craneapp.dll"
]
```

This might fix the issue with malformed Windows images created by `crane mutate --entrypoint`, based on Jon's findings -- https://github.com/moby/moby/issues/33373#issuecomment-522189149

cc @phillipsj 