### PR TITLE
Fallback to anonymous if env or gcloud are not configured

### DIFF
--- a/pkg/v1/google/auth_test.go
+++ b/pkg/v1/google/auth_test.go
@@ -1,5 +1,5 @@
-//go:build !arm64 && !darwin
-// +build !arm64,!darwin
+//go:build !arm64
+// +build !arm64
 
 // Copyright 2018 Google LLC All Rights Reserved.
 //
@@ -234,8 +234,10 @@ func TestKeychainError(t *testing.T) {
 
 	// Reset the keychain to ensure we don't cache earlier results.
 	Keychain = &googleKeychain{}
-	if _, err := Keychain.Resolve(mustRegistry("gcr.io")); err == nil {
-		t.Fatalf("expected err, got: %v", err)
+	if auth, err := Keychain.Resolve(mustRegistry("gcr.io")); err != nil {
+		t.Fatalf("got error: %v", err)
+	} else if auth != authn.Anonymous {
+		t.Fatalf("wanted Anonymous, got %v", auth)
 	}
 }
 

--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -63,21 +63,21 @@ func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, e
 	}
 
 	gk.once.Do(func() {
-		gk.auth, gk.err = resolve()
+		gk.auth = resolve()
 	})
 
-	return gk.auth, gk.err
+	return gk.auth, nil
 }
 
-func resolve() (authn.Authenticator, error) {
+func resolve() authn.Authenticator {
 	auth, envErr := NewEnvAuthenticator()
 	if envErr == nil && auth != authn.Anonymous {
-		return auth, nil
+		return auth
 	}
 
 	auth, gErr := NewGcloudAuthenticator()
 	if gErr == nil && auth != authn.Anonymous {
-		return auth, nil
+		return auth
 	}
 
 	logs.Debug.Println("Failed to get any Google credentials, falling back to Anonymous")
@@ -87,5 +87,5 @@ func resolve() (authn.Authenticator, error) {
 	if gErr != nil {
 		logs.Debug.Printf("gcloud error: %v", gErr)
 	}
-	return authn.Anonymous, nil
+	return authn.Anonymous
 }

--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -28,7 +28,6 @@ var Keychain authn.Keychain = &googleKeychain{}
 type googleKeychain struct {
 	once sync.Once
 	auth authn.Authenticator
-	err  error
 }
 
 // Resolve implements authn.Keychain a la docker-credential-gcr.


### PR DESCRIPTION
If `google.Keychain` is used with `NewMultiKeychain`, it will be selected to provide credentials to pull or push images for images in GCR/AR. If, in this case, Application Default Credentials aren't configured and `gcloud` is not available or configured to provide credentials, the keychain will fail, even if the image is otherwise publicly available.

With this change, if the env credential lookup and `gcloud` credential lookup both fail, instead of returning an error, `google.Keychain` will fallback to return `authn.Anonymous` instead. In this case, `NewMultiKeychain` will fall through each option in turn, until finally using `authn.Anonymous` if none match and provide credentials.