### PR TITLE
Make test registry more resilient

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -10,12 +10,33 @@ import (
 )
 
 var port = flag.Int("port", 1338, "port to run registry on")
+var storage = flag.String("storage", "memory", "Option [memory, disk], default value is memory")
+var diskLocation = flag.String("path", "", "Required when selecting disk storage. Path where the registry will store the blobs")
+var splitRepositories = flag.Bool("split-repositories", false, "Separate blob storage per repository. This feature will ensures that each repository only has access to blobs inside the repository space.")
 
 func main() {
 	flag.Parse()
+
+	var opts []registry.Option
+	switch *storage {
+	case "memory":
+	case "disk":
+		if *diskLocation == "" {
+			log.Fatal("When storage is set to 'disk' a location has to be provided via the flag '--path'")
+		}
+
+		opts = append(opts, registry.DiskBlobStorage(*diskLocation))
+	default:
+		log.Fatalf("Option '%s' is not valid for storage flag. Choose 'memory' or 'disk'", *storage)
+	}
+
+	if *splitRepositories {
+		opts = append(opts, registry.SplitBlobsByRepository())
+	}
+
 	s := &http.Server{
 		Addr:    fmt.Sprintf(":%d", *port),
-		Handler: registry.New(),
+		Handler: registry.New(opts...),
 	}
 	log.Fatal(s.ListenAndServe())
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -102,3 +102,10 @@ func Logger(l *log.Logger) Option {
 		r.manifests.log = l
 	}
 }
+
+// DiskBlobStorage Save the blobs in the folder tmpFolder
+func DiskBlobStorage(blobFolder string) Option {
+	return func(r *registry) {
+		r.blobs.blobHandler = newBlobDiskHandler(blobFolder)
+	}
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -191,6 +191,20 @@ func TestCalls(t *testing.T) {
 			Body:        "foo",
 		},
 		{
+			Description: "mount blob using an invalid digest",
+			Method:      "POST",
+			URL:         "/v2/foo/blobs/uploads?from=some/other/repo&mount=sha256:fake",
+			Code:        http.StatusBadRequest,
+			Body:        "foo",
+		},
+		{
+			Description: "mount blob",
+			Method:      "POST",
+			URL:         "/v2/foo/blobs/uploads?from=some/other/repo&mount=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			Code:        http.StatusCreated,
+			Header:      map[string]string{"Docker-Content-Digest": "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"},
+		},
+		{
 			Description: "upload good digest",
 			Method:      "PUT",
 			URL:         "/v2/foo/blobs/uploads/1?digest=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -201,9 +201,17 @@ func TestCalls(t *testing.T) {
 			Body:        "foo",
 		},
 		{
-			Description: "mount blob",
+			Description: "mount blob request when blob to be mounted cannot be found",
 			Method:      "POST",
 			URL:         "/v2/foo/blobs/uploads?from=some/other/repo&mount=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			Code:        http.StatusAccepted,
+			Header:      map[string]string{"Range": "0-0"},
+		},
+		{
+			Description: "mount blob request when blob can be mounted",
+			Digests:     map[string]string{"sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae": "foo"},
+			Method:      "POST",
+			URL:         "/v2/some/other/repo/blobs/uploads?from=foo&mount=sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
 			Code:        http.StatusCreated,
 			Header:      map[string]string{"Docker-Content-Digest": "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"},
 		},
@@ -611,7 +619,6 @@ func TestBlobAccess(t *testing.T) {
 				URL:    u,
 				Header: map[string][]string{},
 			}
-			t.Log(req.Method, req.URL)
 			resp, err := s.Client().Do(req)
 			if err != nil {
 				t.Fatalf("Error getting %s: %v", loc, err)


### PR DESCRIPTION
In this PR there are 3 changes done to the test Registry that is part of ggcr.
1. Enable blob mounting in the Registry
    This initial part will add a new Interface that is used when the Registry is called with a PUT that contains a mount request
3. Allow the users to decide if they want to save to disk the blobs pushed to the registry
    Activated via the Option `registry.DiskBlobStorage` this is a very simple process that just saves the blobs to disk and keeps a map with information on where to locate the blobs
5. Store blob information based on the repository and SHA
    Activated via the Option `registry.SplitBlobsByRepository` this changes the way the blob storage structs store information to ensure that the repository is also taken into account when accessing the blob information

With this PR we keep the original defaults that existed, so it should have no impact on people currently using the registry.