### PR TITLE
Ignore docker config if it's a directory

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -75,15 +75,11 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	foundDockerConfig := false
 	home, err := homedir.Dir()
 	if err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".docker/config.json")); err == nil {
-			foundDockerConfig = true
-		}
+		foundDockerConfig = fileExists(filepath.Join(home, ".docker/config.json"))
 	}
 	// If $HOME/.docker/config.json isn't found, check $DOCKER_CONFIG (if set)
 	if !foundDockerConfig && os.Getenv("DOCKER_CONFIG") != "" {
-		if _, err := os.Stat(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json")); err == nil {
-			foundDockerConfig = true
-		}
+		foundDockerConfig = fileExists(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json"))
 	}
 	// If either of those locations are found, load it using Docker's
 	// config.Load, which may fail if the config can't be parsed.
@@ -142,6 +138,12 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 		IdentityToken: cfg.IdentityToken,
 		RegistryToken: cfg.RegistryToken,
 	}), nil
+}
+
+// fileExists returns true if the given path exists and is not a directory.
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
 }
 
 // Helper is a subset of the Docker credential helper credentials.Helper


### PR DESCRIPTION
In a kubernetes environment, a volume from a Secret can be optionally
mounted. If the Secret does not exist, the mounted path is always a
directory.

This change modifies auth.DefaultKeychain to ignore the case where the
docker config file is unexpectedly a directory.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>