### PR TITLE
Pluggable registry storage for uploads

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -74,11 +74,14 @@ func (r *registry) root(resp http.ResponseWriter, req *http.Request) {
 // New returns a handler which implements the docker registry protocol.
 // It should be registered at the site root.
 func New(opts ...Option) http.Handler {
+	bh := &memHandler{
+		blobs:   map[string][]byte{},
+		uploads: map[string][]byte{},
+	}
 	r := &registry{
 		log: log.New(os.Stderr, "", log.LstdFlags),
 		blobs: blobs{
-			blobHandler: &memHandler{m: map[string][]byte{}},
-			uploads:     map[string][]byte{},
+			blobHandler: bh,
 		},
 		manifests: manifests{
 			manifests: map[string]map[string]manifest{},


### PR DESCRIPTION
Continuing from #1158 

This adds interfaces and an in-memory implementation for storing partial uploads and committing them to finished blobs.