### PR TITLE
Correct usage of authn.NewKeychainFromHelper in docs

### DIFF
--- a/pkg/authn/README.md
+++ b/pkg/authn/README.md
@@ -110,8 +110,8 @@ For example:
 kc := authn.NewMultiKeychain(
     authn.DefaultKeychain,
     google.Keychain,
-    authn.NewFromHelper(ecr.ECRHelper{ClientFactory: api.DefaultClientFactory{}}),
-    authn.NewFromHelper(acr.ACRCredHelper{}),
+    authn.NewKeychainFromHelper(ecr.ECRHelper{ClientFactory: api.DefaultClientFactory{}}),
+    authn.NewKeychainFromHelper(acr.ACRCredHelper{}),
 )
 ```
 


### PR DESCRIPTION
`authn.NewFromHelper` is not a function, and should be `authn.NewKeychainFromHelper`.