### PR TITLE
docs/ci: update crane installation instructions and release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,47 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
+
+  verification:
+    needs: [goreleaser, provenance]
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      # Note: this will be replaced with the GHA in the future.
+      # See https://github.com/slsa-framework/slsa-verifier/issues/95
+      - name: Install the verifier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh -R slsa-framework/slsa-verifier release download v1.2.0 -p "slsa-verifier-linux-amd64"
+          chmod ug+x slsa-verifier-linux-amd64
+          # Note: see https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md
+          COMPUTED_HASH=$(sha256sum slsa-verifier-linux-amd64 | cut -d ' ' -f1)
+          EXPECTED_HASH="37db23392c7918bb4e243cdb097ed5f9d14b9b965dc1905b25bc2d1c0c91bf3d"
+          if [[ "$EXPECTED_HASH" != "$COMPUTED_HASH" ]];then
+              echo "error: expected $EXPECTED_HASH, computed $COMPUTED_HASH"
+              exit 1
+          fi
+      - name: Download assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "attestation.intoto.jsonl"
+      - name: Verify assets
+        env:
+          CHECKSUMS: ${{ needs.goreleaser.outputs.hashes }}
+          PROVENANCE: "${{ needs.provenance.outputs.attestation-name }}"
+        run: |
+          set -euo pipefail
+          checksums=$(echo "$CHECKSUMS" | base64 -d)
+          while read -r line; do
+              fn=$(echo $line | cut -d ' ' -f2)
+              echo "Verifying $fn"
+              ./slsa-verifier-linux-amd64 -artifact-path "$fn" \
+                                      -provenance "$PROVENANCE" \
+                                      -source "github.com/$GITHUB_REPOSITORY" \
+                                      -tag "$GITHUB_REF_NAME"
+          done <<<"$checksums"

--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -9,8 +9,25 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 
 ## Installation
 
-Download [latest release](https://github.com/google/go-containerregistry/releases/latest).
+### Install from Releases
+Download [latest release](https://github.com/google/go-containerregistry/releases/latest):
 
+```
+$ VERSION=TODO   # Latest, or other
+$ OS=Linux       # or Darwin, Windows
+$ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
+$ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${VERSION}_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+```
+
+We generate [SLSA 3 provenance](https://slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator). To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation) and verify as follows:
+
+```
+$ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/attestation.intoto.jsonl > provenance.intoto.jsonl
+$ slsa-verifier -artifact-path go-containerregistry.tar.gz -provenance provenance.intoto.jsonl -source github.com/google/go-containerregistry -tag "v${VERSION}"
+  PASSED: Verified SLSA provenance
+```
+
+### Install manually
 Install manually:
 
 ```


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Follow-up to https://github.com/google/go-containerregistry/pull/1438

* Adds verification instructions to crane's README.md
* Adds a post-release verification job to verify the generated provenance. Installation of the verifier binary will be replaced with an installer GitHub Action
