### PR TITLE
Use Temp File For `layout.{Write,Append,Replace}` Image/Index Methods

### DIFF
--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -256,8 +256,10 @@ func (l Path) writeBlob(hash v1.Hash, size int64, r io.Reader, renamer func() (v
 	defer w.Close()
 
 	// Write to file and exit if not renaming
-	if _, err := io.Copy(w, r); err != nil || renamer == nil {
+	if n, err := io.Copy(w, r); err != nil || renamer == nil {
 		return err
+	} else if size != -1 && n != size {
+		return fmt.Errorf("expected blob size %d, but only wrote %d", size, n)
 	}
 
 	// Always close file before renaming

--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -229,8 +229,7 @@ func (l Path) WriteBlob(hash v1.Hash, r io.ReadCloser) error {
 
 func (l Path) writeBlob(hash v1.Hash, size int64, r io.Reader, renamer func() (v1.Hash, error)) error {
 	if hash.Hex == "" && renamer == nil {
-		// Should we panic, since this is a programming error?
-		return errors.New("writeBlob called an invalid hash and no renamer")
+		panic("writeBlob called an invalid hash and no renamer")
 	}
 
 	dir := l.path("blobs", hash.Algorithm)

--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -311,7 +311,6 @@ func (l Path) writeLayer(layer v1.Layer) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 
 	if err := l.writeBlob(d, s, r, layer.Digest); err != nil {
 		return fmt.Errorf("error writing layer: %w", err)

--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -253,6 +253,10 @@ func (l Path) writeBlob(hash v1.Hash, size int64, r io.Reader, renamer func() (v
 	if err != nil {
 		return err
 	}
+	if renamer != nil {
+		// Delete temp file if an error is encountered before renaming
+		defer os.Remove(w.Name())
+	}
 	defer w.Close()
 
 	// Write to file and exit if not renaming

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -545,7 +545,7 @@ func TestStreamingWriteLayer(t *testing.T) {
 	}
 }
 
-func TestOverwriteWithwriteLayer(t *testing.T) {
+func TestOverwriteWithWriteLayer(t *testing.T) {
 	// need to set up a basic path
 	tmp, err := ioutil.TempDir("", "overwrite-with-write-layer-test")
 	if err != nil {

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -526,7 +526,7 @@ func TestStreamingWriteLayer(t *testing.T) {
 	if _, err := img.Digest(); err == nil {
 		t.Fatal("digesting image before stream is consumed; (v1.Image).Digest() = nil, expected err")
 	}
-	// AppendImage uses WriteLayer
+	// AppendImage uses writeLayer
 	if err := l.AppendImage(img); err != nil {
 		t.Fatalf("(Path).AppendImage() = %v", err)
 	}
@@ -538,14 +538,14 @@ func TestStreamingWriteLayer(t *testing.T) {
 	}
 	img, err = l.Image(imgDigest)
 	if err != nil {
-		t.Fatalf("error loading image after WriteLayer for validation; (Path).Image = %v", err)
+		t.Fatalf("error loading image after writeLayer for validation; (Path).Image = %v", err)
 	}
 	if err := validate.Image(img); err != nil {
 		t.Fatalf("validate.Image() = %v", err)
 	}
 }
 
-func TestOverwriteWithWriteLayer(t *testing.T) {
+func TestOverwriteWithwriteLayer(t *testing.T) {
 	// need to set up a basic path
 	tmp, err := ioutil.TempDir("", "overwrite-with-write-layer-test")
 	if err != nil {
@@ -626,18 +626,18 @@ func TestOverwriteWithWriteLayer(t *testing.T) {
 		t.Fatal("validating image after attempting repair of truncated layer with WriteBlob; validate.Image() = nil, expected err")
 	}
 
-	// try writing expected contents with WriteLayer
-	if err := l.WriteLayer(layer); err != nil {
-		t.Fatalf("error attempting to overwrite truncated layer with valid layer; (Path).WriteLayer = %v", err)
+	// try writing expected contents with writeLayer
+	if err := l.writeLayer(layer); err != nil {
+		t.Fatalf("error attempting to overwrite truncated layer with valid layer; (Path).writeLayer = %v", err)
 	}
 
 	// validation should now succeed
 	img, err = l.Image(imgDigest)
 	if err != nil {
-		t.Fatalf("error loading truncated image after WriteLayer for validation; (Path).Image = %v", err)
+		t.Fatalf("error loading truncated image after writeLayer for validation; (Path).Image = %v", err)
 	}
 	if err := validate.Image(img); err != nil {
-		t.Fatalf("validating image after attempting repair of truncated layer with WriteLayer; validate.Image() = %v", err)
+		t.Fatalf("validating image after attempting repair of truncated layer with writeLayer; validate.Image() = %v", err)
 	}
 }
 

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -1,6 +1,21 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package layout
 
 import (
+	"archive/tar"
 	"bytes"
 	"io"
 	"io/ioutil"
@@ -12,7 +27,9 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/match"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
@@ -461,5 +478,246 @@ func TestRemoveBlob(t *testing.T) {
 	// now it should not exist
 	if _, err = l.Bytes(hash); err == nil {
 		t.Fatal("still existed after deletion")
+	}
+}
+
+func TestStreamingWriteLayer(t *testing.T) {
+	// need to set up a basic path
+	tmp, err := ioutil.TempDir("", "streaming-write-layer-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tmp)
+
+	var ii v1.ImageIndex = empty.Index
+	l, err := Write(tmp, ii)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a random streaming image and persist
+	pr, pw := io.Pipe()
+	tw := tar.NewWriter(pw)
+	go func() {
+		pw.CloseWithError(func() error {
+			body := "test file"
+			if err := tw.WriteHeader(&tar.Header{
+				Name:     "test.txt",
+				Mode:     0600,
+				Size:     int64(len(body)),
+				Typeflag: tar.TypeReg,
+			}); err != nil {
+				return err
+			}
+			if _, err := tw.Write([]byte(body)); err != nil {
+				return err
+			}
+			return tw.Close()
+		}())
+	}()
+	img, err := mutate.Append(empty.Image, mutate.Addendum{
+		Layer: stream.NewLayer(pr),
+	})
+	if err != nil {
+		t.Fatalf("creating random streaming image failed: %v", err)
+	}
+	if _, err := img.Digest(); err == nil {
+		t.Fatal("digesting image before stream is consumed; (v1.Image).Digest() = nil, expected err")
+	}
+	// AppendImage uses WriteLayer
+	if err := l.AppendImage(img); err != nil {
+		t.Fatalf("(Path).AppendImage() = %v", err)
+	}
+
+	// Check that image was persisted and is valid
+	imgDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("(v1.Image).Digest() = %v", err)
+	}
+	img, err = l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading image after WriteLayer for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Fatalf("validate.Image() = %v", err)
+	}
+}
+
+func TestOverwriteWithWriteLayer(t *testing.T) {
+	// need to set up a basic path
+	tmp, err := ioutil.TempDir("", "overwrite-with-write-layer-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tmp)
+
+	var ii v1.ImageIndex = empty.Index
+	l, err := Write(tmp, ii)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a random image and persist
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	imgDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("(v1.Image).Digest() = %v", err)
+	}
+	if err := l.AppendImage(img); err != nil {
+		t.Fatalf("(Path).AppendImage() = %v", err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Fatalf("validate.Image() = %v", err)
+	}
+
+	// get the random image's layer
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(layers); n != 1 {
+		t.Fatalf("expected image with 1 layer, got %d", n)
+	}
+
+	layer := layers[0]
+	layerDigest, err := layer.Digest()
+	if err != nil {
+		t.Fatalf("(v1.Layer).Digest() = %v", err)
+	}
+
+	// truncate the layer contents on disk
+	completeLayerBytes, err := l.Bytes(layerDigest)
+	if err != nil {
+		t.Fatalf("(Path).Bytes() = %v", err)
+	}
+	truncatedLayerBytes := completeLayerBytes[:512]
+
+	path := l.path("blobs", layerDigest.Algorithm, layerDigest.Hex)
+	if err := ioutil.WriteFile(path, truncatedLayerBytes, os.ModePerm); err != nil {
+		t.Fatalf("ioutil.WriteFile(layerPath, truncated) = %v", err)
+	}
+
+	// ensure validation fails
+	img, err = l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading truncated image for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(img); err == nil {
+		t.Fatal("validating image after truncating layer; validate.Image() = nil, expected err")
+	}
+
+	// try writing expected contents with WriteBlob
+	if err := l.WriteBlob(layerDigest, ioutil.NopCloser(bytes.NewBuffer(completeLayerBytes))); err != nil {
+		t.Fatalf("error attempting to overwrite truncated layer with valid layer; (Path).WriteBlob = %v", err)
+	}
+
+	// validation should still fail
+	img, err = l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading truncated image after WriteBlob for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(img); err == nil {
+		t.Fatal("validating image after attempting repair of truncated layer with WriteBlob; validate.Image() = nil, expected err")
+	}
+
+	// try writing expected contents with WriteLayer
+	if err := l.WriteLayer(layer); err != nil {
+		t.Fatalf("error attempting to overwrite truncated layer with valid layer; (Path).WriteLayer = %v", err)
+	}
+
+	// validation should now succeed
+	img, err = l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading truncated image after WriteLayer for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Fatalf("validating image after attempting repair of truncated layer with WriteLayer; validate.Image() = %v", err)
+	}
+}
+
+func TestOverwriteWithReplaceImage(t *testing.T) {
+	// need to set up a basic path
+	tmp, err := ioutil.TempDir("", "overwrite-with-replace-image-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tmp)
+
+	var ii v1.ImageIndex = empty.Index
+	l, err := Write(tmp, ii)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a random image and persist
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	imgDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("(v1.Image).Digest() = %v", err)
+	}
+	if err := l.AppendImage(img); err != nil {
+		t.Fatalf("(Path).AppendImage() = %v", err)
+	}
+	if err := validate.Image(img); err != nil {
+		t.Fatalf("validate.Image() = %v", err)
+	}
+
+	// get the random image's layer
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(layers); n != 1 {
+		t.Fatalf("expected image with 1 layer, got %d", n)
+	}
+
+	layer := layers[0]
+	layerDigest, err := layer.Digest()
+	if err != nil {
+		t.Fatalf("(v1.Layer).Digest() = %v", err)
+	}
+
+	// truncate the layer contents on disk
+	completeLayerBytes, err := l.Bytes(layerDigest)
+	if err != nil {
+		t.Fatalf("(Path).Bytes() = %v", err)
+	}
+	truncatedLayerBytes := completeLayerBytes[:512]
+
+	path := l.path("blobs", layerDigest.Algorithm, layerDigest.Hex)
+	if err := ioutil.WriteFile(path, truncatedLayerBytes, os.ModePerm); err != nil {
+		t.Fatalf("ioutil.WriteFile(layerPath, truncated) = %v", err)
+	}
+
+	// ensure validation fails
+	truncatedImg, err := l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading truncated image for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(truncatedImg); err == nil {
+		t.Fatal("validating image after truncating layer; validate.Image() = nil, expected err")
+	}
+
+	// try writing expected contents with ReplaceImage
+	if err := l.ReplaceImage(img, match.Digests(imgDigest)); err != nil {
+		t.Fatalf("error attempting to overwrite truncated layer with valid layer; (Path).ReplaceImage = %v", err)
+	}
+
+	// validation should now succeed
+	repairedImg, err := l.Image(imgDigest)
+	if err != nil {
+		t.Fatalf("error loading truncated image after ReplaceImage for validation; (Path).Image = %v", err)
+	}
+	if err := validate.Image(repairedImg); err != nil {
+		t.Fatalf("validating image after attempting repair of truncated layer with ReplaceImage; validate.Image() = %v", err)
 	}
 }

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -705,6 +706,8 @@ func TestOverwriteWithReplaceImage(t *testing.T) {
 	}
 	if err := validate.Image(truncatedImg); err == nil {
 		t.Fatal("validating image after truncating layer; validate.Image() = nil, expected err")
+	} else if strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("validating image after truncating layer; validate.Image() error is not helpful: %v", err)
 	}
 
 	// try writing expected contents with ReplaceImage

--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -113,12 +114,25 @@ func validateLayers(img v1.Image, opt ...Option) error {
 		return layersExist(layers)
 	}
 
+	cf, err := img.ConfigFile()
+	if err != nil {
+		return err
+	}
+
+	m, err := img.Manifest()
+	if err != nil {
+		return err
+	}
+
 	digests := []v1.Hash{}
 	diffids := []v1.Hash{}
 	udiffids := []v1.Hash{}
 	sizes := []int64{}
-	for _, layer := range layers {
+	for i, layer := range layers {
 		cl, err := computeLayer(layer)
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return fmt.Errorf("undersized layer[%d] content: Manifest.Layers[%d].Size=%d", i, i, m.Layers[i].Size)
+		}
 		if err != nil {
 			return err
 		}
@@ -128,16 +142,6 @@ func validateLayers(img v1.Image, opt ...Option) error {
 		diffids = append(diffids, cl.diffid)
 		udiffids = append(udiffids, cl.uncompressedDiffid)
 		sizes = append(sizes, cl.size)
-	}
-
-	cf, err := img.ConfigFile()
-	if err != nil {
-		return err
-	}
-
-	m, err := img.Manifest()
-	if err != nil {
-		return err
 	}
 
 	errs := []string{}


### PR DESCRIPTION
This pull request was prompted by https://github.com/linuxkit/linuxkit/pull/3748.

Linuxkit, which uses an oci-layout cache, suffers the need for frequent cache clears, because interrupted downloads of layers results in images which fail `validate.Image` but cannot be repaired with a subsequent `(layout.Path).ReplaceImage`. This is due to the underlying call to `(layout.Path).WriteBlob` which does not overwrite existing files, even if they are smaller than the size the manifest claims they should be.

I found these comments in `pkg/v1/layout/write.go`:

```
// TODO: A streaming version of WriteBlob so we don't have to know the hash
// before we write it.

// TODO: For streaming layers we should write to a tmp file then Rename to the
// final digest.
```

I believe that this PR addresses both issues and will resolve the issue in Linuxkit, as well. However, I have no need for calling `WriteLayer` as library code, so I'm not opposed to making it unexported, as long as `ReplaceImage` makes use of its behaviors of overwriting undersized layers and/or writing blobs to a temporary location and renaming. 

---

Changes:

`WriteLayer` is an alternative to `WriteBlob` which can be used with streaming layers which have not yet calculated a digest or size. A temporary file is first written and then renamed when the reader has been fully consumed. Also, existing layers which do not have the correct size (and thus invalid hashes, but the hash is not checked) are overwritten.

`{Append,Replace,Write}{Image,Layer}` functions utilize `WriteLayer` instead of `WriteBlob` to correctly overwrite undersized layers which were previously ignored without error. Undersized layers should no longer occur, since `WriteLayer` writes to a temporary file first, but when `WriteBlob` was used, these were common due to incomplete downloads.

Improve error messages for `validate.Image` and `validate.Index` when layer blob content is truncated.