### PR TITLE
crane export: Support reading tarball from a stream

### DIFF
--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -31,14 +31,14 @@ import (
 func NewCmdExport(options *[]crane.Option) *cobra.Command {
 	return &cobra.Command{
 		Use:   "export IMAGE|- TARBALL",
-		Short: "Export contents of a remote image as a filesystem tarball",
+		Short: "Export filesystem of a container image as a tarball",
 		Example: `  # Write tarball to stdout
   crane export ubuntu -
 
   # Write tarball to file
   crane export ubuntu ubuntu.tar
 
-  # Read image tarball from stdin
+  # Read image from stdin
   crane export - ubuntu.tar`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -30,7 +30,7 @@ import (
 // NewCmdExport creates a new cobra.Command for the export subcommand.
 func NewCmdExport(options *[]crane.Option) *cobra.Command {
 	return &cobra.Command{
-		Use:   "export IMAGE|- TARBALL",
+		Use:   "export IMAGE|- TARBALL|-",
 		Short: "Export filesystem of a container image as a tarball",
 		Example: `  # Write tarball to stdout
   crane export ubuntu -

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -52,8 +53,10 @@ func NewCmdExport(options *[]crane.Option) *cobra.Command {
 
 			var img v1.Image
 			if src == "-" {
-				//img, err = tarball.Image(func() (io.ReadCloser, error) { return io.ReadCloser(os.Stdin), nil }, nil)
-				img, err = tarball.ImageFromPath("test.tar", nil)
+				img, err = tarball.Image(func() (io.ReadCloser, error) {
+					return io.ReadCloser(os.Stdin), nil
+				}, nil)
+				//img, err = tarball.ImageFromPath("test.tar", nil)
 				if err != nil {
 					return fmt.Errorf("reading tarball from stdin: %w", err)
 				}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -25,7 +25,7 @@ crane [flags]
 * [crane copy](crane_copy.md)	 - Efficiently copy a remote image from src to dst while retaining the digest value
 * [crane delete](crane_delete.md)	 - Delete an image reference from its registry
 * [crane digest](crane_digest.md)	 - Get the digest of an image
-* [crane export](crane_export.md)	 - Export contents of a remote image as a tarball
+* [crane export](crane_export.md)	 - Export filesystem of a container image as a tarball
 * [crane flatten](crane_flatten.md)	 - Flatten an image's layers into a single layer
 * [crane ls](crane_ls.md)	 - List the tags in a repo
 * [crane manifest](crane_manifest.md)	 - Get the manifest of an image

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -1,9 +1,9 @@
 ## crane export
 
-Export contents of a remote image as a tarball
+Export filesystem of a container image as a tarball
 
 ```
-crane export IMAGE TARBALL [flags]
+crane export IMAGE|- TARBALL [flags]
 ```
 
 ### Examples
@@ -14,6 +14,9 @@ crane export IMAGE TARBALL [flags]
 
   # Write tarball to file
   crane export ubuntu ubuntu.tar
+
+  # Read image from stdin
+  crane export - ubuntu.tar
 ```
 
 ### Options

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -3,7 +3,7 @@
 Export filesystem of a container image as a tarball
 
 ```
-crane export IMAGE|- TARBALL [flags]
+crane export IMAGE|- TARBALL|- [flags]
 ```
 
 ### Examples

--- a/pkg/crane/export.go
+++ b/pkg/crane/export.go
@@ -17,7 +17,6 @@ package crane
 import (
 	"io"
 
-	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 )
@@ -30,7 +29,6 @@ func Export(img v1.Image, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	logs.Debug.Printf("layers found: %v", len(layers))
 	if len(layers) == 1 {
 		// If it's a single layer, we don't have to flatten the filesystem.
 		// An added perk of skipping mutate.Extract here is that this works

--- a/pkg/crane/export.go
+++ b/pkg/crane/export.go
@@ -17,6 +17,7 @@ package crane
 import (
 	"io"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 )
@@ -29,6 +30,7 @@ func Export(img v1.Image, w io.Writer) error {
 	if err != nil {
 		return err
 	}
+	logs.Debug.Printf("layers found: %v", len(layers))
 	if len(layers) == 1 {
 		// If it's a single layer, we don't have to flatten the filesystem.
 		// An added perk of skipping mutate.Extract here is that this works


### PR DESCRIPTION
Implementation for #1273.

The goal is to read from stdin if the first argument is "-".

```
./crane export - ubuntu.tar < test.tar
```

~~I was not able to trace what is wrong with reading from `os.Stdin`, and my Go skills are not that good to understand it from the code.~~