### PR TITLE
Allow config files to be mounted

### DIFF
--- a/pkg/v1/partial/compressed_test.go
+++ b/pkg/v1/partial/compressed_test.go
@@ -87,6 +87,14 @@ func TestRemote(t *testing.T) {
 	if got, want := ok, true; got != want {
 		t.Errorf("Exists() = %t != %t", got, want)
 	}
+
+	cl, err := partial.ConfigLayer(img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cl.(*remote.MountableLayer); !ok {
+		t.Errorf("ConfigLayer() expected to be MountableLayer, got %T", cl)
+	}
 }
 
 type noDiffID struct {

--- a/pkg/v1/remote/mount.go
+++ b/pkg/v1/remote/mount.go
@@ -93,3 +93,16 @@ func (mi *mountableImage) LayerByDiffID(d v1.Hash) (v1.Layer, error) {
 func (mi *mountableImage) Descriptor() (*v1.Descriptor, error) {
 	return partial.Descriptor(mi.Image)
 }
+
+// ConfigLayer retains the original reference so that it can be mounted.
+// See partial.ConfigLayer.
+func (mi *mountableImage) ConfigLayer() (v1.Layer, error) {
+	l, err := partial.ConfigLayer(mi.Image)
+	if err != nil {
+		return nil, err
+	}
+	return &MountableLayer{
+		Layer:     l,
+		Reference: mi.Reference,
+	}, nil
+}


### PR DESCRIPTION
Because we wanted to reuse the layer uploading code, we wrap the config
bytes up as a Layer. Unfortunately, the partial.ConfigLayer
implementation doesn't preserve the fact that for mountable images, we
can perform a cross-repo mount.

This change updates partial.ConfigLayer to look for a ConfigLayer
implementation on the given image to see if it can simply dispatch to
that, falling back to calculating it from the config bytes otherwise.