### PR TITLE
Add one-time workflow to push an image to ghcr.io

### DIFF
--- a/.github/workflows/ghcr-auth.yaml
+++ b/.github/workflows/ghcr-auth.yaml
@@ -28,4 +28,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # List the tags
-          krane ls ghcr.io/${{ github.repository }}
+          krane ls ghcr.io/${{ github.repository }}/testimage

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -1,0 +1,25 @@
+name: Push image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  push-image:
+    name: Push image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+
+    - env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        go build ./cmd/crane
+        echo ${GITHUB_TOKEN} | ./crane auth login ghcr.io --username unused --password-stdin
+        ./crane cp gcr.io/distroless/static:nonroot ghcr.io/${{ github.repository }}/testimage


### PR DESCRIPTION
This will hopefully fix our permanently failing GHCR auth test. 🤞 

After we run it and have an image in the repo, we can delete the workflow, unless we want to keep it around for some reason.