### PR TITLE
feat: Add krane to release archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,10 @@ builds:
   flags:
   - -trimpath
   ldflags:
-  - "-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}"
-  - "-s -w -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}"
+    - -s
+    - -w
+    - -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}
+    - -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}
   goarch:
     - amd64
     - arm
@@ -39,8 +41,37 @@ builds:
   flags:
   - -trimpath
   ldflags:
-  - "-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}"
-  - "-s -w -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}"
+    - -s
+    - -w
+    - -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}
+    - -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}
+  goarch:
+    - amd64
+    - arm
+    - arm64
+    - 386
+    - s390x
+  goos:
+    - linux
+    - darwin
+    - windows
+  ignore:
+    - goos: windows
+      goarch: 386
+
+- id: krane
+  env:
+  - CGO_ENABLED=0
+  main: ./main.go
+  dir: ./cmd/krane
+  binary: krane
+  flags:
+  - -trimpath
+  ldflags:
+    - -s
+    - -w
+    - -X github.com/google/go-containerregistry/cmd/crane/cmd.Version={{.Version}}
+    - -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version={{.Version}}
   goarch:
     - amd64
     - arm


### PR DESCRIPTION
This adds krane to the release artifacts of this repo so it is not necessary to run `go install` to use it.