### PR TITLE
tarball: Streaming image parser PoC

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,4 +90,5 @@ jobs:
         
         ./app/crane pull ubuntu ubuntu.tar
         ./app/crane export - - < ubuntu.tar > filesystem.tar
+        ls -la *.tar
         

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -82,3 +82,12 @@ jobs:
         ./app/crane pull --platform=linux/arm64 --format=oci $remote $distroless
         ./app/crane push $distroless $local
         diff <(./app/crane manifest --platform linux/arm64 $remote) <(./app/crane manifest $local)
+                
+    - name: crane pull image, and export it from stdin to filesystem tar to stdout
+      shell: bash
+      run: |
+        set -euxo pipefail
+        
+        ./app/crane pull ubuntu ubuntu.tar
+        ./app/crane export - - < ubuntu.tar > filesystem.tar
+        

--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -17,8 +17,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -55,18 +53,10 @@ func NewCmdExport(options *[]crane.Option) *cobra.Command {
 
 			var img v1.Image
 			if src == "-" {
-				tmpfile, err := ioutil.TempFile("", "crane")
-				if err != nil {
-					log.Fatal(err)
+				stdoutreader := func() (io.ReadCloser, error) {
+					return io.ReadCloser(os.Stdin), nil
 				}
-				defer os.Remove(tmpfile.Name())
-
-				if _, err := io.Copy(tmpfile, os.Stdin); err != nil {
-					log.Fatal(err)
-				}
-				tmpfile.Close()
-
-				img, err = tarball.ImageFromPath(tmpfile.Name(), nil)
+				img, err = tarball.Image(stdoutreader, nil)
 				if err != nil {
 					return fmt.Errorf("reading tarball from stdin: %w", err)
 				}

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/internal/gzip"
+	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/match"
@@ -220,6 +221,7 @@ func CreatedAt(base v1.Image, created v1.Time) (v1.Image, error) {
 // If a caller doesn't read the full contents, they should Close it to free up
 // resources used during extraction.
 func Extract(img v1.Image) io.ReadCloser {
+	logs.Debug.Printf("mutate: extract %T", img)
 	pr, pw := io.Pipe()
 
 	go func() {

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -177,11 +177,10 @@ func (i *image) areLayersCompressed() (bool, error) {
 		return false, errors.New("0 layers found in image")
 	}
 	layer := i.imgDescriptor.Layers[0]
-	blob, err := extractFileFromTar(i.opener, layer)
+	blob, err := i.tarbuf.scanFile(layer)
 	if err != nil {
 		return false, err
 	}
-	defer blob.Close()
 	return gzip.Is(blob)
 }
 

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -250,7 +250,7 @@ func (tb *TarBuffered) scanFile(filePath string) (io.Reader, error) {
 		}
 	}
 	// if file is not found, continue parsing
-	for tb.EOF != true {
+	for !tb.EOF {
 		hdr, err := tb.tf.Next()
 		if errors.Is(err, io.EOF) {
 			tb.EOF = true

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -230,6 +230,7 @@ type TarBuffered struct {
 	EOF     bool
 }
 
+// NewTarBuffered prepares and returns struct for parsing tar stream
 func NewTarBuffered(f io.Reader) *TarBuffered {
 	// [ ] what happens if we don't return a pointer here?
 	//     will reference to tf be duplicated in gc?


### PR DESCRIPTION
TarBuffered scans stream (`io.Reader`) once for filename and saves
unused sections in memory for later access. This should speedup
parsing a bit, because right now tarball is scanned several times,
and should save resources and speed for parsing well-formed images
from network.

Solves #1339.