### PR TITLE
Add EOF to remote default retry predicate

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -59,7 +59,7 @@ type Backoff = retry.Backoff
 var defaultRetryPredicate retry.Predicate = func(err error) bool {
 	// Various failure modes here, as we're often reading from and writing to
 	// the network.
-	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE) {
+	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || errors.Is(err, syscall.EPIPE) {
 		logs.Warn.Printf("retrying %v", err)
 		return true
 	}


### PR DESCRIPTION
We see EOF when the server closes a connection without sending an
appropriate "Connection: close" header. The http Client attempts to
reuse a connection, but it fails with EOF because that connection is
closed. For idempotent requests, the http client will handle this for
us, but because this is a POST request, we just get the EOF back.