### PR TITLE
feat(crane): allow mutating multiple images and optionally create a manifest list

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -35,6 +35,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var newLayers []string
 	var outFile string
 	var newRef string
+	var newRepo string
 	var user string
 
 	mutateCmd := &cobra.Command{
@@ -53,6 +54,10 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				if desc.MediaType.IsIndex() {
 					return errors.New("mutating annotations on an index is not yet supported")
 				}
+			}
+
+			if newRepo != "" && newRef != "" {
+				return errors.New("repository can't be set when a tag is specified")
 			}
 
 			img, err := crane.Pull(ref, *options...)
@@ -121,7 +126,9 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 			// If that ref was provided by digest (e.g., output from
 			// another crane command), then strip that and push the
 			// mutated image by digest instead.
-			if newRef == "" {
+			if newRepo != "" {
+				newRef = newRepo
+			} else if newRef == "" {
 				newRef = ref
 			}
 			digest, err := img.Digest()
@@ -137,7 +144,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("parsing %s: %w", newRef, err)
 				}
-				if _, ok := r.(name.Digest); ok {
+				if _, ok := r.(name.Digest); ok || newRepo != "" {
 					newRef = r.Context().Digest(digest.String()).String()
 				}
 				if err := crane.Push(img, newRef, *options...); err != nil {
@@ -153,6 +160,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	mutateCmd.Flags().StringToStringVarP(&envVars, "env", "e", nil, "New envvar to add")
 	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
 	mutateCmd.Flags().StringSliceVar(&cmd, "cmd", nil, "New cmd to set")
+	mutateCmd.Flags().StringVarP(&newRepo, "repo", "r", "", "Repository to push the mutated image to. If provided, push by digest to this repository.")
 	mutateCmd.Flags().StringVarP(&newRef, "tag", "t", "", "New tag to apply to mutated image. If not provided, push by digest to the original image repository.")
 	mutateCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
 	mutateCmd.Flags().StringSliceVar(&newLayers, "append", []string{}, "Path to tarball to append to image")


### PR DESCRIPTION
Depends on https://github.com/google/go-containerregistry/pull/1323

The idea is to be able to mutate multiple images the same way
```
crane mutate --platform windows/amd64 --entrypoint=dotnet.exe --append app.tar \
  mcr.microsoft.com/windows/nanoserver:1809 \
  mcr.microsoft.com/windows/nanoserver:20H2 \
  mcr.microsoft.com/windows/nanoserver:ltsc2022 \
  -t lippertmarkus/test-crane
```

If multiple images are provided and...
- neither `-t` nor `-r` is provided, each mutated image will be pushed to the original image repository
- `-r` is provided, each mutated image will be pushed by digest to the specified repo
- `-t` is provided, each mutated image will be pushed by digest to the repo that is extracted from the tag. Additionally, a manifest list is created at that tag referencing all digests pushed before.

I basically just added a loop and store the pushed digests at the end of each iteration (Hide whitespace changes in GitHub diff).

@imjasonh what do you think about that approach? Can you guide me on how I can create a manifest list based on the digests I have in `pushedDigests`? 

As an alternative, instead of creating the manfest list inside the mutate command, we could also feed the list of digests outputted by the mutate command into something like `crane manifest push`:
```
crane manifest push lippertmarkus/test-crane:1.0 $(
  crane mutate --platform windows/amd64 --entrypoint=dotnet.exe --append app.tar \
  mcr.microsoft.com/windows/nanoserver:1809 \
  mcr.microsoft.com/windows/nanoserver:20H2 \
  -r lippertmarkus/test-crane
)
```

I'm sure something like that could be a great base for [language ecosystems to build `ko`-like tooling](https://twitter.com/ImJasonH/status/1506769195366760454) with multi-arch support :)