### PR TITLE
Fix krane:debug image to include shell

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
     cd ../../
 
     # Use the ko binary to build the crane-ish builder *debug* images.
-    export KO_CONFIG_PATH=./.ko/debug/
+    export KO_CONFIG_PATH=$(pwd)/.ko/debug/
     ko publish --platform=all -B github.com/google/go-containerregistry/cmd/crane  -t "debug"
     ko publish --platform=all -B github.com/google/go-containerregistry/cmd/gcrane -t "debug"
     # ./cmd/krane is a separate module, so switch directories.


### PR DESCRIPTION
`KO_CONFIG_PATH=./.ko/debug` was being interpreted as relative to `cmd/krane` when we `cd`'d into it. Making it an absolute path fixes this.

Fixes https://github.com/google/go-containerregistry/issues/1262

Tested locally and produced `gcr.io/imjasonh/krane:debug`:

```console
$ docker run --rm --entrypoint sh gcr.io/imjasonh/krane:debug -c "ls /"
bin
boot
busybox
...
```