### PR TITLE
Support the platform specific authentication of krane in "auth get" command

### DIFF
--- a/.github/workflows/ecr-auth.yaml
+++ b/.github/workflows/ecr-auth.yaml
@@ -39,6 +39,20 @@ jobs:
           # List the tags
           krane ls ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/go-containerregistry-test
 
+      - name: Test krane auth get + ECR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          CRED1=$(krane auth get ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com)
+          CRED2=$(krane auth get ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com)
+          if [[ "$CRED1" == "" ]] ; then
+            exit 1
+          fi
+          if [[ "$CRED1" == "$CRED2" ]] ; then
+            echo "credentials are cached by infrastructure"
+          fi
+          
   crane-ecr-login:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ecr-auth.yaml
+++ b/.github/workflows/ecr-auth.yaml
@@ -40,8 +40,6 @@ jobs:
           krane ls ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/go-containerregistry-test
 
       - name: Test krane auth get + ECR
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           CRED1=$(krane auth get ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com)
@@ -52,7 +50,7 @@ jobs:
           if [[ "$CRED1" == "$CRED2" ]] ; then
             echo "credentials are cached by infrastructure"
           fi
-          
+
   crane-ecr-login:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ghcr-auth.yaml
+++ b/.github/workflows/ghcr-auth.yaml
@@ -30,3 +30,18 @@ jobs:
         run: |
           # List the tags
           krane ls ghcr.io/${{ github.repository }}/testimage
+
+      - name: Test krane auth get + GHCR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          CRED1=$(krane auth get ghcr.io)
+          CRED2=$(krane auth get ghcr.io)
+          if [[ "$CRED1" == "" ]] ; then
+            exit 1
+          fi
+          if [[ "$CRED1" == "$CRED2" ]] ; then
+            echo "credentials are cached by infrastructure"
+          fi
+          

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -32,7 +32,7 @@ import (
 )
 
 // NewCmdAuth creates a new cobra.Command for the auth subcommand.
