### PR TITLE
Add debug logs to google.Keychain

### DIFF
--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -71,11 +71,13 @@ func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, e
 func resolve() authn.Authenticator {
 	auth, envErr := NewEnvAuthenticator()
 	if envErr == nil && auth != authn.Anonymous {
+		logs.Debug.Println("google.Keychain: using Application Default Credentials")
 		return auth
 	}
 
 	auth, gErr := NewGcloudAuthenticator()
 	if gErr == nil && auth != authn.Anonymous {
+		logs.Debug.Println("google.Keychain: using gcloud fallback")
 		return auth
 	}
 


### PR DESCRIPTION
This would have been helpful in debugging why crane worked while gcrane
didn't.