### PR TITLE
Retry ECONNRESET errors

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -59,7 +59,7 @@ type Backoff = retry.Backoff
 var defaultRetryPredicate retry.Predicate = func(err error) bool {
 	// Various failure modes here, as we're often reading from and writing to
 	// the network.
-	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || errors.Is(err, syscall.EPIPE) {
+	if retry.IsTemporary(err) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
 		logs.Warn.Printf("retrying %v", err)
 		return true
 	}


### PR DESCRIPTION
We see this often as "connection reset by peer" errors. Not a lot we can
do about this beyond retrying.