### PR TITLE
Returning the specific reason for the failure of ParseReference

### DIFF
--- a/pkg/name/errors_test.go
+++ b/pkg/name/errors_test.go
@@ -28,7 +28,7 @@ func TestBadName(t *testing.T) {
 	if !errors.As(err, &berr) {
 		t.Errorf("Not an ErrBadName using errors.As: %v", err)
 	}
-	if err.Error() != "could not parse reference: @@" {
+	if err.Error() != "could not parse reference: @@. detail: parse tag err: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: @@. parse digest err: a digest must contain exactly one '@' separator (e.g. registry/repository@digest) saw: @@" {
 		t.Errorf("Unexpected string: %v", err)
 	}
 }

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -38,13 +38,19 @@ type Reference interface {
 
 // ParseReference parses the string as a reference, either by tag or digest.
 func ParseReference(s string, opts ...Option) (Reference, error) {
-	if t, err := NewTag(s, opts...); err == nil {
+	var err error
+	t, err := NewTag(s, opts...)
+	if err == nil {
 		return t, nil
 	}
-	if d, err := NewDigest(s, opts...); err == nil {
+	detail := fmt.Sprintf("parse tag err: %s. ",
+		err.Error())
+	d, err := NewDigest(s, opts...)
+	if err == nil {
 		return d, nil
 	}
-	return nil, newErrBadName("could not parse reference: " + s)
+	detail += fmt.Sprintf("parse digest err: " + err.Error())
+	return nil, newErrBadName(fmt.Sprintf("could not parse reference: %s. detail: %s", s, detail))
 }
 
 type stringConst string


### PR DESCRIPTION
I think it's better to return the specific reason for the failure of `ParseReference`, so that it is easier for users to debug. For example, when executing the following code, return the reason for the failure of `NewTag` (repo name cannot contain capital letters), so that the the user knows what went wrong and how to fix it (not everyone knows that repo names can't have capital letters...)
```go
	err := crane.Push(nil, "badRepo:1.0")
	if err != nil {
		panic(err.Error())
	}

```