### PR TITLE
authn.kubernetes.Resolve now behaves exactly like Kubernetes

### DIFF
--- a/pkg/authn/k8schain/go.mod
+++ b/pkg/authn/k8schain/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220228164355-396b2034c795
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
-	github.com/google/go-containerregistry v0.8.1-0.20220110151055-a61fd0a8e2bb
+	github.com/google/go-containerregistry v0.8.1-0.20220414133640-f1b729141d33
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220301182634-bfe2ffc6b6bd
 	k8s.io/api v0.23.4
 	k8s.io/client-go v0.23.4

--- a/pkg/authn/kubernetes/go.mod
+++ b/pkg/authn/kubernetes/go.mod
@@ -5,6 +5,7 @@ go 1.17
 replace github.com/google/go-containerregistry => ../../../
 
 require (
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.1-0.20220414133640-f1b729141d33
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
@@ -20,7 +21,6 @@ require (
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/authn/kubernetes/go.mod
+++ b/pkg/authn/kubernetes/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/google/go-containerregistry => ../../../
 
 require (
-	github.com/google/go-containerregistry v0.8.0
+	github.com/google/go-containerregistry v0.8.1-0.20220414133640-f1b729141d33
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4

--- a/pkg/authn/kubernetes/keychain.go
+++ b/pkg/authn/kubernetes/keychain.go
@@ -183,17 +183,17 @@ func (keyring *keyring) Resolve(target authn.Resource) (authn.Authenticator, err
 
 	for _, k := range keyring.index {
 		// both k and image are schemeless URLs because even though schemes are allowed
-		// in the credential configurations, we remove them in Add.
+		// in the credential configurations, we remove them when constructing the keyring
 		if matched, _ := urlsMatchStr(k, image); matched {
 			auths = append(auths, keyring.creds[k]...)
 		}
 	}
 
-	if len(auths) > 0 {
-		return toAuthenticator(auths...)
+	if len(auths) == 0 {
+		return authn.Anonymous, nil
 	}
 
-	return authn.Anonymous, nil
+	return toAuthenticator(auths)
 }
 
 // urlsMatchStr is wrapper for URLsMatch, operating on strings instead of URLs.
@@ -270,7 +270,7 @@ func urlsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
 	return true, nil
 }
 
-func toAuthenticator(configs ...authn.AuthConfig) (authn.Authenticator, error) {
+func toAuthenticator(configs []authn.AuthConfig) (authn.Authenticator, error) {
 	cfg := configs[0]
 
 	if cfg.Auth != "" {

--- a/pkg/authn/kubernetes/keychain.go
+++ b/pkg/authn/kubernetes/keychain.go
@@ -16,10 +16,12 @@ package kubernetes
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -101,29 +103,34 @@ func NewInCluster(ctx context.Context, opt Options) (authn.Keychain, error) {
 	return New(ctx, client, opt)
 }
 
+type dockerConfigJSON struct {
+	Auths map[string]authn.AuthConfig
+}
+
 // NewFromPullSecrets returns a new authn.Keychain suitable for resolving image references as
 // scoped by the pull secrets.
 func NewFromPullSecrets(ctx context.Context, secrets []corev1.Secret) (authn.Keychain, error) {
-	m := map[string]authn.AuthConfig{}
+	keyring := &keyring{
+		index: make([]string, 0),
+		creds: make(map[string][]authn.AuthConfig),
+	}
+
+	var cfg dockerConfigJSON
+
+	// From: https://github.com/kubernetes/kubernetes/blob/0dcafb1f37ee522be3c045753623138e5b907001/pkg/credentialprovider/keyring.go
 	for _, secret := range secrets {
-		auths := map[string]authn.AuthConfig{}
 		if b, exists := secret.Data[corev1.DockerConfigJsonKey]; secret.Type == corev1.SecretTypeDockerConfigJson && exists && len(b) > 0 {
-			var cfg struct {
-				Auths map[string]authn.AuthConfig
-			}
 			if err := json.Unmarshal(b, &cfg); err != nil {
 				return nil, err
 			}
-			auths = cfg.Auths
 		}
 		if b, exists := secret.Data[corev1.DockerConfigKey]; secret.Type == corev1.SecretTypeDockercfg && exists && len(b) > 0 {
-			if err := json.Unmarshal(b, &auths); err != nil {
+			if err := json.Unmarshal(b, &cfg.Auths); err != nil {
 				return nil, err
 			}
 		}
 
-		for registry, v := range auths {
-			// From: https://github.com/kubernetes/kubernetes/blob/0dcafb1f37ee522be3c045753623138e5b907001/pkg/credentialprovider/keyring.go
+		for registry, v := range cfg.Auths {
 			value := registry
 			if !strings.HasPrefix(value, "https://") && !strings.HasPrefix(value, "http://") {
 				value = "https://" + value
@@ -150,45 +157,125 @@ func NewFromPullSecrets(ctx context.Context, secrets []corev1.Secret) (authn.Key
 				key = parsed.Host
 			}
 
-			// Don't overwrite previously specified Auths for a given key.
-			if _, found := m[key]; !found {
-				m[key] = v
+			if _, ok := keyring.creds[key]; !ok {
+				keyring.index = append(keyring.index, key)
 			}
+
+			keyring.creds[key] = append(keyring.creds[key], v)
+
 		}
+
+		// We reverse sort in to give more specific (aka longer) keys priority
+		// when matching for creds
+		sort.Sort(sort.Reverse(sort.StringSlice(keyring.index)))
 	}
-	return authsKeychain(m), nil
+	return keyring, nil
 }
 
-type authsKeychain map[string]authn.AuthConfig
+type keyring struct {
+	index []string
+	creds map[string][]authn.AuthConfig
+}
 
-func (kc authsKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
-	// Check for an auth that matches the repository, then if that's not
-	// found, one that matches the registry.
-	var cfg authn.AuthConfig
-	for _, key := range []string{target.String(), target.RegistryStr()} {
-		var ok bool
-		cfg, ok = kc[key]
-		if ok {
-			break
+func (keyring *keyring) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	image := target.String()
+	auths := []authn.AuthConfig{}
+
+	for _, k := range keyring.index {
+		// both k and image are schemeless URLs because even though schemes are allowed
+		// in the credential configurations, we remove them in Add.
+		if matched, _ := urlsMatchStr(k, image); matched {
+			auths = append(auths, keyring.creds[k]...)
 		}
 	}
-	empty := authn.AuthConfig{}
-	if cfg == empty {
-		return authn.Anonymous, nil
+
+	if len(auths) > 0 {
+		return toAuthenticator(auths...)
 	}
-	if cfg.Auth != "" {
-		dec, err := base64.StdEncoding.DecodeString(cfg.Auth)
+
+	return authn.Anonymous, nil
+}
+
+// urlsMatchStr is wrapper for URLsMatch, operating on strings instead of URLs.
+func urlsMatchStr(glob string, target string) (bool, error) {
+	globURL, err := parseSchemelessURL(glob)
+	if err != nil {
+		return false, err
+	}
+	targetURL, err := parseSchemelessURL(target)
+	if err != nil {
+		return false, err
+	}
+	return urlsMatch(globURL, targetURL)
+}
+
+// parseSchemelessURL parses a schemeless url and returns a url.URL
+// url.Parse require a scheme, but ours don't have schemes.  Adding a
+// scheme to make url.Parse happy, then clear out the resulting scheme.
+func parseSchemelessURL(schemelessURL string) (*url.URL, error) {
+	parsed, err := url.Parse("https://" + schemelessURL)
+	if err != nil {
+		return nil, err
+	}
+	// clear out the resulting scheme
+	parsed.Scheme = ""
+	return parsed, nil
+}
+
+// splitURL splits the host name into parts, as well as the port
+func splitURL(url *url.URL) (parts []string, port string) {
+	host, port, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		// could not parse port
+		host, port = url.Host, ""
+	}
+	return strings.Split(host, "."), port
+}
+
+// urlsMatch checks whether the given target url matches the glob url, which may have
+// glob wild cards in the host name.
+//
+// Examples:
+//    globURL=*.docker.io, targetURL=blah.docker.io => match
+//    globURL=*.docker.io, targetURL=not.right.io   => no match
+//
+// Note that we don't support wildcards in ports and paths yet.
+func urlsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
+	globURLParts, globPort := splitURL(globURL)
+	targetURLParts, targetPort := splitURL(targetURL)
+	if globPort != targetPort {
+		// port doesn't match
+		return false, nil
+	}
+	if len(globURLParts) != len(targetURLParts) {
+		// host name does not have the same number of parts
+		return false, nil
+	}
+	if !strings.HasPrefix(targetURL.Path, globURL.Path) {
+		// the path of the credential must be a prefix
+		return false, nil
+	}
+	for k, globURLPart := range globURLParts {
+		targetURLPart := targetURLParts[k]
+		matched, err := filepath.Match(globURLPart, targetURLPart)
 		if err != nil {
-			return nil, err
+			return false, err
 		}
-		parts := strings.SplitN(string(dec), ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("unable to parse auth field, must be formatted as base64(username:password)")
+		if !matched {
+			// glob mismatch for some part
+			return false, nil
 		}
-		cfg.Username = parts[0]
-		cfg.Password = parts[1]
+	}
+	// everything matches
+	return true, nil
+}
+
+func toAuthenticator(configs ...authn.AuthConfig) (authn.Authenticator, error) {
+	cfg := configs[0]
+
+	if cfg.Auth != "" {
 		cfg.Auth = ""
 	}
 
-	return authn.FromConfig(authn.AuthConfig(cfg)), nil
+	return authn.FromConfig(cfg), nil
 }

--- a/pkg/authn/kubernetes/keychain_test.go
+++ b/pkg/authn/kubernetes/keychain_test.go
@@ -16,17 +16,60 @@ package kubernetes
 
 import (
 	"context"
-	"encoding/base64"
+	"crypto/md5"
+	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 )
+
+var dockerSecretTypes = []secretType{
+	dockerConfigJSONSecretType,
+	dockerCfgSecretType,
+}
+
+type secretType struct {
+	name    corev1.SecretType
+	key     string
+	marshal func(t *testing.T, registry string, auth authn.AuthConfig) []byte
+}
+
+func (s *secretType) Create(t *testing.T, namespace, name string, registry string, auth authn.AuthConfig) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: s.name,
+		Data: map[string][]byte{
+			s.key: s.marshal(t, registry, auth),
+		},
+	}
+}
+
+var dockerConfigJSONSecretType = secretType{
+	name: corev1.SecretTypeDockerConfigJson,
+	key:  corev1.DockerConfigJsonKey,
+	marshal: func(t *testing.T, target string, auth authn.AuthConfig) []byte {
+		return toJSON(t, dockerConfigJSON{
+			Auths: map[string]authn.AuthConfig{target: auth},
+		})
+	},
+}
+
+var dockerCfgSecretType = secretType{
+	name: corev1.SecretTypeDockercfg,
+	key:  corev1.DockerConfigKey,
+	marshal: func(t *testing.T, target string, auth authn.AuthConfig) []byte {
+		return toJSON(t, map[string]authn.AuthConfig{target: auth})
+	},
+}
 
 func TestAnonymousFallback(t *testing.T) {
 	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
@@ -41,18 +84,7 @@ func TestAnonymousFallback(t *testing.T) {
 		t.Errorf("New() = %v", err)
 	}
 
-	reg, err := name.NewRegistry("fake.registry.io", name.WeakValidation)
-	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
-	}
-
-	auth, err := kc.Resolve(reg)
-	if err != nil {
-		t.Errorf("Resolve(%v) = %v", reg, err)
-	}
-	if got, want := auth, authn.Anonymous; got != want {
-		t.Errorf("Resolve() = %v, want %v", got, want)
-	}
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.Anonymous)
 }
 
 func TestAttachedServiceAccount(t *testing.T) {
@@ -65,19 +97,12 @@ func TestAttachedServiceAccount(t *testing.T) {
 		ImagePullSecrets: []corev1.LocalObjectReference{{
 			Name: "secret",
 		}},
-	}, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret",
-			Namespace: "ns",
-		},
-		Type: corev1.SecretTypeDockercfg,
-		Data: map[string][]byte{
-			corev1.DockerConfigKey: []byte(
-				fmt.Sprintf(`{"fake.registry.io": {"username": "%s", "password": "%s"}}`,
-					username, password),
-			),
-		},
-	})
+	},
+		dockerCfgSecretType.Create(t, "ns", "secret", "fake.registry.io", authn.AuthConfig{
+			Username: username,
+			Password: password,
+		}),
+	)
 
 	kc, err := New(context.Background(), client, Options{
 		Namespace:          "ns",
@@ -87,203 +112,242 @@ func TestAttachedServiceAccount(t *testing.T) {
 		t.Fatalf("New() = %v", err)
 	}
 
-	reg, err := name.NewRegistry("fake.registry.io", name.WeakValidation)
-	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
+	testResolve(t, kc, registry(t, "fake.registry.io"),
+		&authn.Basic{Username: username, Password: password})
+}
+
+// Prioritze picking the first secret
+func TestSecretPriority(t *testing.T) {
+	secrets := []corev1.Secret{
+		*dockerCfgSecretType.Create(t, "ns", "secret", "fake.registry.io", authn.AuthConfig{
+			Username: "user", Password: "pass",
+		}),
+		*dockerCfgSecretType.Create(t, "ns", "secret-2", "fake.registry.io", authn.AuthConfig{
+			Username: "anotherUser", Password: "anotherPass",
+		}),
 	}
 
-	auth, err := kc.Resolve(reg)
+	kc, err := NewFromPullSecrets(context.Background(), secrets)
 	if err != nil {
-		t.Errorf("Resolve(%v) = %v", reg, err)
+		t.Fatalf("NewFromPullSecrets() = %v", err)
+	}
+
+	expectedAuth := &authn.Basic{Username: "user", Password: "pass"}
+	testResolve(t, kc, registry(t, "fake.registry.io"), expectedAuth)
+}
+
+func TestResolveTargets(t *testing.T) {
+	// Iterate over target types
+	targetTypes := []authn.Resource{
+		registry(t, "fake.registry.io"),
+		repo(t, "fake.registry.io/repo"),
+	}
+
+	for _, secretType := range dockerSecretTypes {
+		for _, target := range targetTypes {
+			// Drop the .
+			testName := secretType.key[1:] + "_" + target.String()
+
+			t.Run(testName, func(t *testing.T) {
+				auth := authn.AuthConfig{
+					Password: fmt.Sprintf("%x", md5.Sum([]byte(t.Name()))),
+					Username: "user" + fmt.Sprintf("%x", md5.Sum([]byte(t.Name()))),
+				}
+
+				kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+					*secretType.Create(t, "ns", "secret", target.String(), auth),
+				})
+
+				if err != nil {
+					t.Fatalf("New() = %v", err)
+				}
+				authenticator := &authn.Basic{Username: auth.Username, Password: auth.Password}
+				testResolve(t, kc, target, authenticator)
+			})
+		}
+	}
+}
+
+func TestAuthWithScheme(t *testing.T) {
+	auth := authn.AuthConfig{
+		Password: "password",
+		Username: "username",
+	}
+
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret", "https://fake.registry.io", auth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	authenticator := &authn.Basic{Username: auth.Username, Password: auth.Password}
+	testResolve(t, kc, registry(t, "fake.registry.io"), authenticator)
+	testResolve(t, kc, repo(t, "fake.registry.io/repo"), authenticator)
+}
+
+func TestAuthWithPorts(t *testing.T) {
+	auth := authn.AuthConfig{
+		Password: "password",
+		Username: "username",
+	}
+
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret", "fake.registry.io:5000", auth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	authenticator := &authn.Basic{Username: auth.Username, Password: auth.Password}
+	testResolve(t, kc, registry(t, "fake.registry.io:5000"), authenticator)
+	testResolve(t, kc, repo(t, "fake.registry.io:5000/repo"), authenticator)
+
+	// Non-matching ports should return Anonymous
+	testResolve(t, kc, registry(t, "fake.registry.io:1000"), authn.Anonymous)
+	testResolve(t, kc, repo(t, "fake.registry.io:1000/repo"), authn.Anonymous)
+}
+
+func TestAuthPathMatching(t *testing.T) {
+	rootAuth := authn.AuthConfig{Username: "root", Password: "root"}
+	nestedAuth := authn.AuthConfig{Username: "nested", Password: "nested"}
+	leafAuth := authn.AuthConfig{Username: "leaf", Password: "leaf"}
+	partialAuth := authn.AuthConfig{Username: "partial", Password: "partial"}
+
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-1", "fake.registry.io", rootAuth),
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-2", "fake.registry.io/nested", nestedAuth),
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-3", "fake.registry.io/nested/repo", leafAuth),
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-4", "fake.registry.io/par", partialAuth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.FromConfig(rootAuth))
+	testResolve(t, kc, repo(t, "fake.registry.io/nested"), authn.FromConfig(nestedAuth))
+	testResolve(t, kc, repo(t, "fake.registry.io/nested/repo"), authn.FromConfig(leafAuth))
+	testResolve(t, kc, repo(t, "fake.registry.io/nested/repo/dirt"), authn.FromConfig(leafAuth))
+	testResolve(t, kc, repo(t, "fake.registry.io/partial"), authn.FromConfig(partialAuth))
+}
+
+func TestAuthHostNameVariations(t *testing.T) {
+	rootAuth := authn.AuthConfig{Username: "root", Password: "root"}
+	subdomainAuth := authn.AuthConfig{Username: "sub", Password: "sub"}
+
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-1", "fake.registry.io", rootAuth),
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-2", "1.fake.registry.io", subdomainAuth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.FromConfig(rootAuth))
+	testResolve(t, kc, registry(t, "1.fake.registry.io"), authn.FromConfig(subdomainAuth))
+
+	// Unrecognized subdomain uses Anonymous
+	testResolve(t, kc, registry(t, "2.fake.registry.io"), authn.Anonymous)
+}
+
+func TestAuthSpecialPathsIgnored(t *testing.T) {
+	auth := authn.AuthConfig{Username: "root", Password: "root"}
+	auth2 := authn.AuthConfig{Username: "root2", Password: "root2"}
+
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		// Note the paths need a trailing '/'
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-1", "https://fake.registry.io/v1/", auth),
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret-2", "https://fake2.registry.io/v2/", auth2),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.FromConfig(auth))
+	testResolve(t, kc, repo(t, "fake.registry.io/repo"), authn.FromConfig(auth))
+	testResolve(t, kc, registry(t, "fake2.registry.io"), authn.FromConfig(auth2))
+	testResolve(t, kc, repo(t, "fake2.registry.io/repo"), authn.FromConfig(auth2))
+}
+
+func TestAuthDockerRegistry(t *testing.T) {
+	auth := authn.AuthConfig{Username: "root", Password: "root"}
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret", "index.docker.io", auth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	testResolve(t, kc, repo(t, "ubuntu"), authn.FromConfig(auth))
+	testResolve(t, kc, repo(t, "knative/serving"), authn.FromConfig(auth))
+}
+
+func TestAuthWithGlobs(t *testing.T) {
+	auth := authn.AuthConfig{Username: "root", Password: "root"}
+	kc, err := NewFromPullSecrets(context.Background(), []corev1.Secret{
+		*dockerConfigJSONSecretType.Create(t, "ns", "secret", "*.registry.io", auth),
+	})
+
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.FromConfig(auth))
+	testResolve(t, kc, repo(t, "fake.registry.io/repo"), authn.FromConfig(auth))
+	testResolve(t, kc, registry(t, "blah.registry.io"), authn.FromConfig(auth))
+	testResolve(t, kc, repo(t, "blah.registry.io/repo"), authn.FromConfig(auth))
+}
+
+func testResolve(t *testing.T, kc authn.Keychain, target authn.Resource, expectedAuth authn.Authenticator) {
+	t.Helper()
+
+	auth, err := kc.Resolve(target)
+	if err != nil {
+		t.Errorf("Resolve(%v) = %v", target, err)
 	}
 	got, err := auth.Authorization()
 	if err != nil {
 		t.Errorf("Authorization() = %v", err)
 	}
-	want, err := (&authn.Basic{Username: username, Password: password}).Authorization()
+	want, err := expectedAuth.Authorization()
 	if err != nil {
 		t.Errorf("Authorization() = %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Resolve() = %v, want %v", got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("Resolve() diff (-want, +got)\n", diff)
 	}
 }
 
-func TestImagePullSecrets(t *testing.T) {
-	username, password := "foo", "bar"
-	specificUser, specificPass := "very", "specific"
-	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
-			Namespace: "ns",
-		},
-	}, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret",
-			Namespace: "ns",
-		},
-		Type: corev1.SecretTypeDockercfg,
-		Data: map[string][]byte{
-			corev1.DockerConfigKey: []byte(
-				fmt.Sprintf(`{"fake.registry.io": {"auth": %q}, "fake.registry.io/more/specific": {"auth": %q}}`,
-					base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
-					base64.StdEncoding.EncodeToString([]byte(specificUser+":"+specificPass))),
-			),
-		},
-	})
+func toJSON(t *testing.T, obj interface{}) []byte {
+	t.Helper()
 
-	kc, err := New(context.Background(), client, Options{
-		Namespace:        "ns",
-		ImagePullSecrets: []string{"secret"},
-	})
+	bites, err := json.Marshal(obj)
+
 	if err != nil {
-		t.Fatalf("New() = %v", err)
+		t.Fatal("unable to json marshal", err)
 	}
-
-	repo, err := name.NewRepository("fake.registry.io/more/specific", name.WeakValidation)
-	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
-	}
-
-	for _, tc := range []struct {
-		name   string
-		auth   authn.Authenticator
-		target authn.Resource
-	}{{
-		name:   "registry",
-		auth:   &authn.Basic{Username: username, Password: password},
-		target: repo.Registry,
-	}, {
-		name:   "repo",
-		auth:   &authn.Basic{Username: specificUser, Password: specificPass},
-		target: repo,
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
-			auth, err := kc.Resolve(tc.target)
-			if err != nil {
-				t.Errorf("Resolve(%v) = %v", tc.target, err)
-			}
-			got, err := auth.Authorization()
-			if err != nil {
-				t.Errorf("Authorization() = %v", err)
-			}
-			want, err := tc.auth.Authorization()
-			if err != nil {
-				t.Errorf("Authorization() = %v", err)
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("Resolve() = %v, want %v", got, want)
-			}
-		})
-	}
+	return bites
 }
 
