### PR TITLE
fix(v1/random): set MediaType in `randomIndex.manifest`

### DIFF
--- a/pkg/v1/random/index.go
+++ b/pkg/v1/random/index.go
@@ -34,6 +34,7 @@ type randomIndex struct {
 func Index(byteSize, layers, count int64) (v1.ImageIndex, error) {
 	manifest := v1.IndexManifest{
 		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
 		Manifests:     []v1.Descriptor{},
 	}
 
@@ -73,7 +74,7 @@ func Index(byteSize, layers, count int64) (v1.ImageIndex, error) {
 }
 
 func (i *randomIndex) MediaType() (types.MediaType, error) {
-	return types.OCIImageIndex, nil
+	return i.manifest.MediaType, nil
 }
 
 func (i *randomIndex) Digest() (v1.Hash, error) {

--- a/pkg/v1/random/index_test.go
+++ b/pkg/v1/random/index_test.go
@@ -52,4 +52,13 @@ func TestRandomIndex(t *testing.T) {
 	if got, want := mt, types.OCIImageIndex; got != want {
 		t.Errorf("MediaType(): got: %v, want: %v", got, want)
 	}
+
+	man, err := ii.IndexManifest()
+	if err != nil {
+		t.Errorf("IndexManifest(): unexpected err: %v", err)
+	}
+
+	if got, want := man.MediaType, types.OCIImageIndex; got != want {
+		t.Errorf("MediaType: got: %v, want: %v", got, want)
+	}
 }


### PR DESCRIPTION
`random.Index()` does not set media type on it's return value's underlying `v1.IndexManifest`, which is accessible to callers.