### PR TITLE
Implement cross-registry blob mounting experiment

### DIFF
--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -39,7 +39,7 @@ func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTrip
 		client:  &http.Client{Transport: tr},
 		context: context.Background(),
 	}
-	loc, _, err := w.initiateUpload("", "")
+	loc, _, err := w.initiateUpload("", "", "")
 	if loc != "" {
 		// Since we're only initiating the upload to check whether we
 		// can, we should attempt to cancel it, in case initiating

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -257,7 +257,7 @@ func TestInitiateUploadNoMountsExists(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload("baz/bar", h.String())
+	_, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -295,7 +295,7 @@ func TestInitiateUploadNoMountsInitiated(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload("baz/bar", h.String())
+	location, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -334,7 +334,7 @@ func TestInitiateUploadNoMountsBadStatus(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload("baz/bar", h.String())
+	location, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
 	if err == nil {
 		t.Errorf("intiateUpload() = %v, %v; wanted error", location, mounted)
 	}
@@ -367,7 +367,7 @@ func TestInitiateUploadMountsWithMountFromDifferentRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload("baz/bar", h.String())
+	_, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -407,7 +407,49 @@ func TestInitiateUploadMountsWithMountFromTheSameRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String())
+	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String(), "")
+	if err != nil {
+		t.Errorf("intiateUpload() = %v", err)
+	}
+	if !mounted {
+		t.Error("initiateUpload() = !mounted, want mounted")
+	}
+}
+
+func TestInitiateUploadMountsWithOrigin(t *testing.T) {
+	img := setupImage(t)
+	h := mustConfigName(t, img)
+	expectedMountRepo := "a/different/repo"
+	expectedRepo := "yet/again"
+	expectedPath := fmt.Sprintf("/v2/%s/blobs/uploads/", expectedRepo)
+	expectedOrigin := "fakeOrigin"
+	expectedQuery := url.Values{
+		"mount":  []string{h.String()},
+		"from":   []string{expectedMountRepo},
+		"origin": []string{expectedOrigin},
+	}.Encode()
+
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method; got %v, want %v", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("URL; got %v, want %v", r.URL.Path, expectedPath)
+		}
+		if r.URL.RawQuery != expectedQuery {
+			t.Errorf("RawQuery; got %v, want %v", r.URL.RawQuery, expectedQuery)
+		}
+		http.Error(w, "Mounted", http.StatusCreated)
+	})
+	server := httptest.NewServer(serverHandler)
+
+	w, closer, err := setupWriterWithServer(server, expectedRepo)
+	if err != nil {
+		t.Fatalf("setupWriterWithServer() = %v", err)
+	}
+	defer closer.Close()
+
+	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String(), "fakeOrigin")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}


### PR DESCRIPTION
This is currently only implemented by Google but we'd like to upstream
this to the distribution spec. There's a small possibility that this
will break registries that don't implement the spec properly.

We signal the domain of the origin registry with the "origin"
querystring parameter.

Fixes https://github.com/google/go-containerregistry/issues/1321

Likely breaks with harbor because of https://github.com/google/go-containerregistry/pull/219 but they [SHOULD](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#mounting-a-blob-from-another-repository) be returning a 202 here.