### PR TITLE
fix(ConfigFile): Add Variant

### DIFF
--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -37,6 +37,7 @@ type ConfigFile struct {
 	RootFS        RootFS    `json:"rootfs"`
 	Config        Config    `json:"config"`
 	OSVersion     string    `json:"os.version,omitempty"`
+	Variant       string    `json:"variant,omitempty"`
 }
 
 // History is one entry of a list recording how this container image was built.


### PR DESCRIPTION
Signed-off-by: Markus Lippert <lippertmarkus@gmx.de>

By mutating an image, the configfile is copied. When the source image is e.g. linux/arm/v7 the variant is currently not copied as its not part of the ConfigFile struct.

This field is usually part of the config https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants:
`crane config mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine-arm64v8`
```diff
{
     ...
     "architecture": "arm64",
     "os": "linux",
+    "variant": "v8"
}
```