### PR TITLE
Do not check /v2 endpoint on registry when RoundTripper is provided

### DIFF
--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -27,7 +27,7 @@ export GOPATH="${TMP_DIR}"
 pushd ${TMP_DIR}
 trap popd EXIT
 go install golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616
-go install honnef.co/go/tools/cmd/staticcheck@v0.2.1
+go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 popd
 
 pushd ${PROJECT_ROOT}

--- a/pkg/v1/remote/transport/transport.go
+++ b/pkg/v1/remote/transport/transport.go
@@ -33,9 +33,18 @@ func New(reg name.Registry, auth authn.Authenticator, t http.RoundTripper, scope
 }
 
 // NewWithContext returns a new RoundTripper based on the provided RoundTripper that has been
-// setup to authenticate with the remote registry "reg", in the capacity
+// set up to authenticate with the remote registry "reg", in the capacity
 // laid out by the specified scopes.
+// In case the RoundTripper is already of the type Wrapper it assumes
+// authentication was already done prior to this call, so it just returns
+// the provided RoundTripper without further action
 func NewWithContext(ctx context.Context, reg name.Registry, auth authn.Authenticator, t http.RoundTripper, scopes []string) (http.RoundTripper, error) {
+	// When the transport provided is of the type Wrapper this function assumes that the caller already
+	// executed the necessary login and check.
+	switch t.(type) {
+	case *Wrapper:
+		return t, nil
+	}
 	// The handshake:
 	//  1. Use "t" to ping() the registry for the authentication challenge.
 	//


### PR DESCRIPTION
This PR contains the following changes:
1. Bump staticcheck to the latest version and fix problems detected.
2. When a RoundTripper of the type `transport.Wrapper` is provided to the function `NewWithContext`, the function will assume that the called has already created the RoundTripper and made sure that the authentication happened and that the registry supports V2 of distribution spec.
