### PR TITLE
pull: Write image to stdout with "-"

### DIFF
--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -35,8 +35,8 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "pull IMAGE TARBALL",
-		Short: "Pull remote images by reference and store their contents locally",
+		Use:   "pull IMAGE TARBALL|-",
+		Short: "Pull remote images by reference and store them locally",
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			imageMap := map[string]v1.Image{}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -31,7 +31,7 @@ crane [flags]
 * [crane ls](crane_ls.md)	 - List the tags in a repo
 * [crane manifest](crane_manifest.md)	 - Get the manifest of an image
 * [crane mutate](crane_mutate.md)	 - Modify image labels and annotations. The container must be pushed to a registry, and the manifest is updated there.
-* [crane pull](crane_pull.md)	 - Pull remote images by reference and store their contents locally
+* [crane pull](crane_pull.md)	 - Pull remote images by reference and store them locally
 * [crane push](crane_push.md)	 - Push local image contents to a remote registry
 * [crane rebase](crane_rebase.md)	 - Rebase an image onto a new base image
 * [crane tag](crane_tag.md)	 - Efficiently tag a remote image

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -1,9 +1,9 @@
 ## crane pull
 
-Pull remote images by reference and store their contents locally
+Pull remote images by reference and store them locally
 
 ```
-crane pull IMAGE TARBALL [flags]
+crane pull IMAGE TARBALL|- [flags]
 ```
 
 ### Options

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -27,11 +27,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-// Tag applied to images that were pulled by digest. This denotes that the
-// image was (probably) never tagged with this, but lets us avoid applying the
-// ":latest" tag which might be misleading.
-const iWasADigestTag = "i-was-a-digest"
-
 // Pull returns a v1.Image of the remote image src.
 func Pull(src string, opt ...Option) (v1.Image, error) {
 	o := makeOptions(opt...)
@@ -52,34 +47,21 @@ func Save(img v1.Image, src, path string) error {
 // MultiSave writes collection of v1.Image img with tag as a tarball.
 func MultiSave(imgMap map[string]v1.Image, path string, opt ...Option) error {
 	o := makeOptions(opt...)
-	tagToImage := map[name.Tag]v1.Image{}
+	refToImage := map[name.Reference]v1.Image{}
 
 	for src, img := range imgMap {
 		ref, err := name.ParseReference(src, o.Name...)
 		if err != nil {
 			return fmt.Errorf("parsing ref %q: %w", src, err)
 		}
-
-		// WriteToFile wants a tag to write to the tarball, but we might have
-		// been given a digest.
-		// If the original ref was a tag, use that. Otherwise, if it was a
-		// digest, tag the image with :i-was-a-digest instead.
-		tag, ok := ref.(name.Tag)
-		if !ok {
-			d, ok := ref.(name.Digest)
-			if !ok {
-				return fmt.Errorf("ref wasn't a tag or digest")
-			}
-			tag = d.Repository.Tag(iWasADigestTag)
-		}
-		tagToImage[tag] = img
+		refToImage[ref] = img
 	}
 	// no progress channel (for now)
 	if path == "-" {
 		w := os.Stdout
-		return tarball.MultiWrite(tagToImage, w)
+		return tarball.MultiRefWrite(refToImage, w)
 	}
-	return tarball.MultiWriteToFile(path, tagToImage)
+	return tarball.MultiRefWriteToFile(path, refToImage)
 }
 
 // PullLayer returns the given layer from a registry.

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -75,6 +75,10 @@ func MultiSave(imgMap map[string]v1.Image, path string, opt ...Option) error {
 		tagToImage[tag] = img
 	}
 	// no progress channel (for now)
+	if path == "-" {
+		w := os.Stdout
+		return tarball.MultiWrite(tagToImage, w)
+	}
 	return tarball.MultiWriteToFile(path, tagToImage)
 }
 

--- a/pkg/v1/tarball/README.md
+++ b/pkg/v1/tarball/README.md
@@ -165,9 +165,7 @@ $ jq < nanoserver/manifest.json
 [
   {
     "Config": "sha256:bc5d255ea81f83c8c38a982a6d29a6f2198427d258aea5f166e49856896b2da6",
-    "RepoTags": [
-      "index.docker.io/library/hello-world:i-was-a-digest"
-    ],
+    "RepoTags": null,
     "Layers": [
       "a35da61c356213336e646756218539950461ff2bf096badf307a23add6e70053.tar.gz",
       "be21f08f670160cbae227e3053205b91d6bfa3de750b90c7e00bd2c511ccb63a.tar.gz",
@@ -188,11 +186,9 @@ $ jq < nanoserver/manifest.json
 ```
 
 A couple things to note about this `manifest.json` versus the other:
-* The `RepoTags` field is a bit weird here. `hello-world` is a multi-platform
+* The `RepoTags` field is `null`. `hello-world` is a multi-platform
   image, so We had to pull this image by digest, since we're (I'm) on
-  amd64/linux and wanted to grab a windows image. Since the tarball format
-  expects a tag under `RepoTags`, and we didn't pull by tag, we replace the
-  digest with a sentinel `i-was-a-digest` "tag" to appease docker.
+  amd64/linux and wanted to grab a windows image..
 * The `LayerSources` has enough information to reconstruct the foreign layers
   pointer when pushing/pulling from the registry. For legal reasons, microsoft
   doesn't want anyone but them to serve windows base images, so the mediaType

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -55,15 +55,9 @@ func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image, opts ...WriteO
 // MultiRefWriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.MultiRefWrite with a new file.
 func MultiRefWriteToFile(p string, refToImage map[name.Reference]v1.Image, opts ...WriteOption) error {
-	var w io.WriteCloser
-	var err error
-	if p == "-" {
-		w = os.Stdout
-	} else {
-		w, err = os.Create(p)
-		if err != nil {
-			return err
-		}
+	w, err := os.Create(p)
+	if err != nil {
+		return err
 	}
 	defer w.Close()
 

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -55,9 +55,15 @@ func MultiWriteToFile(p string, tagToImage map[name.Tag]v1.Image, opts ...WriteO
 // MultiRefWriteToFile writes in the compressed format to a tarball, on disk.
 // This is just syntactic sugar wrapping tarball.MultiRefWrite with a new file.
 func MultiRefWriteToFile(p string, refToImage map[name.Reference]v1.Image, opts ...WriteOption) error {
-	w, err := os.Create(p)
-	if err != nil {
-		return err
+	var w io.WriteCloser
+	var err error
+	if p == "-" {
+		w = os.Stdout
+	} else {
+		w, err = os.Create(p)
+		if err != nil {
+			return err
+		}
 	}
 	defer w.Close()
 

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -75,11 +75,8 @@ func Write(ref name.Reference, img v1.Image, w io.Writer, opts ...WriteOption) e
 	return MultiRefWrite(map[name.Reference]v1.Image{ref: img}, w, opts...)
 }
 
-// MultiWrite writes the contents of each image to the provided reader, in the compressed format.
-// The contents are written in the following format:
-// One manifest.json file at the top level containing information about several images.
-// One file for each layer, named after the layer's SHA.
-// One file for the config blob, named after its SHA.
+// MultiWrite writes the contents of each image to the provided writer, in the compressed format.
+// This is just syntactic sugar converting tags to references for tarball.MultiRefWrite
 func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer, opts ...WriteOption) error {
 	refToImage := make(map[name.Reference]v1.Image, len(tagToImage))
 	for i, d := range tagToImage {
@@ -88,7 +85,7 @@ func MultiWrite(tagToImage map[name.Tag]v1.Image, w io.Writer, opts ...WriteOpti
 	return MultiRefWrite(refToImage, w, opts...)
 }
 
-// MultiRefWrite writes the contents of each image to the provided reader, in the compressed format.
+// MultiRefWrite writes the contents of each image to the provided writer, in the compressed format.
 // The contents are written in the following format:
 // One manifest.json file at the top level containing information about several images.
 // One file for each layer, named after the layer's SHA.


### PR DESCRIPTION
This allows `crane pull` to stream image to stdout, so that it is possible to stream-extract files from filesystems of remote images without explicitly saving them.
```
✗ ./crane pull ubuntu - | ./crane export - | tar -Oxf - etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.4 LTS"  
```
As asked by @imjasonh in https://github.com/google/go-containerregistry/pull/1274#pullrequestreview-895584402