### PR TITLE
Fall back to no mount if registry misbehaves

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -284,6 +284,11 @@ func (w *writer) initiateUpload(from, mount, origin string) (location string, mo
 	defer resp.Body.Close()
 
 	if err := transport.CheckError(resp, http.StatusCreated, http.StatusAccepted); err != nil {
+		if origin != "" && origin != w.repo.RegistryStr() {
+			// https://github.com/google/go-containerregistry/issues/1404
+			logs.Warn.Printf("retrying without mount: %v", err)
+			return w.initiateUpload("", "", "")
+		}
 		return "", false, err
 	}
 


### PR DESCRIPTION
Sometimes we see authentication errors if the from repo doesn't exist,
so fall back to just initiating an upload without a mount attempt.

Fixes https://github.com/google/go-containerregistry/issues/1404