### PR TITLE
deps: update goreleaser-action for bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: 1.17
           check-latest: true
-      - uses: goreleaser/goreleaser-action@v3
+      - uses: goreleaser/goreleaser-action@v3.1.0
         id: run-goreleaser
         with:
           version: latest


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This updates goreleaser-action to fix this bug, ensures that v3.1.0 is chosen: https://github.com/goreleaser/goreleaser-action/issues/368

Otherwise, the action does not populate the artifacts output, which would lead to provenance generation failure.

@laurentsimon