-func TestFromPullSecrets(t *testing.T) {
-	username, password := "foo", "bar"
-	specificUser, specificPass := "very", "specific"
+func registry(t *testing.T, registry string) authn.Resource {
+	t.Helper()
 
-	pullSecrets := []corev1.Secret{{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret",
-			Namespace: "ns",
-		},
-		Type: corev1.SecretTypeDockercfg,
-		Data: map[string][]byte{
-			corev1.DockerConfigKey: []byte(
-				fmt.Sprintf(`
-					{
-						"fake.registry.io": {"auth": %q},
-						"fake.registry.io/more/specific": {"auth": %q},
-						"http://fake.scheme-registry.io": {"auth": %q},
-						"https://fake.scheme-registry.io/more/specific": {"auth": %q},
-						"https://index.docker.io/v1/": {"auth": %q}
-					}`,
-					base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
-					base64.StdEncoding.EncodeToString([]byte(specificUser+":"+specificPass)),
-					base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
-					base64.StdEncoding.EncodeToString([]byte(specificUser+":"+specificPass)),
-					base64.StdEncoding.EncodeToString([]byte(username+":"+password))),
-			),
-		},
-	}, {
-		// Check that a subsequent Secret that matches the registry is
-		// _not_ used; i.e., first matching Secret wins.
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret-2",
-			Namespace: "ns",
-		},
-		Type: corev1.SecretTypeDockercfg,
-		Data: map[string][]byte{
-			corev1.DockerConfigKey: []byte(
-				fmt.Sprintf(`{"fake.registry.io": {"auth": %q}}`,
-					base64.StdEncoding.EncodeToString([]byte("anotherUser:anotherPass"))),
-			),
-		},
-	}}
-
-	kc, err := NewFromPullSecrets(context.Background(), pullSecrets)
+	reg, err := name.NewRegistry(registry, name.WeakValidation)
 	if err != nil {
-		t.Fatalf("NewFromPullSecrets() = %v", err)
+		t.Fatal("failed to create registry", err)
 	}
