### PR TITLE
Always use basic for anonymous pings

### DIFF
--- a/pkg/v1/remote/multi_write_test.go
+++ b/pkg/v1/remote/multi_write_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -243,7 +244,7 @@ func TestMultiWrite_Retry(t *testing.T) {
 
 		// using a transport.Wrapper, meaning retry logic should not be wrapped
 		doesNotRetryTransport := &countTransport{inner: http.DefaultTransport}
-		transportWrapper, err := transport.NewWithContext(context.Background(), tag1.Repository.Registry, nil, doesNotRetryTransport, nil)
+		transportWrapper, err := transport.NewWithContext(context.Background(), tag1.Repository.Registry, authn.Anonymous, doesNotRetryTransport, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -283,7 +284,7 @@ func TestMultiWrite_Retry(t *testing.T) {
 
 		tag1 := mustNewTag(t, u.Host+"/repo:tag1")
 		// using a transport.Wrapper, meaning retry logic should not be wrapped
-		transportWrapper, err := transport.NewWithContext(context.Background(), tag1.Repository.Registry, nil, http.DefaultTransport, nil)
+		transportWrapper, err := transport.NewWithContext(context.Background(), tag1.Repository.Registry, authn.Anonymous, http.DefaultTransport, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -68,9 +68,7 @@ func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authentic
 	}
 
 	switch pr.challenge.Canonical() {
-	case anonymous:
-		return &Wrapper{t}, nil
-	case basic:
+	case anonymous, basic:
 		return &Wrapper{&basicTransport{inner: t, auth: auth, target: reg.RegistryStr()}}, nil
 	case bearer:
 		// We require the realm, which tells us where to send our Basic auth to turn it into Bearer auth.


### PR DESCRIPTION
Previously we would eschew any kind of wrapper if the ping returned a
200, but this means we don't correctly respond to challenges after the
initial ping. This is a half-fix, but for now we just assume basic if
the ping returns a 200 so that (at least) basic auth registries will
work.