### PR TITLE
Add --user flag to crane mutate

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -35,6 +35,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var newLayers []string
 	var outFile string
 	var newRef string
+	var user string
 
 	mutateCmd := &cobra.Command{
 		Use:   "mutate",
@@ -103,6 +104,11 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				cfg.Config.Cmd = cmd
 			}
 
+			// Set user.
+			if len(user) > 0 {
+				cfg.Config.User = user
+			}
+
 			// Mutate and write image.
 			img, err = mutate.Config(img, cfg.Config)
 			if err != nil {
@@ -150,6 +156,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	mutateCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
 	mutateCmd.Flags().StringSliceVar(&newLayers, "append", []string{}, "Path to tarball to append to image")
+	mutateCmd.Flags().StringVarP(&user, "user", "u", "", "New user to set")
 	return mutateCmd
 }
 

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -18,6 +18,7 @@ crane mutate [flags]
   -l, --label stringToString        New labels to add (default [])
   -o, --output string               Path to new tarball of resulting image
   -t, --tag string                  New tag to apply to mutated image. If not provided, push by digest to the original image repository.
+  -u, --user string                 New user to set
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This flag sets the `User` property of the container config. 

Tested with:

```
go run cmd/crane/main.go mutate <my image> --user="12:34"
```

Fixes #1309 