### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/crane_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/crane_bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: crane: Bug report
+name: crane bug report
 about: Create a report to help us improve the crane or gcrane CLIs
 title: 'crane:'
 labels: bug

--- a/.github/ISSUE_TEMPLATE/ggcr_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/ggcr_bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Go library: Bug report
+name: Go library bug report
 about: Create a report to help us improve the Go library
 title: 'ggcr:'
 labels: bug


### PR DESCRIPTION
The `:` in the name seems to confuse the YAML parser, and as a result these issue templates are not available at https://github.com/google/go-containerregistry/issues/new/choose