### PR TITLE
Add `--image-refs` to `crane push`.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,5 +61,5 @@ jobs:
         dst=localhost:1338/roundtrip-test
 
         ./app/crane pull --format=oci $img $layout
-        ./app/crane push $layout $dst 
-        diff <(./app/crane manifest $img) <(./app/crane manifest $dst)
+        ./app/crane push --image-refs=foo.images $layout $dst
+        diff <(./app/crane manifest $img) <(./app/crane manifest $(cat foo.images))

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -13,8 +13,9 @@ crane push PATH IMAGE [flags]
 ### Options
 
 ```
-  -h, --help    help for push
-      --index   push a collection of images as a single index, currently required if PATH contains multiple images
+  -h, --help                help for push
+      --image-refs string   path to file where a list of the published image references will be written
+      --index               push a collection of images as a single index, currently required if PATH contains multiple images
 ```
 
 ### Options inherited from parent commands

--- a/go.sum
+++ b/go.sum
@@ -432,7 +432,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
-github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=


### PR DESCRIPTION
This adds an `--image-refs` flag to `crane push` similar to the flag
I recently added to `ko`, which emits a file containing the digests
of the various images published by the command.

The intention of this flag is to work well with things like Tekton
Chains' `IMAGES` result for attesting to how a bunch of images were
produced.