### PR TITLE
Add output option to mutate to save to a tar file and not push to a registry (same as append)

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -33,7 +33,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var entrypoint, cmd []string
 	var envVars map[string]string
 	var newLayers []string
-
+	var outFile string
 	var newRef string
 
 	mutateCmd := &cobra.Command{
@@ -122,17 +122,23 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("digesting new image: %w", err)
 			}
-			r, err := name.ParseReference(newRef)
-			if err != nil {
-				return fmt.Errorf("parsing %s: %w", newRef, err)
+			if outFile != "" {
+				if err := crane.Save(img, newRef, outFile); err != nil {
+					return fmt.Errorf("writing output %q: %w", outFile, err)
+				}
+			} else {
+				r, err := name.ParseReference(newRef)
+				if err != nil {
+					return fmt.Errorf("parsing %s: %w", newRef, err)
+				}
+				if _, ok := r.(name.Digest); ok {
+					newRef = r.Context().Digest(digest.String()).String()
+				}
+				if err := crane.Push(img, newRef, *options...); err != nil {
+					return fmt.Errorf("pushing %s: %w", newRef, err)
+				}
+				fmt.Println(r.Context().Digest(digest.String()))
 			}
-			if _, ok := r.(name.Digest); ok {
-				newRef = r.Context().Digest(digest.String()).String()
-			}
-			if err := crane.Push(img, newRef, *options...); err != nil {
-				return fmt.Errorf("pushing %s: %w", newRef, err)
-			}
-			fmt.Println(r.Context().Digest(digest.String()))
 			return nil
 		},
 	}
@@ -142,6 +148,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
 	mutateCmd.Flags().StringSliceVar(&cmd, "cmd", nil, "New cmd to set")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
+	mutateCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
 	mutateCmd.Flags().StringSliceVar(&newLayers, "append", []string{}, "Path to tarball to append to image")
 	return mutateCmd
 }

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -16,6 +16,7 @@ crane mutate [flags]
   -e, --env stringToString          New envvar to add (default [])
   -h, --help                        help for mutate
   -l, --label stringToString        New labels to add (default [])
+  -o, --output string               Path to new tarball of resulting image
   -t, --tag string                  New tag to apply to mutated image. If not provided, push by digest to the original image repository.
 ```
 


### PR DESCRIPTION
Support passing crane mutate an output as a tar. Append has it and it is useful for all kinds of more complex build and push flows