### PR TITLE
Include header referring to the image ref being pulled

### DIFF
--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -243,6 +243,9 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 	if err != nil {
 		return nil, nil, err
 	}
+	if f.Ref != nil {
+		req.Header.Set("X-Go-Container-Registry-For-Ref", f.Ref.Name())
+	}
 	accept := []string{}
 	for _, mt := range acceptable {
 		accept = append(accept, string(mt))
@@ -307,6 +310,9 @@ func (f *fetcher) headManifest(ref name.Reference, acceptable []types.MediaType)
 	if err != nil {
 		return nil, err
 	}
+	if f.Ref != nil {
+		req.Header.Set("X-Go-Container-Registry-For-Ref", f.Ref.Name())
+	}
 	accept := []string{}
 	for _, mt := range acceptable {
 		accept = append(accept, string(mt))
@@ -363,6 +369,10 @@ func (f *fetcher) fetchBlob(ctx context.Context, size int64, h v1.Hash) (io.Read
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if f.Ref != nil {
+		req.Header.Set("X-Go-Container-Registry-For-Ref", f.Ref.Name())
 	}
 
 	resp, err := f.Client.Do(req.WithContext(ctx))

--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -102,6 +102,9 @@ func TestGetImageAsIndex(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Header().Set("Content-Type", string(types.DockerManifestSchema2))
 			w.Write([]byte("doesn't matter"))
 		default:

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -160,6 +160,9 @@ func TestRawManifestDigests(t *testing.T) {
 					if r.Method != http.MethodGet {
 						t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 					}
+					if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+						t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+					}
 
 					w.Header().Set("Docker-Content-Digest", tc.contentDigest)
 					w.Write(tc.responseBody)
@@ -202,6 +205,9 @@ func TestRawManifestNotFound(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Fatalf("Unexpected path: %v", r.URL.Path)
@@ -237,10 +243,16 @@ func TestRawConfigFileNotFound(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.WriteHeader(http.StatusNotFound)
 		case manifestPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(mustRawManifest(t, img))
 		default:
@@ -275,6 +287,9 @@ func TestAcceptHeaders(t *testing.T) {
 		case manifestPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			wantAccept := strings.Join([]string{
 				string(types.DockerManifestSchema2),
@@ -328,11 +343,17 @@ func TestImage(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Write(mustRawConfigFile(t, img))
 		case manifestPath:
 			manifestReqCount++
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(mustRawManifest(t, img))
 		case layerPath:
@@ -419,21 +440,33 @@ func TestPullingManifestList(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Header().Set("Content-Type", string(mustMediaType(t, idx)))
 			w.Write(rawManifest)
 		case childPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Write(mustRawManifest(t, child))
 		case configPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Write(mustRawConfigFile(t, child))
 		case fakePlatformChildPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(mustRawManifest(t, fakePlatformChild))
 		default:
@@ -492,16 +525,25 @@ func TestPullingManifestListNoMatch(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Header().Set("Content-Type", string(mustMediaType(t, idx)))
 			w.Write(mustRawManifest(t, idx))
 		case childPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Write(mustRawManifest(t, child))
 		case configPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(mustRawConfigFile(t, child))
 		default:
@@ -619,10 +661,16 @@ func TestPullingForeignLayer(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
+			}
 			w.Write(mustRawConfigFile(t, img))
 		case manifestPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(mustRawManifest(t, img))
 		case layerPath:
@@ -715,6 +763,9 @@ func TestData(t *testing.T) {
 		case "/v2/test/manifests/latest":
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			if got := r.Header.Get("X-Go-Container-Registry-For-Ref"); got == "" {
+				t.Errorf("X-Go-Container-Registry-For-Ref header missing")
 			}
 			w.Write(rawManifest)
 		default:


### PR DESCRIPTION
This can be useful to registry operators to help associate blob pull traffic with the actual image being requested.

I'm opening this mainly to gather input (and to bikeshed the header name). I think this information could be useful to registry operators, both as information that can be usefully aggregated to show how many blobs or bytes were pulled "because" of an image ref, and possibly to inform better rate limiting decisions.

Ideally I'd like to propose something like this to OCI's distribution-spec, as a "clients MAY send ..." section, and try to get that into more and more clients (docker, containers/image, etc), so this is more uniformly reported across the ecosystem. But first I wanted to try it out in here and get feedback.

edit: Instead of `X-Go-Container-Registry-For-Ref`, which is a mouthful, maybe just `OCI-Ref: index.docker.io/library/ubuntu:latest` ?

Example:

```
$ go run ./cmd/crane pull ubuntu /dev/null --verbose
...
2022/05/18 10:15:07 --> GET https://index.docker.io/v2/library/ubuntu/manifests/sha256:aa6c2c047467afc828e77e306041b7fa4a65734fe3449a54aa9c280822b0d87d
2022/05/18 10:15:07 GET /v2/library/ubuntu/manifests/sha256:aa6c2c047467afc828e77e306041b7fa4a65734fe3449a54aa9c280822b0d87d HTTP/1.1
Host: index.docker.io
User-Agent: crane/(devel) go-containerregistry/(devel)
Accept: application/vnd.docker.distribution.manifest.v2+json
Authorization: <redacted>
X-Go-Container-Registry-For-Ref: index.docker.io/library/ubuntu:latest
Accept-Encoding: gzip
...
2022/05/18 10:10:48 --> GET https://index.docker.io/v2/library/ubuntu/blobs/sha256:d2e4e1f511320dfb2d0baff2468fcf0526998b73fe10c8890b4684bb7ef8290f
2022/05/18 10:10:48 GET /v2/library/ubuntu/blobs/sha256:d2e4e1f511320dfb2d0baff2468fcf0526998b73fe10c8890b4684bb7ef8290f HTTP/1.1
Host: index.docker.io
User-Agent: crane/(devel) go-containerregistry/(devel)
Authorization: <redacted>
X-Go-Container-Registry-For-Ref: index.docker.io/library/ubuntu@sha256:aa6c2c047467afc828e77e306041b7fa4a65734fe3449a54aa9c280822b0d87d
Accept-Encoding: gzip
...
```

NB: In the example above, a manifest GET for a child manifest in an index includes the ref of the parent index, and a blob GET for a child manifest includes the child manifest's ref-by-digest, not the parent index's. We can change this if we want to, or even include both if we really felt like it.