### PR TITLE
Preserve descriptors when writing to layout

### DIFF
--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -45,33 +45,17 @@ func (l Path) AppendImage(img v1.Image, options ...Option) error {
 		return err
 	}
 
-	mt, err := img.MediaType()
+	desc, err := partial.Descriptor(img)
 	if err != nil {
 		return err
-	}
-
-	d, err := img.Digest()
-	if err != nil {
-		return err
-	}
-
-	manifest, err := img.RawManifest()
-	if err != nil {
-		return err
-	}
-
-	desc := v1.Descriptor{
-		MediaType: mt,
-		Size:      int64(len(manifest)),
-		Digest:    d,
 	}
 
 	o := makeOptions(options...)
 	for _, opt := range o.descOpts {
-		opt(&desc)
+		opt(desc)
 	}
 
-	return l.AppendDescriptor(desc)
+	return l.AppendDescriptor(*desc)
 }
 
 // AppendIndex writes a v1.ImageIndex to the Path and updates
@@ -81,33 +65,17 @@ func (l Path) AppendIndex(ii v1.ImageIndex, options ...Option) error {
 		return err
 	}
 
-	mt, err := ii.MediaType()
+	desc, err := partial.Descriptor(ii)
 	if err != nil {
 		return err
-	}
-
-	d, err := ii.Digest()
-	if err != nil {
-		return err
-	}
-
-	manifest, err := ii.RawManifest()
-	if err != nil {
-		return err
-	}
-
-	desc := v1.Descriptor{
-		MediaType: mt,
-		Size:      int64(len(manifest)),
-		Digest:    d,
 	}
 
 	o := makeOptions(options...)
 	for _, opt := range o.descOpts {
-		opt(&desc)
+		opt(desc)
 	}
 
-	return l.AppendDescriptor(desc)
+	return l.AppendDescriptor(*desc)
 }
 
 // AppendDescriptor adds a descriptor to the index.json of the Path.
@@ -492,12 +460,15 @@ func (l Path) WriteIndex(ii v1.ImageIndex) error {
 //
 // The contents are written in the following format:
 // At the top level, there is:
-//   One oci-layout file containing the version of this image-layout.
-//   One index.json file listing descriptors for the contained images.
+//
+//	One oci-layout file containing the version of this image-layout.
+//	One index.json file listing descriptors for the contained images.
+//
 // Under blobs/, there is, for each image:
-//   One file for each layer, named after the layer's SHA.
-//   One file for each config blob, named after its SHA.
-//   One file for each manifest blob, named after its SHA.
+//
+//	One file for each layer, named after the layer's SHA.
+//	One file for each config blob, named after its SHA.
+//	One file for each manifest blob, named after its SHA.
 func Write(path string, ii v1.ImageIndex) (Path, error) {
 	lp := Path(path)
 	// Always just write oci-layout file, since it's small.


### PR DESCRIPTION
We currently compute these manually, but that drops platform information
and annotations. Keep these instead so it's easy to put together an
index using crane pull.