### PR TITLE
Eagerly fetch image ID in daemon.Image

### DIFF
--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -31,6 +31,7 @@ type image struct {
 	ref          name.Reference
 	opener       *imageOpener
 	tarballImage v1.Image
+	id           *v1.Hash
 
 	once sync.Once
 	err  error
@@ -95,10 +96,20 @@ func Image(ref name.Reference, options ...Option) (v1.Image, error) {
 		ctx:      o.ctx,
 	}
 
-	return &image{
+	img := &image{
 		ref:    ref,
 		opener: i,
-	}, nil
+	}
+
+	// Eagerly fetch Image ID to ensure it actually exists.
+	// https://github.com/google/go-containerregistry/issues/1186
+	id, err := img.ConfigName()
+	if err != nil {
+		return nil, err
+	}
+	img.id = &id
+
+	return img, nil
 }
 
 func (i *image) initialize() error {
@@ -133,6 +144,9 @@ func (i *image) Size() (int64, error) {
 }
 
 func (i *image) ConfigName() (v1.Hash, error) {
+	if i.id != nil {
+		return *i.id, nil
+	}
 	res, _, err := i.opener.client.ImageInspectWithRaw(i.opener.ctx, i.ref.String())
 	if err != nil {
 		return v1.Hash{}, err


### PR DESCRIPTION
Currently, daemon.Image is so lazy that non-existent images don't return
an error. This changes ensures that the image actually exists by asking
the daemon for its Image ID.

Fixes https://github.com/google/go-containerregistry/issues/1186