### PR TITLE
crane: allow appending of complete docker images

### DIFF
--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -179,9 +180,12 @@ func rebaseImage(orig v1.Image, oldBase, newBase string, opt ...crane.Option) (v
 		return nil, fmt.Errorf("either old base or %q annotation is required", specsv1.AnnotationBaseImageDigest)
 	}
 
-	oldBaseImg, err := crane.Pull(oldBase, opt...)
-	if err != nil {
-		return nil, err
+	oldBaseImg := empty.Image
+	if oldBase != empty.Scratch {
+		oldBaseImg, err = crane.Pull(oldBase, opt...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// NB: if newBase is an index, we need to grab the index's digest to

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -181,7 +181,7 @@ func rebaseImage(orig v1.Image, oldBase, newBase string, opt ...crane.Option) (v
 	}
 
 	oldBaseImg := empty.Image
-	if oldBase != empty.Scratch {
+	if oldBase != "scratch" {
 		oldBaseImg, err = crane.Pull(oldBase, opt...)
 		if err != nil {
 			return nil, err

--- a/pkg/v1/empty/image.go
+++ b/pkg/v1/empty/image.go
@@ -22,6 +22,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+// docker scratch image name
+const Scratch = "scratch"
+
 // Image is a singleton empty image, think: FROM scratch.
 var Image, _ = partial.UncompressedToImage(emptyImage{})
 

--- a/pkg/v1/empty/image.go
+++ b/pkg/v1/empty/image.go
@@ -22,9 +22,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-// docker scratch image name
-const Scratch = "scratch"
-
 // Image is a singleton empty image, think: FROM scratch.
 var Image, _ = partial.UncompressedToImage(emptyImage{})
 


### PR DESCRIPTION
crane rebase: correctly interpret 'scratch' as reference to the empty image rather than trying to resolve it from a registry.

This effectively allows rebase to work as an append operation, appending all images of a source onto a destination image:
`crane rebase -t C --new_base B  --old_base scratch A`
-> appends all layers of image A onto image B and stores as image C

Fixes https://github.com/google/go-containerregistry/issues/1295