### PR TITLE
Take advantage of Chainguard maintained versions of various actions.

### DIFF
--- a/.github/workflows/boilerplate.yaml
+++ b/.github/workflows/boilerplate.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - uses: chainguard-dev/actions/boilerplate@main
+      - uses: chainguard-dev/actions/boilerplate@84c993eaf02da1c325854fb272a4df9184bd80fc # main
         with:
           extension: ${{ matrix.extension }}
           language: ${{ matrix.language }}

--- a/.github/workflows/boilerplate.yaml
+++ b/.github/workflows/boilerplate.yaml
@@ -24,47 +24,10 @@ jobs:
           language: Bash
 
     steps:
-      - uses: actions/setup-go@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: chainguard-dev/actions/boilerplate@main
         with:
-          go-version: 1.16.x
-
-      - uses: actions/checkout@v2
-
-      - name: Install Tools
-        run: |
-          TEMP_PATH="$(mktemp -d)"
-          cd $TEMP_PATH
-
-          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
-          echo '::endgroup::'
-
-          echo '::group:: Installing boilerplate-check ... https://github.com/mattmoor/boilerplate-check'
-          go get github.com/mattmoor/boilerplate-check/cmd/boilerplate-check
-          echo '::endgroup::'
-
-          echo "${TEMP_PATH}" >> $GITHUB_PATH
-
-      - name: ${{ matrix.language }} license boilerplate
-        shell: bash
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
-
-          echo '::group:: Running github.com/mattmoor/boilerplate-check for ${{ matrix.language }} with reviewdog 🐶 ...'
-          # Don't fail because of boilerplate-check
-          set +o pipefail
-          boilerplate-check check \
-            --boilerplate ./hack/boilerplate/boilerplate.${{ matrix.extension }}.txt \
-            --file-extension ${{ matrix.extension }} \
-            --exclude "(vendor|third_party)/" |
-          reviewdog -efm="%A%f:%l: %m" \
-                -efm="%C%.%#" \
-                -name="${{ matrix.language }} headers" \
-                -reporter="github-pr-check" \
-                -filter-mode="diff_context" \
-                -fail-on-error="true" \
-                -level="error"
-          echo '::endgroup::'
+          extension: ${{ matrix.extension }}
+          language: ${{ matrix.language }}

--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -12,4 +12,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: chainguard-dev/actions/donotsubmit@main
+    - uses: chainguard-dev/actions/donotsubmit@84c993eaf02da1c325854fb272a4df9184bd80fc # main

