### PR TITLE
Don't annotate refs by default, switch to OCI key

### DIFF
--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
@@ -28,7 +29,10 @@ import (
 
 // NewCmdPull creates a new cobra.Command for the pull subcommand.
 func NewCmdPull(options *[]crane.Option) *cobra.Command {
-	var cachePath, format string
+	var (
+		cachePath, format string
+		annotateRef       bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "pull IMAGE TARBALL",
@@ -38,8 +42,8 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 			imageMap := map[string]v1.Image{}
 			indexMap := map[string]v1.ImageIndex{}
 			srcList, path := args[:len(args)-1], args[len(args)-1]
+			o := crane.GetOptions(*options...)
 			for _, src := range srcList {
-				o := crane.GetOptions(*options...)
 				ref, err := name.ParseReference(src, o.Name...)
 				if err != nil {
 					return fmt.Errorf("parsing reference %q: %w", src, err)
@@ -81,20 +85,42 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 					return fmt.Errorf("saving legacy tarball %s: %w", path, err)
 				}
 			case "oci":
-				if err := crane.MultiSaveOCI(imageMap, path); err != nil {
-					return fmt.Errorf("saving oci image layout %s: %w", path, err)
-				}
-
-				// crane.MultiSaveOCI doesn't support index, so just append these at the end.
+				// Don't use crane.MultiSaveOCI so we can control annotations.
 				p, err := layout.FromPath(path)
 				if err != nil {
-					return err
-				}
-				for ref, idx := range indexMap {
-					anns := map[string]string{
-						"dev.ggcr.image.name": ref,
+					p, err = layout.Write(path, empty.Index)
+					if err != nil {
+						return err
 					}
-					if err := p.AppendIndex(idx, layout.WithAnnotations(anns)); err != nil {
+				}
+				for ref, img := range imageMap {
+					opts := []layout.Option{}
+					if annotateRef {
+						parsed, err := name.ParseReference(ref, o.Name...)
+						if err != nil {
+							return err
+						}
+						opts = append(opts, layout.WithAnnotations(map[string]string{
+							"org.opencontainers.image.ref.name": parsed.Name(),
+						}))
+					}
+					if err = p.AppendImage(img, opts...); err != nil {
+						return err
+					}
+				}
+
+				for ref, idx := range indexMap {
+					opts := []layout.Option{}
+					if annotateRef {
+						parsed, err := name.ParseReference(ref, o.Name...)
+						if err != nil {
+							return err
+						}
+						opts = append(opts, layout.WithAnnotations(map[string]string{
+							"org.opencontainers.image.ref.name": parsed.Name(),
+						}))
+					}
+					if err := p.AppendIndex(idx, opts...); err != nil {
 						return err
 					}
 				}
@@ -106,6 +132,7 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
 	cmd.Flags().StringVar(&format, "format", "tarball", fmt.Sprintf("Format in which to save images (%q, %q, or %q)", "tarball", "legacy", "oci"))
+	cmd.Flags().BoolVar(&annotateRef, "annotate-ref", false, "Preserves image reference used to pull as an annotation when used with --format=oci")
 
 	return cmd
 }

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -9,6 +9,7 @@ crane pull IMAGE TARBALL [flags]
 ### Options
 
 ```
+      --annotate-ref        Preserves image reference used to pull as an annotation when used with --format=oci
   -c, --cache_path string   Path to cache image layers
       --format string       Format in which to save images ("tarball", "legacy", or "oci") (default "tarball")
   -h, --help                help for pull

--- a/pkg/crane/pull.go
+++ b/pkg/crane/pull.go
@@ -133,11 +133,8 @@ func MultiSaveOCI(imgMap map[string]v1.Image, path string) error {
 			return err
 		}
 	}
-	for ref, img := range imgMap {
-		anns := map[string]string{
-			"dev.ggcr.image.name": ref,
-		}
-		if err = p.AppendImage(img, layout.WithAnnotations(anns)); err != nil {
+	for _, img := range imgMap {
+		if err = p.AppendImage(img); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
A bunch of breaking changes that might be contentious, but I think this
is probably the right behavior.

1. Stick the full image ref in the image (not just e.g. ubuntu) so it's
   clear that it's the image and not just a tag.
2. Only do this when --annotate-ref is passed, so that these things are
   location-independent by default.
3. Switch from a crane annotation key to the standard OCI key.