### PR TITLE
use k8s keychain first

### DIFF
--- a/pkg/authn/k8schain/k8schain.go
+++ b/pkg/authn/k8schain/k8schain.go
@@ -46,11 +46,11 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 	}
 
 	return authn.NewMultiKeychain(
+		k8s,
 		authn.DefaultKeychain,
 		google.Keychain,
 		amazonKeychain,
 		azureKeychain,
-		k8s,
 	), nil
 }
 


### PR DESCRIPTION
This speeds up instances where the credentials are in image pull secrets
