### PR TITLE
update go action to always get the latest available and other updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,13 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.14, 1.15, 1.16, 1.17, 1.18]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - run: |
           go build ./...

--- a/.github/workflows/bump-deps.yaml
+++ b/.github/workflows/bump-deps.yaml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.17
+        check-latest: true
 
     - run: ./hack/bump-deps.sh
     - name: Create Pull Request

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,7 @@
 name: Basic e2e test
 
 on:
-  pull_request: 
+  pull_request:
     branches: ['main']
 
 jobs:
@@ -19,7 +19,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.17
+        check-latest: true
 
     - name: crane append to an image, set the entrypoint, run it locally, roundtrip it
       shell: bash
@@ -53,7 +54,7 @@ jobs:
                 --new_layer crane.tar))
 
         # Run the image with and without args.
-        docker run $img 
+        docker run $img
         docker run $img --help
 
         # Make sure we can roundtrip it through pull/push

--- a/.github/workflows/ecr-auth.yaml
+++ b/.github/workflows/ecr-auth.yaml
@@ -21,7 +21,8 @@ jobs:
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.17
+          check-latest: true
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -51,7 +52,8 @@ jobs:
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.17
+          check-latest: true
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/ghcr-auth.yaml
+++ b/.github/workflows/ghcr-auth.yaml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.17
+          check-latest: true
 
       - name: Install krane
         working-directory: ./cmd/krane

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -29,5 +29,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.17
+          check-latest: true
       - run: ./hack/presubmit.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
         run: git fetch --prune --unshallow
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.17
+          check-latest: true
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -22,7 +22,7 @@ jobs:
         stale-pr-message: |-
           This Pull Request is stale because it has been open for 90 days with
           no activity. It will automatically close after 30 more days of
-          inactivity. Keep fresh with the 'lifecycle/frozen' label. 
+          inactivity. Keep fresh with the 'lifecycle/frozen' label.
         stale-pr-label: 'lifecycle/stale'
         exempt-pr-labels: 'lifecycle/frozen'
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.17
+          check-latest: true
       - uses: actions/checkout@v3
       - uses: chainguard-dev/actions/goimports@84c993eaf02da1c325854fb272a4df9184bd80fc # main
 
@@ -24,7 +25,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.17
+          check-latest: true
 
       - uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.42.1
+          version: v1.45.2
 
       - uses: reviewdog/action-misspell@v1
         if: ${{ always() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.14, 1.15, 1.16, 1.17, 1.18]
 
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - run: go test -coverprofile=coverage.txt -covermode=atomic -race ./...
 

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -208,7 +208,7 @@ func TestCheckErrorWithError(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		b, err := json.Marshal(test.error)
+		b, err := json.Marshal(test.error) // nolint: staticcheck
 		if err != nil {
 			t.Errorf("json.Marshal(%v) = %v", test.error, err)
 		}

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -894,7 +894,7 @@ func TestWriteWithErrors(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
 			}
-			b, err := json.Marshal(expectedError)
+			b, err := json.Marshal(expectedError) // nolint: staticcheck
 			if err != nil {
 				t.Fatalf("json.Marshal() = %v", err)
 			}


### PR DESCRIPTION
- update go action to always get the latest available
- update some jobs to use go 1.17
- add go1.18 to be tested as well
- update golangci-lint to 1.45.2