### PR TITLE
Let image pull secrets have higher precedence

### DIFF
--- a/pkg/authn/k8schain/k8schain.go
+++ b/pkg/authn/k8schain/k8schain.go
@@ -96,10 +96,10 @@ func NewFromPullSecrets(ctx context.Context, pullSecrets []corev1.Secret) (authn
 	}
 
 	return authn.NewMultiKeychain(
+		k8s,
 		authn.DefaultKeychain,
 		google.Keychain,
 		amazonKeychain,
 		azureKeychain,
-		k8s,
 	), nil
 }


### PR DESCRIPTION
github.com/google/go-containerregistry/pkg/authn/k8schain.NewFromPullSecrets
now sets image pull secrets with higher precedence.

Similar to #1346.