### PR TITLE
Fix NewKeychainFromHelper

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -154,9 +154,14 @@ func NewKeychainFromHelper(h Helper) Keychain { return wrapper{h} }
 type wrapper struct{ h Helper }
 
 func (w wrapper) Resolve(r Resource) (Authenticator, error) {
-	u, p, err := w.h.Get(r.String())
+	u, p, err := w.h.Get(r.RegistryStr())
 	if err != nil {
 		return Anonymous, nil
+	}
+	// If the secret being stored is an identity token, the Username should be set to <token>
+	// ref: https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol
+	if u == "<token>" {
+		return FromConfig(AuthConfig{Username: u, IdentityToken: p}), nil
 	}
 	return FromConfig(AuthConfig{Username: u, Password: p}), nil
 }

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -285,7 +285,7 @@ func TestNewKeychainFromHelper(t *testing.T) {
 			t.Errorf("Username: got %q, want %q", got, want)
 		}
 		if got, want := cfg.IdentityToken, ""; got != want {
-			t.Errorf("Password: got %q, want %q", got, want)
+			t.Errorf("IdentityToken: got %q, want %q", got, want)
 		}
 		if got, want := cfg.Password, "password"; got != want {
 			t.Errorf("Password: got %q, want %q", got, want)
@@ -306,7 +306,7 @@ func TestNewKeychainFromHelper(t *testing.T) {
 			t.Errorf("Username: got %q, want %q", got, want)
 		}
 		if got, want := cfg.IdentityToken, "idtoken"; got != want {
-			t.Errorf("Password: got %q, want %q", got, want)
+			t.Errorf("IdentityToken: got %q, want %q", got, want)
 		}
 		if got, want := cfg.Password, ""; got != want {
 			t.Errorf("Password: got %q, want %q", got, want)

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -256,36 +256,68 @@ func TestVariousPaths(t *testing.T) {
 	}
 }
 
-type helper struct{ err error }
+type helper struct {
+	u, p string
+	err  error
+}
 
 func (h helper) Get(serverURL string) (string, string, error) {
-	return "helper-username", "helper-password", h.err
+	if serverURL != "example.com" {
+		return "", "", fmt.Errorf("unexpected serverURL: %s", serverURL)
+	}
+	return h.u, h.p, h.err
 }
 
 func TestNewKeychainFromHelper(t *testing.T) {
+	var repo = name.MustParseReference("example.com/my/repo").Context()
+
 	t.Run("success", func(t *testing.T) {
-		kc := NewKeychainFromHelper(helper{})
-		auth, err := kc.Resolve(defaultRegistry)
+		kc := NewKeychainFromHelper(helper{"username", "password", nil})
+		auth, err := kc.Resolve(repo)
 		if err != nil {
-			t.Fatalf("Resolve(%q): %v", defaultRegistry, err)
+			t.Fatalf("Resolve(%q): %v", repo, err)
 		}
 		cfg, err := auth.Authorization()
 		if err != nil {
 			t.Fatalf("Authorization: %v", err)
 		}
-		if got, want := cfg.Username, "helper-username"; got != want {
+		if got, want := cfg.Username, "username"; got != want {
 			t.Errorf("Username: got %q, want %q", got, want)
 		}
-		if got, want := cfg.Password, "helper-password"; got != want {
+		if got, want := cfg.IdentityToken, ""; got != want {
+			t.Errorf("Password: got %q, want %q", got, want)
+		}
+		if got, want := cfg.Password, "password"; got != want {
+			t.Errorf("Password: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("success; identity token", func(t *testing.T) {
+		kc := NewKeychainFromHelper(helper{"<token>", "idtoken", nil})
+		auth, err := kc.Resolve(repo)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", repo, err)
+		}
+		cfg, err := auth.Authorization()
+		if err != nil {
+			t.Fatalf("Authorization: %v", err)
+		}
+		if got, want := cfg.Username, "<token>"; got != want {
+			t.Errorf("Username: got %q, want %q", got, want)
+		}
+		if got, want := cfg.IdentityToken, "idtoken"; got != want {
+			t.Errorf("Password: got %q, want %q", got, want)
+		}
+		if got, want := cfg.Password, ""; got != want {
 			t.Errorf("Password: got %q, want %q", got, want)
 		}
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		kc := NewKeychainFromHelper(helper{errors.New("oh no bad")})
-		auth, err := kc.Resolve(defaultRegistry)
+		kc := NewKeychainFromHelper(helper{"", "", errors.New("oh no bad")})
+		auth, err := kc.Resolve(repo)
 		if err != nil {
-			t.Fatalf("Resolve(%q): %v", defaultRegistry, err)
+			t.Fatalf("Resolve(%q): %v", repo, err)
 		}
 		if auth != Anonymous {
 			t.Errorf("Resolve: got %v, want %v", auth, Anonymous)


### PR DESCRIPTION
- only pass RegistryStr, since helpers don't expect to see repo paths,
  and might not handle them correctly
- if the returned username is "<token>", interpret the returned password
  as an identity token
- add unit tests to cover both of these behaviors

This builds on the excellent work done by @simongottschlag in https://github.com/google/go-containerregistry/pull/1256, and adds unit tests.