### PR TITLE
Fix Azure Container Registry authentication

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -160,5 +160,12 @@ func (w wrapper) Resolve(r Resource) (Authenticator, error) {
 	if err != nil {
 		return Anonymous, nil
 	}
+
+	// if the secret being stored is an identity token, the Username should be set to <token>
+	// reference: https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol
+	if u == "<token>" {
+		return FromConfig(AuthConfig{Username: u, IdentityToken: p}), nil
+	}
+
 	return FromConfig(AuthConfig{Username: u, Password: p}), nil
 }

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -156,7 +156,7 @@ func NewKeychainFromHelper(h Helper) Keychain { return wrapper{h} }
 type wrapper struct{ h Helper }
 
 func (w wrapper) Resolve(r Resource) (Authenticator, error) {
-	u, p, err := w.h.Get(r.String())
+	u, p, err := w.h.Get(r.RegistryStr())
 	if err != nil {
 		return Anonymous, nil
 	}


### PR DESCRIPTION
Fixes #1255

I'm not sure if this is the best or preferred way of handling this, another way may be to add a check to `NewKeychainFromHelper()` that checks if the username is `<token>` and adds `IdentityToken` to the `AuthConfig{}`.

Any and all feedback is welcome and if you see that I've missed something obvious and that's why I've done this, please point it out and I'll fix the issue where it's located.