### PR TITLE
Fix Windows e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
         base=alpine
         platform=linux/amd64
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
-          base=mcr.microsoft.com/windows/nanoserver:1809
+          base=mcr.microsoft.com/windows/nanoserver:ltsc2022
           platform=windows/amd64
         fi
 


### PR DESCRIPTION
GitHub Actions recently updated the Windows version used by
windows-latest, which is no longer compatible with the nanoserver:1809
base image used in our Windows e2e test.

Using :ltsc2022 instead should ensure we have a compatible image.

Example successful run: https://github.com/imjasonh/go-containerregistry/runs/5202498982