### PR TITLE
remote: Collect ETag in response, optimistically send that back in future updates

### DIFF
--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -39,6 +39,13 @@ type image struct {
 	digestMap       map[v1.Hash]v1.Layer
 }
 
+func (i *image) ETag() string {
+	if e, ok := i.base.(partial.WithETag); ok {
+		return e.ETag()
+	}
+	return ""
+}
+
 var _ v1.Image = (*image)(nil)
 
 func (i *image) MediaType() (types.MediaType, error) {

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -25,6 +25,16 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+// WithETag defines the subset of manifest types that can expose an ETag
+// returned by a registry server.
+//
+// If a manifest provides an ETag using this method, it will be used when
+// pushing updates, to prevent race conditions.
+type WithETag interface {
+	// ETag returns the ETag returned by remote registry implementations.
+	ETag() string
+}
+
 // WithRawConfigFile defines the subset of v1.Image used by these helper methods
 type WithRawConfigFile interface {
 	// RawConfigFile returns the serialized bytes of this image's config file.

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -60,6 +60,8 @@ func Image(ref name.Reference, options ...Option) (v1.Image, error) {
 	return desc.Image()
 }
 
+func (r *remoteImage) ETag() string { return r.etag }
+
 func (r *remoteImage) MediaType() (types.MediaType, error) {
 	if string(r.mediaType) != "" {
 		return r.mediaType, nil

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -45,6 +45,7 @@ type remoteImage struct {
 	config       []byte
 	mediaType    types.MediaType
 	descriptor   *v1.Descriptor
+	etag         string
 }
 
 var _ partial.CompressedImageCore = (*remoteImage)(nil)
@@ -76,7 +77,7 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
 	// do type-checking via remote.Descriptor. I've left this here for tests that
 	// directly instantiate a remoteImage.
-	manifest, desc, err := r.fetchManifest(r.Ref, acceptableImageMediaTypes)
+	manifest, desc, _, err := r.fetchManifest(r.Ref, acceptableImageMediaTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -38,6 +38,7 @@ type remoteIndex struct {
 	manifest     []byte
 	mediaType    types.MediaType
 	descriptor   *v1.Descriptor
+	etag         string
 }
 
 // Index provides access to a remote index reference.
@@ -75,7 +76,7 @@ func (r *remoteIndex) RawManifest() ([]byte, error) {
 	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
 	// do type-checking via remote.Descriptor. I've left this here for tests that
 	// directly instantiate a remoteIndex.
-	manifest, desc, err := r.fetchManifest(r.Ref, acceptableIndexMediaTypes)
+	manifest, desc, _, err := r.fetchManifest(r.Ref, acceptableIndexMediaTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -236,6 +237,7 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 	var (
 		manifest []byte
 		err      error
+		etag     string
 	)
 	if child.Data != nil {
 		if err := verify.Descriptor(child); err != nil {
@@ -243,7 +245,7 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 		}
 		manifest = child.Data
 	} else {
-		manifest, _, err = r.fetchManifest(ref, []types.MediaType{child.MediaType})
+		manifest, _, etag, err = r.fetchManifest(ref, []types.MediaType{child.MediaType})
 		if err != nil {
 			return nil, err
 		}
@@ -257,6 +259,7 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 		Manifest:   manifest,
 		Descriptor: child,
 		platform:   platform,
+		etag:       etag,
 	}, nil
 }
 

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -51,6 +51,8 @@ func Index(ref name.Reference, options ...Option) (v1.ImageIndex, error) {
 	return desc.ImageIndex()
 }
 
+func (r *remoteIndex) ETag() string { return r.etag }
+
 func (r *remoteIndex) MediaType() (types.MediaType, error) {
 	if string(r.mediaType) != "" {
 		return r.mediaType, nil

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -612,11 +612,8 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		}
 		req.Header.Set("Content-Type", string(desc.MediaType))
 
-		if ri, ok := t.(*remoteImage); ok && ri.etag != "" {
-			req.Header.Set("If-Match", ri.etag)
-		}
-		if ri, ok := t.(*remoteIndex); ok && ri.etag != "" {
-			req.Header.Set("If-Match", ri.etag)
+		if e, ok := t.(partial.WithETag); ok && e.ETag() != "" {
+			req.Header.Set("If-Match", e.ETag())
 		}
 
 		resp, err := w.client.Do(req.WithContext(ctx))

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -612,6 +612,13 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		}
 		req.Header.Set("Content-Type", string(desc.MediaType))
 
+		if ri, ok := t.(*remoteImage); ok && ri.etag != "" {
+			req.Header.Set("If-Match", ri.etag)
+		}
+		if ri, ok := t.(*remoteIndex); ok && ri.etag != "" {
+			req.Header.Set("If-Match", ri.etag)
+		}
+
 		resp, err := w.client.Do(req.WithContext(ctx))
 		if err != nil {
 			return err


### PR DESCRIPTION
When pulling a manifest, if the response includes an `ETag` header, hold on to it, and send that back in an `If-Match` request header when putting that manifest back.

This should prevent some race conditions during read-modify-write cycles, if the registry respects the `If-Match` header, since the resource's etag will have changed when the other client updated it.

TODO: Add test.

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#avoiding_mid-air_collisions
- https://github.com/opencontainers/distribution-spec/pull/251/