### PR TITLE
pkg/authn: return Anonymous on podman auth.json errors

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -101,10 +101,8 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 		}
 	} else {
 		f, err := os.Open(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json"))
-		if os.IsNotExist(err) {
+		if err != nil {
 			return Anonymous, nil
-		} else if err != nil {
-			return nil, err
 		}
 		defer f.Close()
 		cf, err = config.LoadFromReader(f)


### PR DESCRIPTION
This is similar to what happens when the package looks for Docker's
config.json, it ignores any error (not found, permissions denied, …)
and pass on.

This should help https://github.com/tektoncd/chains/issues/320 not to happen for example.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @imjasonh @mattmoor @concaf