### PR TITLE
Include blob existence checks in retries

### DIFF
--- a/pkg/v1/remote/multi_write_test.go
+++ b/pkg/v1/remote/multi_write_test.go
@@ -249,9 +249,11 @@ func TestMultiWrite_Retry(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		noRetry := func(error) bool { return false }
+
 		if err := MultiWrite(map[name.Reference]Taggable{
 			tag1: img1,
-		}, WithTransport(transportWrapper), WithJobs(1)); err == nil {
+		}, WithTransport(transportWrapper), WithJobs(1), WithRetryPredicate(noRetry)); err == nil {
 			t.Errorf("Expected an error, got nil")
 		}
 


### PR DESCRIPTION
Currently we just fail outright if the registry returns a 500 during a
blob HEAD because it's not included in the retry logic. This is not
ideal, especially in cases where an upload actually succeeded but we
never got a response from the server so we're re-uploading a blob for no
reason.