+	return reg
+}
 
-	repo, err := name.NewRepository("fake.registry.io/more/specific", name.WeakValidation)
+func repo(t *testing.T, repository string) authn.Resource {
+	t.Helper()
+
+	repo, err := name.NewRepository(repository, name.WeakValidation)
 	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
+		t.Fatal("failed to create repo", err)
 	}
-
-	schemeRepo, err := name.NewRepository("fake.scheme-registry.io/more/specific", name.WeakValidation)
-	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
-	}
-
-	dockerHubRepo, err := name.NewRepository("nginx", name.WeakValidation)
-	if err != nil {
-		t.Errorf("NewRegistry() = %v", err)
-	}
-
-	for _, tc := range []struct {
-		name   string
-		auth   authn.Authenticator
-		target authn.Resource
-	}{{
-		name:   "registry",
-		auth:   &authn.Basic{Username: username, Password: password},
-		target: repo.Registry,
-	}, {
-		name:   "repo",
-		auth:   &authn.Basic{Username: specificUser, Password: specificPass},
-		target: repo,
-	}, {
-		name:   "registry with scheme",
-		auth:   &authn.Basic{Username: username, Password: password},
-		target: schemeRepo.Registry,
-	}, {
-		name:   "repo with scheme",
-		auth:   &authn.Basic{Username: specificUser, Password: specificPass},
-		target: schemeRepo,
-	}, {
-		name:   "docker hub repo",
-		auth:   &authn.Basic{Username: username, Password: password},
-		target: dockerHubRepo,
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
-			auth, err := kc.Resolve(tc.target)
-			if err != nil {
-				t.Errorf("Resolve(%v) = %v", tc.target, err)
-			}
-			got, err := auth.Authorization()
-			if err != nil {
-				t.Errorf("Authorization() = %v", err)
-			}
-			want, err := tc.auth.Authorization()
-			if err != nil {
-				t.Errorf("Authorization() = %v", err)
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("Resolve() = %v, want %v", got, want)
-			}
-		})
-	}
+	return repo
 }


### PR DESCRIPTION
Prior we weren't matching host names and partial paths properly

This was breaking Gitlab and Azure tag to digest resolution in Knative (https://github.com/knative/serving/issues/12761)