### PR TITLE
Don't parse challenge's scopes, put them first

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -87,25 +87,23 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 
 	// If we hit a WWW-Authenticate challenge, it might be due to expired tokens or insufficient scope.
 	if challenges := authchallenge.ResponseChallenges(res); len(challenges) != 0 {
+		newScopes := []string{}
 		for _, wac := range challenges {
 			// TODO(jonjohnsonjr): Should we also update "realm" or "service"?
-			if scope, ok := wac.Parameters["scope"]; ok {
-				// From https://tools.ietf.org/html/rfc6750#section-3
-				// The "scope" attribute is defined in Section 3.3 of [RFC6749].  The
-				// "scope" attribute is a space-delimited list of case-sensitive scope
-				// values indicating the required scope of the access token for
-				// accessing the requested resource.
-				scopes := strings.Split(scope, " ")
-
+			if want, ok := wac.Parameters["scope"]; ok {
 				// Add any scopes that we don't already request.
 				got := stringSet(bt.scopes)
-				for _, want := range scopes {
-					if _, ok := got[want]; !ok {
-						bt.scopes = append(bt.scopes, want)
-					}
+				if _, ok := got[want]; !ok {
+					newScopes = append(newScopes, want)
 				}
 			}
 		}
+
+		// Some registries seem to only look at the first scope parameter during a token exchange.
+		// If a request fails because it's missing a scope, we should put those at the beginning,
+		// otherwise the registry might just ignore it :/
+		newScopes = append(newScopes, bt.scopes...)
+		bt.scopes = newScopes
 
 		// TODO(jonjohnsonjr): Teach transport.Error about "error" and "error_description" from challenge.
 


### PR DESCRIPTION
This is an attempt to work around some interesting behavior from
DockerHub.

> This query parameter should be specified multiple times if there is
> more than one scope entry from the WWW-Authenticate header.

https://docs.docker.com/registry/spec/auth/token/#requesting-a-token

It would stand to reason that we shouldn't specify scope multiple times
if there is only one (space-separated) scope in the header.