### PR TITLE
Make crane export more ergonomic

### DIFF
--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -32,9 +32,12 @@ func NewCmdExport(options *[]crane.Option) *cobra.Command {
 
   # Write tarball to file
   crane export ubuntu ubuntu.tar`,
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			src, dst := args[0], args[1]
+			src, dst := args[0], "-"
+			if len(args) > 1 {
+				dst = args[1]
+			}
 
 			f, err := openFile(dst)
 			if err != nil {

--- a/internal/gzip/zip.go
+++ b/internal/gzip/zip.go
@@ -115,3 +115,32 @@ func Is(r io.Reader) (bool, error) {
 	}
 	return bytes.Equal(magicHeader, gzipMagicHeader), nil
 }
+
+// PeekReader is an io.Reader that also implements Peek a la bufio.Reader.
+type PeekReader interface {
+	io.Reader
+	Peek(n int) ([]byte, error)
+}
+
+// Peek detects whether the input stream is gzip compressed.
+//
+// If r implements Peek, we will use that directly, otherwise a small number
+// of bytes are buffered to Peek at the gzip header, and the returned
+// PeekReader can be used as a replacement for the consumed input io.Reader.
+func Peek(r io.Reader) (bool, PeekReader, error) {
+	var pr PeekReader
+	if p, ok := r.(PeekReader); ok {
+		pr = p
+	} else {
+		pr = bufio.NewReader(r)
+	}
+	header, err := pr.Peek(2)
+	if err != nil {
+		// https://github.com/google/go-containerregistry/issues/367
+		if err == io.EOF {
+			return false, pr, nil
+		}
+		return false, pr, err
+	}
+	return bytes.Equal(header, gzipMagicHeader), pr, nil
+}

--- a/pkg/crane/export_test.go
+++ b/pkg/crane/export_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crane
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestExport(t *testing.T) {
+	want := []byte(`{"foo":"bar"}`)
+	layer := static.NewLayer(want, types.MediaType("application/json"))
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Export(img, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Errorf("got: %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
Default second arg to stdout so I don't have to type "-".

For images with a single layer, avoid calling mutate.Extract to flatten
the filesystem, instead we just write the uncompressed bytes to stdout.
In order to make that work, partial.Compressed now actually detects
whether the payload is gzipped or not when calling Uncompressed instead of just
assuming all blobs are compressed (and failing).

Fixes https://github.com/google/go-containerregistry/issues/1150