### PR TITLE
k8schain: prioritize imagePullSecrets over implicit auth

### DIFF
--- a/pkg/authn/k8schain/k8schain.go
+++ b/pkg/authn/k8schain/k8schain.go
@@ -96,10 +96,10 @@ func NewFromPullSecrets(ctx context.Context, pullSecrets []corev1.Secret) (authn
 	}
 
 	return authn.NewMultiKeychain(
+		k8s,
 		authn.DefaultKeychain,
 		google.Keychain,
 		amazonKeychain,
 		azureKeychain,
-		k8s,
 	), nil
 }


### PR DESCRIPTION
supercedes #1367

cc @vpnachev

#1346 only prioritized the k8s secrets when using `New`, not `NewFromPullSecrets`.