### PR TITLE
Propagate crane options through gcrane cp -r

### DIFF
--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -213,7 +213,7 @@ func (c *copier) copyImages(ctx context.Context, t task) error {
 		srcImg := fmt.Sprintf("%s@%s", t.oldRepo, t.digest)
 		dstImg := fmt.Sprintf("%s@%s", t.newRepo, t.digest)
 
-		return Copy(srcImg, dstImg)
+		return crane.Copy(srcImg, dstImg, c.opt.crane...)
 	}
 
 	// We only need to push the whole image once.
@@ -221,7 +221,7 @@ func (c *copier) copyImages(ctx context.Context, t task) error {
 	srcImg := fmt.Sprintf("%s:%s", t.oldRepo, tag)
 	dstImg := fmt.Sprintf("%s:%s", t.newRepo, tag)
 
-	if err := Copy(srcImg, dstImg); err != nil {
+	if err := crane.Copy(srcImg, dstImg, c.opt.crane...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Missed this when refactoring a while back. We want options to get
proagated down into the image copying logic.

Adding this to release-0.6 so I can just cut v0.6.1 because `gcrane.CopyRepository` is kinda broken at v0.6.0 and I don't want to deal with all the changes in v0.7.0 right now.