### PR TITLE
LayerFromReader: buffer contents to a temp file instead of in memory

### DIFF
--- a/pkg/crane/filemap_test.go
+++ b/pkg/crane/filemap_test.go
@@ -16,6 +16,7 @@ package crane_test
 
 import (
 	"archive/tar"
+	"errors"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -85,7 +86,7 @@ func TestLayer(t *testing.T) {
 			saw := map[string]struct{}{}
 			for {
 				th, err := tr.Next()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				if err != nil {

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -252,6 +252,8 @@ func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 // LayerFromReader returns a v1.Layer given a io.Reader.
 //
 // The reader's contents are read and buffered to a temp file in the process.
+//
+// Deprecated: Use LayerFromOpener or stream.NewLayer instead, if possible.
 func LayerFromReader(reader io.Reader, opts ...LayerOption) (v1.Layer, error) {
 	tmp, err := ioutil.TempFile("", "")
 	if err != nil {

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -262,7 +262,7 @@ func LayerFromReader(reader io.Reader, opts ...LayerOption) (v1.Layer, error) {
 	if _, err := io.Copy(tmp, reader); err != nil {
 		return nil, fmt.Errorf("writing temp file to buffer reader: %w", err)
 	}
-	return LayerFromFile(tmp.Name())
+	return LayerFromFile(tmp.Name(), opts...)
 }
 
 func computeDigest(opener Opener) (v1.Hash, int64, error) {

--- a/pkg/v1/tarball/layer.go
+++ b/pkg/v1/tarball/layer.go
@@ -17,6 +17,7 @@ package tarball
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -249,15 +250,17 @@ func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 }
 
 // LayerFromReader returns a v1.Layer given a io.Reader.
+//
+// The reader's contents are read and buffered to a temp file in the process.
 func LayerFromReader(reader io.Reader, opts ...LayerOption) (v1.Layer, error) {
-	// Buffering due to Opener requiring multiple calls.
-	a, err := ioutil.ReadAll(reader)
+	tmp, err := ioutil.TempFile("", "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating temp file to buffer reader: %w", err)
 	}
-	return LayerFromOpener(func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(a)), nil
-	}, opts...)
+	if _, err := io.Copy(tmp, reader); err != nil {
+		return nil, fmt.Errorf("writing temp file to buffer reader: %w", err)
+	}
+	return LayerFromFile(tmp.Name())
 }
 
 func computeDigest(opener Opener) (v1.Hash, int64, error) {


### PR DESCRIPTION
See https://twitter.com/ariadneconill/status/1491913976795602947

Also mark the method as `Deprecated`, and reimplement our own only usage of it in `pkg/crane.Layer(filemap)` using `tarball.LayerFromOpener` instead.