--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -11,32 +11,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Do Not Submit
-        shell: bash
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
-
-          TEMP_PATH="$(mktemp -d)"
-          PATH="${TEMP_PATH}:$PATH"
-
-          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
-          echo '::endgroup::'
-
-          echo '::group:: Running DO NOT SUBMIT with reviewdog 🐶 ...'
-          # Don't fail because of grep
-          set +o pipefail
-          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' -not -path './.github/workflows/*' |
-          xargs grep -n "DO NOT SUBMIT" |
-          reviewdog -efm="%f:%l:%m" \
-                -name="DO NOT SUBMIT" \
-                -reporter="github-pr-check" \
-                -filter-mode="added" \
-                -fail-on-error="true" \
-                -level="error"
-
-          echo '::endgroup::'
+    - uses: actions/checkout@v2
+    - uses: chainguard-dev/actions/donotsubmit@main

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -6,39 +6,15 @@ on:
 
 jobs:
 
-  autoformat:
-    name: Auto-format and Check
+  goimports:
+    name: check goimports
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - run: go install golang.org/x/tools/cmd/goimports@latest
-      - run: >
-          goimports -w $(find .
-          -path './vendor' -prune
-          -o -path './third_party' -prune
-          -o -name '*.pb.go' -prune
-          -o -name 'wire_gen.go' -prune
-          -o -type f -name '*.go' -print)
-
-      - run: |
-          # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
-          # This is to leverage this workaround:
-          # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
-          function urlencode() {
-            sed ':begin;$!N;s/\n/%0A/;tbegin'
-          }
-          if [[ $(git diff-index --name-only HEAD --) ]]; then
-              for x in $(git diff-index --name-only HEAD --); do
-                echo "::error file=$x::Please run goimports.%0A$(git diff $x | urlencode)"
-              done
-              echo "${{ github.repository }} is out of style. Please run goimports."
-              exit 1
-          fi
-          echo "${{ github.repository }} is formatted correctly."
+      - uses: actions/checkout@v2
+      - uses: chainguard-dev/actions/goimports@main
 
   lint:
     name: Lint
@@ -50,149 +26,27 @@ jobs:
         with:
           go-version: 1.16.x
 
-      - name: Install Tools
-        env:
-          WOKE_VERSION: v0.5.0
-        run: |
-          TEMP_PATH="$(mktemp -d)"
-          cd $TEMP_PATH
-
-          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
-          echo '::endgroup::'
-
-          echo '::group:: Installing misspell ... https://github.com/client9/misspell'
-          go get github.com/client9/misspell/cmd/misspell
-          echo '::endgroup::'
-
-          echo '::group:: Installing woke ... https://github.com/get-woke/woke'
-          curl -sfL https://raw.githubusercontent.com/get-woke/woke/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${WOKE_VERSION}" 2>&1
-          echo '::endgroup::'
-
-          echo "${TEMP_PATH}" >> $GITHUB_PATH
-
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1
 
-      - name: misspell
+      - uses: reviewdog/action-misspell@v1
         if: ${{ always() }}
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
+        with:
+          github_token: ${{ secrets.github_token }}
+          fail_on_error: true
+          locale: "US"
 
-          echo '::group:: Running github.com/client9/misspell with reviewdog 🐶 ...'
-          # Don't fail because of misspell
-          set +o pipefail
-          # Exclude generated and vendored files, plus some legacy
-          # paths until we update all .gitattributes
-          git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          grep -Ev '^(vendor/|third_party/|.git)' |
-          xargs misspell -i importas -error |
-          reviewdog -efm="%f:%l:%c: %m" \
-                -name="github.com/client9/misspell" \
-                -reporter="github-pr-check" \
-                -filter-mode="added" \
-                -fail-on-error="true" \
-                -level="error"
-
-          echo '::endgroup::'
-
-      - name: trailing whitespace
+      - uses: chainguard-dev/actions/trailing-space@main
         if: ${{ always() }}
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
 
-          echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
-          # Don't fail because of grep
-          set +o pipefail
-          
-          # Exclude generated and vendored files, plus some legacy
-          # paths until we update all .gitattributes
-          git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          grep -Ev '^(vendor/|third_party/|.git)' |
-          xargs grep -nE " +$" |
-          reviewdog -efm="%f:%l:%m" \
-                -name="trailing whitespace" \
-                -reporter="github-pr-check" \
-                -filter-mode="added" \
-                -fail-on-error="true" \
-                -level="error"
-
-          echo '::endgroup::'
-
-      - name: EOF newline
+      - uses: chainguard-dev/actions/eof-newline@main
         if: ${{ always() }}
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
 
-          echo '::group:: Flagging missing EOF newlines with reviewdog 🐶 ...'
-          # Don't fail because of misspell
-          set +o pipefail
-          # Lint exclude rule:
-          #  - nothing in vendor/
-          #  - nothing in third_party
-          #  - nothing in .git/
-          #  - no *.ai (Adobe Illustrator) files.
-          LINT_FILES=$(git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          grep -Ev '^(vendor/|third_party/|.git)' |
-          grep -v '\.ai$')
-
-          for x in $LINT_FILES; do
-            # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file
-            if [[ -f $x && ! ( -s "$x" && -z "$(tail -c 1 $x)" ) ]]; then
-              # We add 1 to `wc -l` here because of this limitation (from the man page):
-              # Characters beyond the final <newline> character will not be included in the line count.
-              echo $x:$((1 + $(wc -l $x | tr -s ' ' | cut -d' ' -f 1))): Missing newline
-            fi
-          done |
-          reviewdog -efm="%f:%l: %m" \
-                -name="EOF Newline" \
-                -reporter="github-pr-check" \
-                -filter-mode="added" \
-                -fail-on-error="true" \
-                -level="error"
-
-          echo '::endgroup::'
-
-      # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh
-      # since their action is not yet released under a stable version.
-      - name: Language
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          set -e
-          cd "${GITHUB_WORKSPACE}" || exit 1
-
-          # Create a minimal .wokeignore if none already exist.
-          if [ ! -f .wokeignore ]; then
-            cat > .wokeignore <<EOF
-            vendor/*
-            third_party/*
-          EOF
-          fi
-
-          echo '::group:: Running woke with reviewdog 🐶 ...'
-          woke --output simple \
-            | reviewdog -efm="%f:%l:%c: %m" \
-                -name="woke" \
-                -reporter="github-pr-check" \
-                -filter-mode="added" \
-                -fail-on-error="true" \
-                -level="error"
-          echo '::endgroup::'
+      - uses: get-woke/woke-action-reviewdog@v0
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: error
+          fail-on-error: true

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           go-version: 1.16.x
       - uses: actions/checkout@v2
-      - uses: chainguard-dev/actions/goimports@main
+      - uses: chainguard-dev/actions/goimports@84c993eaf02da1c325854fb272a4df9184bd80fc # main
 
   lint:
     name: Lint
@@ -37,10 +37,10 @@ jobs:
           fail_on_error: true
           locale: "US"
 
-      - uses: chainguard-dev/actions/trailing-space@main
+      - uses: chainguard-dev/actions/trailing-space@84c993eaf02da1c325854fb272a4df9184bd80fc # main
         if: ${{ always() }}
 
-      - uses: chainguard-dev/actions/eof-newline@main
+      - uses: chainguard-dev/actions/eof-newline@84c993eaf02da1c325854fb272a4df9184bd80fc # main
         if: ${{ always() }}
 
       - uses: get-woke/woke-action-reviewdog@v0


### PR DESCRIPTION
I created these so we could more centrally manage them for folks.  We can snap a release and use `@v1` instead of `@main` (and manage with dependabot) but I wanted to test the waters.

If y'all are interested in this, I can do the same for `ko` next.