-func NewCmdAuth(options *[]crane.Option, argv ...string) *cobra.Command {
+func NewCmdAuth(options []crane.Option, argv ...string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Log in or access credentials",
@@ -63,7 +63,7 @@ func toCreds(config *authn.AuthConfig) credentials {
 }
 
 // NewCmdAuthGet creates a new `crane auth get` command.
-func NewCmdAuthGet(options *[]crane.Option, argv ...string) *cobra.Command {
+func NewCmdAuthGet(options []crane.Option, argv ...string) *cobra.Command {
 	if len(argv) == 0 {
 		argv = []string{os.Args[0]}
 	}
@@ -97,12 +97,7 @@ func NewCmdAuthGet(options *[]crane.Option, argv ...string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			keychain := authn.DefaultKeychain
-			if options != nil {
-				opts := crane.GetOptions(*options...)
-				keychain = opts.Keychain
-			}
-			authorizer, err := keychain.Resolve(reg)
+			authorizer, err := crane.GetOptions(options...).Keychain.Resolve(reg)
 			if err != nil {
 				return err
 			}

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -68,21 +68,32 @@ func NewCmdAuthGet(options *[]crane.Option, argv ...string) *cobra.Command {
 		argv = []string{os.Args[0]}
 	}
 
+	baseCmd := strings.Join(argv, " ")
 	eg := fmt.Sprintf(`  # Read configured credentials for reg.example.com
-  echo "reg.example.com" | %s get
-  {"username":"AzureDiamond","password":"hunter2"}`, strings.Join(argv, " "))
+  $ echo "reg.example.com" | %s get
+  {"username":"AzureDiamond","password":"hunter2"}
+  # or 
+  $ %s get reg.example.com
+  {"username":"AzureDiamond","password":"hunter2"}`, baseCmd, baseCmd)
 
 	return &cobra.Command{
-		Use:     "get",
+		Use:     "get [REGISTRY_ADDR]",
 		Short:   "Implements a credential helper",
 		Example: eg,
-		Args:    cobra.NoArgs,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			b, err := ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				return err
+			registryAddr := ""
+			if len(args) == 1 {
+				registryAddr = args[0]
+			} else {
+				b, err := ioutil.ReadAll(os.Stdin)
+				if err != nil {
+					return err
+				}
+				registryAddr = strings.TrimSpace(string(b))
 			}
-			reg, err := name.NewRegistry(strings.TrimSpace(string(b)))
+
+			reg, err := name.NewRegistry(registryAddr)
 			if err != nil {
 				return err
 			}

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -72,7 +72,7 @@ func NewCmdAuthGet(options []crane.Option, argv ...string) *cobra.Command {
 	eg := fmt.Sprintf(`  # Read configured credentials for reg.example.com
   $ echo "reg.example.com" | %s get
   {"username":"AzureDiamond","password":"hunter2"}
-  # or 
+  # or
   $ %s get reg.example.com
   {"username":"AzureDiamond","password":"hunter2"}`, baseCmd, baseCmd)
 

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -93,7 +93,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 
 	commands := []*cobra.Command{
 		NewCmdAppend(&options),
-		NewCmdAuth(&options, "crane", "auth"),
+		NewCmdAuth(options, "crane", "auth"),
 		NewCmdBlob(&options),
 		NewCmdCatalog(&options),
 		NewCmdConfig(&options),

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -93,7 +93,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 
 	commands := []*cobra.Command{
 		NewCmdAppend(&options),
-		NewCmdAuth("crane", "auth"),
+		NewCmdAuth(&options, "crane", "auth"),
 		NewCmdBlob(&options),
 		NewCmdCatalog(&options),
 		NewCmdConfig(&options),

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -10,10 +10,10 @@ crane auth get [REGISTRY_ADDR] [flags]
 
 ```
   # Read configured credentials for reg.example.com
-  echo "reg.example.com" | crane auth get
+  $ echo "reg.example.com" | crane auth get
   {"username":"AzureDiamond","password":"hunter2"}
   # or
-  crane auth get reg.example.com
+  $ crane auth get reg.example.com
   {"username":"AzureDiamond","password":"hunter2"}
 ```
 

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -3,7 +3,7 @@
 Implements a credential helper
 
 ```
-crane auth get [flags]
+crane auth get [REGISTRY_ADDR] [flags]
 ```
 
 ### Examples
@@ -11,6 +11,9 @@ crane auth get [flags]
 ```
   # Read configured credentials for reg.example.com
   echo "reg.example.com" | crane auth get
+  {"username":"AzureDiamond","password":"hunter2"}
+  # or
+  crane auth get reg.example.com
   {"username":"AzureDiamond","password":"hunter2"}
 ```
 

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -42,7 +42,7 @@ func main() {
 	root := cmd.New(use, short, []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)})
 
 	// Add or override commands.
-	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy(), cmd.NewCmdAuth("gcrane", "auth")}
+	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy(), cmd.NewCmdAuth(nil, "gcrane", "auth")}
 
 	// Maintain a map of google-specific commands that we "override".
 	used := make(map[string]bool)

--- a/cmd/gcrane/main.go
+++ b/cmd/gcrane/main.go
@@ -38,11 +38,12 @@ const (
 )
 
 func main() {
+	options := []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)}
 	// Same as crane, but override usage and keychain.
-	root := cmd.New(use, short, []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)})
+	root := cmd.New(use, short, options)
 
 	// Add or override commands.
-	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy(), cmd.NewCmdAuth(nil, "gcrane", "auth")}
+	gcraneCmds := []*cobra.Command{gcmd.NewCmdList(), gcmd.NewCmdGc(), gcmd.NewCmdCopy(), cmd.NewCmdAuth(options, "gcrane", "auth")}
 
 	// Maintain a map of google-specific commands that we "override".
 	used := make(map[string]bool)

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	Name     []name.Option
 	Remote   []remote.Option
 	Platform *v1.Platform
+	Keychain authn.Keychain
 }
 
 // GetOptions exposes the underlying []remote.Option, []name.Option, and
@@ -44,6 +45,7 @@ func makeOptions(opts ...Option) Options {
 		Remote: []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 		},
+		Keychain: authn.DefaultKeychain,
 	}
 	for _, o := range opts {
 		o(&opt)
@@ -86,6 +88,7 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 	return func(o *Options) {
 		// Replace the default keychain at position 0.
 		o.Remote[0] = remote.WithAuthFromKeychain(keys)
+		o.Keychain = keys
 	}
 }
 


### PR DESCRIPTION
This PR enables to work "auth get" command with the platform specific keychains given in `krane` tool.