### PR TITLE
WIP: add References() methods to remote.Image and remote.ImageIndex

### DIFF
--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -28,6 +28,11 @@ type Manifest struct {
 	Config        Descriptor        `json:"config"`
 	Layers        []Descriptor      `json:"layers"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
+
+	// This field is *experimental* and surrounding behavior is likely to change.
+	//
+	// See https://github.com/opencontainers/wg-reference-types/blob/main/docs/proposals/PROPOSAL_E.md#image-spec
+	Refers *Descriptor `json:"refers,omitempty"`
 }
 
 // IndexManifest represents an OCI image index in a structured way.

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -131,6 +131,15 @@ func (r *remoteImage) Descriptor() (*v1.Descriptor, error) {
 	return r.descriptor, err
 }
 
+// References returns a list of descriptors for artifacts that refer to this image.
+//
+// This is based on https://github.com/opencontainers/wg-reference-types/blob/main/docs/proposals/PROPOSAL_E.md
+//
+// *NOTE*: This API is experimental, and is likely to change in the future.
+func (r *remoteImage) References() ([]v1.Descriptor, error) {
+	return r.fetcher.fetchReferences(r.descriptor.Digest)
+}
+
 // remoteImageLayer implements partial.CompressedLayer
 type remoteImageLayer struct {
 	ri     *remoteImage

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -181,6 +181,15 @@ func (r *remoteIndex) Manifests() ([]partial.Describable, error) {
 	return manifests, nil
 }
 
+// References returns a list of descriptors for artifacts that refer to this index.
+//
+// This is based on https://github.com/opencontainers/wg-reference-types/blob/main/docs/proposals/PROPOSAL_E.md
+//
+// *NOTE*: This API is experimental, and is likely to change in the future.
+func (r *remoteIndex) References() ([]v1.Descriptor, error) {
+	return r.fetcher.fetchReferences(r.descriptor.Digest)
+}
+
 func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
 	desc, err := r.childByPlatform(platform)
 	if err != nil {


### PR DESCRIPTION
This starts to sketch out support for the OCI ref types proposal in https://github.com/opencontainers/wg-reference-types/blob/main/docs/proposals/PROPOSAL_E.md, soon to be proposed for discussion and 🤞acceptance🤞 by OCI spec maintainers.

This adds a `References()` method to `pkg/v1/remote.Image` and `pkg/v1/remote.ImageIndex` to query for descriptors that refer to this image or index.

From here we can build a `Walk` method that recursively walks while it can find a `References()` method, e.g., to copy trees of things between registries, maintaining their structure.

The next step here would probably be to add optional support in `pkg/registry` for tests, so we can test upgrade/downgrade scenarios and general (Go) API functionality.

Future changes can also add support for the [artifact manifest type](https://github.com/opencontainers/wg-reference-types/blob/main/docs/proposals/PROPOSAL_E.md#artifact-spec), but that's a bit more involved and not yet supported by any registry, so I think we should wait to add that, and/or play with it in `internal` before committing to anything.

This is a draft to get feedback.

cc @jdolitsky