### PR TITLE
Add fuzzer and run it in CI

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/
+COPY .clusterfuzzlite/build.sh $SRC/
+WORKDIR $SRC/go-containerregistry
+

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,1 @@
+compile_go_fuzzer github.com/google/go-containerregistry/pkg/name FuzzParseReference fuzz_parse_reference

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite.yaml
+++ b/.github/workflows/cflite.yaml
@@ -1,0 +1,26 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: go
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite.yaml
+++ b/.github/workflows/cflite.yaml
@@ -10,16 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sanitizer: [address]
     steps:
-    - name: Build Fuzzers (${{ matrix.sanitizer }})
+    - name: Build Fuzzers
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
-        sanitizer: ${{ matrix.sanitizer }}
+        sanitizer: 'address'
         language: go
-    - name: Run Fuzzers (${{ matrix.sanitizer }})
+    - name: Run Fuzzers
       id: run
       uses: google/clusterfuzzlite/actions/run_fuzzers@v1
       with:

--- a/pkg/name/fuzz.go
+++ b/pkg/name/fuzz.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+func FuzzParseReference(data []byte) int {
+	_, _ = ParseReference(string(data))
+	return 1
+}


### PR DESCRIPTION
This adds a fuzzer and runs it in the CI with [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/).

I contribute fuzzers to several projects on OSS-Fuzz and have seen crashes in GCR by fuzzing projects that use its APIs. It would be great to have a setting where contributors can add fuzzers that will run and the GCR maintainers get notified about found issues. Integrating into OSS-Fuzz may also be an option, but for now ClusterfuzzLite should be enough to get started.

With this PR, ClusterfuzzLite will run fuzzers in the CI when PRs are made, and it can be extended beyond this PR with code coverage and batch fuzzing: https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/