### PR TITLE
Support specifying osversion in the --platform flag

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -39,7 +39,6 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 	verbose := false
 	insecure := false
 	platform := &platformValue{}
-	var osVersion string
 
 	root := &cobra.Command{
 		Use:               use,
@@ -62,10 +61,6 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 					binary = filepath.Base(os.Args[0])
 				}
 				options = append(options, crane.WithUserAgent(fmt.Sprintf("%s/%s", binary, Version)))
-			}
-
-			if osVersion != "" {
-				platform.platform.OSVersion = osVersion
 			}
 
 			options = append(options, crane.WithPlatform(platform.platform))
@@ -118,8 +113,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
 	root.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow image references to be fetched without TLS")
-	root.PersistentFlags().Var(platform, "platform", "Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64).")
-	root.PersistentFlags().StringVar(&osVersion, "osversion", "", "Specifies the OS version.")
+	root.PersistentFlags().Var(platform, "platform", "Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64).")
 
 	return root
 }

--- a/cmd/crane/cmd/util.go
+++ b/cmd/crane/cmd/util.go
@@ -48,7 +48,13 @@ func parsePlatform(platform string) (*v1.Platform, error) {
 	}
 
 	p := &v1.Platform{}
-	parts := strings.Split(platform, "/")
+
+	parts := strings.SplitN(platform, ":", 2)
+	if len(parts) == 2 {
+		p.OSVersion = parts[1]
+	}
+
+	parts = strings.Split(parts[0], "/")
 
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("failed to parse platform '%s': expected format os/arch[/variant]", platform)

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -11,8 +11,7 @@ crane [flags]
 ```
   -h, --help                help for crane
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -31,8 +31,7 @@ crane append [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -16,8 +16,7 @@ crane auth [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -24,8 +24,7 @@ crane auth get [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -26,8 +26,7 @@ crane auth login [OPTIONS] [SERVER] [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_blob.md
+++ b/cmd/crane/doc/crane_blob.md
@@ -22,8 +22,7 @@ crane blob ubuntu@sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac3
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -16,8 +16,7 @@ crane catalog [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -16,8 +16,7 @@ crane config IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -16,8 +16,7 @@ crane copy SRC DST [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -16,8 +16,7 @@ crane delete IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -17,8 +17,7 @@ crane digest IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -26,8 +26,7 @@ crane export IMAGE TARBALL [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_flatten.md
+++ b/cmd/crane/doc/crane_flatten.md
@@ -17,8 +17,7 @@ crane flatten [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -16,8 +16,7 @@ crane ls REPO [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -16,8 +16,7 @@ crane manifest IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -23,8 +23,7 @@ crane mutate [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -18,8 +18,7 @@ crane pull IMAGE TARBALL [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -16,8 +16,7 @@ crane push TARBALL IMAGE [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -21,8 +21,7 @@ crane rebase [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_tag.md
+++ b/cmd/crane/doc/crane_tag.md
@@ -35,8 +35,7 @@ crane tag ubuntu v1
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -19,8 +19,7 @@ crane validate [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_version.md
+++ b/cmd/crane/doc/crane_version.md
@@ -23,8 +23,7 @@ crane version [flags]
 
 ```
       --insecure            Allow image references to be fetched without TLS
-      --osversion string    Specifies the OS version.
-      --platform platform   Specifies the platform in the form os/arch[/variant] (e.g. linux/amd64). (default all)
+      --platform platform   Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose             Enable debug logs
 ```
 


### PR DESCRIPTION
This removes the --osversion flag, and lets users specify the osversion
in the --platform flag itself, separated by a ":"

For example:

    crane manifest golang:1.17 --platform=windows/amd64:10.0.17763.2366

This matches the proposed behavior in https://github.com/google/ko/pull/536

cc @phillipsj -- is this format acceptable for your uses? `ko` has a stronger need to be able to specify the osversion in the platform, since it allows specifying multiple values, but I'd really like to keep them aligned if we can.