### PR TITLE
ci: Generate SLSA signatures for GitHub released tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - uses: actions/checkout@v3
       - name: Unshallow
@@ -16,8 +18,29 @@ jobs:
           go-version: 1.17
           check-latest: true
       - uses: goreleaser/goreleaser-action@v3
+        id: run-goreleaser
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate subject
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+
+  provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true # upload to a new release


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Hi,

I'm reaching out on behalf of the [Open Source Security Foundation (openssf.org)](https://openssf.org/). We work on improving the security of critical open source projects like yours. 

Together with [GitHub](https://github.blog/2022-04-07-slsa-3-compliance-with-github-actions/), we designed a free, easy-to-use method of code signing. It will help your users verify that your release tarballs were built from your repository’s [workflow](https://github.com/google/go-containerregistry/blob/main/.github/workflows/release.yml) and not altered by anyone. It’s just a few lines of code, but it will make your project more secure against third-party tampering and attacks like attacks like [Codecov](https://about.codecov.io/apr-2021-post-mortem) and [CTX](https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e).

I’ve created this PR to shows how to add this seamless code signing to your workflow. You don’t have to be a cryptography expert or learn complicated tools and [verification](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-of-provenance) is simple for your users.  

Furthermore, I have tested the workflow on my own fork. You can see the release with the attached provenance [here](https://github.com/asraa/go-containerregistry/releases/tag/v0.1). I would love to add verification instructions as well, but don't see a place where this is mentioned yet. Verification looks like
```
$ go run ./cli/slsa-verifier -provenance ~/Downloads/attestation.intoto.jsonl -artifact-path ~/Downloads/go-containerregistry_Linux_arm64.tar.gz -source github.com/asraa/go-containerregistry
Verified signature against tlog entry index 3209559 at URL: https://rekor.sigstore.dev/api/v1/log/entries/40191448c1cf944ad66fe37e196e351775fc21b77215f30049ecf9101d05e97b
Verified build using builder https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.2.0 at commit 58229d2a58b3f3a118d2e48dc44662c02fe77959
PASSED: Verified SLSA provenance
```

You can read more on the [SLSA blog](https://slsa.dev/blog/2022/06/slsa-github-workflows). Please reach out if you have any questions!