### PR TITLE
Allow uppercase repository names with `name.WeakValidation` (default)

### DIFF
--- a/pkg/name/digest_test.go
+++ b/pkg/name/digest_test.go
@@ -38,6 +38,7 @@ var goodStrictValidationTagDigestNames = []string{
 var goodWeakValidationDigestNames = []string{
 	"namespace/pathcomponent/image@" + validDigest,
 	"library/ubuntu@" + validDigest,
+	"gcr.io/CROSSplane/PROVIDER-gcp@" + validDigest,
 }
 
 var goodWeakValidationTagDigestNames = []string{

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -26,11 +26,13 @@ var (
 		"crossplane/provider-gcp:v0.14.0",
 		"ubuntu",
 		"gcr.io/crossplane/provider-gcp:latest",
+		"gcr.io/CROSSplane/PROVIDER-gcp:latest",
 	}
 	outputDefaultNames = []string{
 		"registry.upbound.io/crossplane/provider-gcp:stable",
 		"registry.upbound.io/crossplane/provider-gcp:v0.14.0",
 		"registry.upbound.io/ubuntu:stable",
+		"gcr.io/crossplane/provider-gcp:latest",
 		"gcr.io/crossplane/provider-gcp:latest",
 	}
 )
@@ -39,10 +41,10 @@ func TestParseReferenceDefaulting(t *testing.T) {
 	for i, name := range inputDefaultNames {
 		ref, err := ParseReference(name, WithDefaultRegistry(testDefaultRegistry), WithDefaultTag(testDefaultTag))
 		if err != nil {
-			t.Errorf("ParseReference(%q); %v", name, err)
+			t.Fatalf("ParseReference(%q); %v", name, err)
 		}
 		if ref.Name() != outputDefaultNames[i] {
-			t.Errorf("ParseReference(%q); got %v, want %v", name, ref.String(), outputDefaultNames[i])
+			t.Errorf("ParseReference(%q); got %v, want %v", name, ref.Name(), outputDefaultNames[i])
 		}
 	}
 }

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -86,6 +86,13 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 		repo = parts[1]
 	}
 
+	if !opt.strict {
+		// The Docker client allows uppercase letters in repo names, which it lowercases
+		// to push to registries, so allow the repository to contain uppercase letters when
+		// strict validation is disabled.
+		repo = strings.ToLower(repo)
+	}
+
 	if err := checkRepository(repo); err != nil {
 		return Repository{}, err
 	}

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -33,6 +33,7 @@ var goodWeakValidationRepositoryNames = []string{
 	"namespace/pathcomponent/image",
 	"library/ubuntu",
 	"ubuntu",
+	"uBuNtU",
 }
 
 var badRepositoryNames = []string{


### PR DESCRIPTION
We recently discovered that `docker push` implicitly lowercases repository names, which isn't supported by GGCR.  This adds it to the list of magic :sparkles: that we do under `name.WeakValidation` to align with what docker supports.

Related: https://github.com/actions/starter-workflows/issues/1293