### PR TITLE
WIP: support multiple credentials

### DIFF
--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -27,6 +27,10 @@ type Authenticator interface {
 	Authorization() (*AuthConfig, error)
 }
 
+type MultiAuthenticator interface {
+	Authorizations() ([]AuthConfig, error)
+}
+
 // AuthConfig contains authorization information for connecting to a Registry
 // Inlined what we use from github.com/docker/cli/cli/config/types
 type AuthConfig struct {

--- a/pkg/authn/multikeychain.go
+++ b/pkg/authn/multikeychain.go
@@ -28,14 +28,50 @@ func NewMultiKeychain(kcs ...Keychain) Keychain {
 
 // Resolve implements Keychain.
 func (mk *multiKeychain) Resolve(target Resource) (Authenticator, error) {
+	var auths []Authenticator
 	for _, kc := range mk.keychains {
 		auth, err := kc.Resolve(target)
 		if err != nil {
 			return nil, err
 		}
 		if auth != Anonymous {
-			return auth, nil
+			auths = append(auths, auth)
 		}
 	}
-	return Anonymous, nil
+	if len(auths) == 0 {
+		return Anonymous, nil
+	}
+	return multiAuthenticator{auths: auths}, nil
+}
+
+type multiAuthenticator struct {
+	auths []Authenticator
+}
+
+func (ma multiAuthenticator) Authorization() (*AuthConfig, error) {
+	auths, err := ma.Authorizations()
+	if err != nil {
+		return nil, err
+	}
+	return &auths[0], nil
+}
+
+func (ma *multiAuthenticator) Authorizations() ([]AuthConfig, error) {
+	var auths []AuthConfig
+	for _, a := range ma.auths {
+		if ma, ok := a.(MultiAuthenticator); ok {
+			as, err := ma.Authorizations()
+			if err != nil {
+				return nil, err
+			}
+			auths = append(auths, as...)
+		} else {
+			a, err := a.Authorization()
+			if err != nil {
+				return nil, err
+			}
+			auths = append(auths, *a)
+		}
+	}
+	return auths, nil
 }

--- a/pkg/authn/multikeychain_test.go
+++ b/pkg/authn/multikeychain_test.go
@@ -70,16 +70,33 @@ func TestMultiKeychain(t *testing.T) {
 			fixedKeychain{regOne: three, regTwo: two},
 		),
 		want: Anonymous,
+	}, {
+		name: "match multiple keychains, take the first",
+		reg:  regOne,
+		kc: NewMultiKeychain(
+			fixedKeychain{regOne: one},
+			fixedKeychain{regOne: three, regTwo: two},
+			fixedKeychain{regOne: two},
+		),
+		want: one, // TODO: test that this actually has one,three,two internall and can return them all if asked.
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.kc.Resolve(test.reg)
+			auth, err := test.kc.Resolve(test.reg)
 			if err != nil {
 				t.Errorf("Resolve() = %v", err)
 			}
-			if got != test.want {
-				t.Errorf("Resolve() = %v, wanted %v", got, test.want)
+			got, err := auth.Authorization()
+			if err != nil {
+				t.Errorf("Authorization() = %v", err)
+			}
+			want, err := test.want.Authorization()
+			if err != nil {
+				t.Errorf("want.Authorization() = %v", err)
+			}
+			if got.Username != want.Username || got.Password != want.Password {
+				t.Errorf("Resolve() = %+v, wanted %+v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
This is an attempt to allow our authn and transport packages to cooperate and allow for keychains (incl `DefaultKeychain`) to provide multiple creds, which will be tried in turn by the transport, until one succeeds.

This is not optimal so far, since each time through `RoundTrip` will try all the provided credentials from the start until one works, when it should "remember" which one worked for this registry+repo and reuse that if possible next time against that registry+repo.

This also doesn't support bearer auth yet, only basic auth, since bearer auth requires refreshing tokens before checking if they can be used. That should be doable though, it's just work.

This changes `DefaultKeychain` to provide creds for both `"registry.com"` and `"registry.com/repo"`, and for backward compatibility adds an extension interface `MultiAuthenticator` which is an `Authenticator` capable of returning multiple auths.

We may also want to extend this to `MultiKeychain` so we can allow a multikeychain to try creds from the Docker config and then fallback to a cred helper if that first request fails -- today, we'll just fail if that first matching cred is invalid.

cc @jonjohnsonjr for 👀 

https://github.com/google/go-containerregistry/issues/1329
https://github.com/google/go-containerregistry/issues/1431

@jwcesign