### PR TITLE
Support multiple auth for same registry/repo

### DIFF
--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -27,6 +27,10 @@ type Authenticator interface {
 	Authorization() (*AuthConfig, error)
 }
 
+type MultiAuthenticator interface {
+	Authorizations() ([]AuthConfig, error)
+}
+
 // AuthConfig contains authorization information for connecting to a Registry
 // Inlined what we use from github.com/docker/cli/cli/config/types
 type AuthConfig struct {

--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -27,6 +27,7 @@ type Authenticator interface {
 	Authorization() (*AuthConfig, error)
 }
 
+// MultiAuthenticator is used to authenticate Docker transports with multiple configs.
 type MultiAuthenticator interface {
 	Authorizations() ([]AuthConfig, error)
 }

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -45,6 +45,8 @@ type Keychain interface {
 }
 
 // KeychainMany is an interface for resolving an image reference to multiple credentials.
+// NOTE: This name might change before (or even after) we cut a release. Will be removed as soon
+// as we find a better name for it.
 type KeychainMany interface {
 	ResolveMany(Resource) ([]Authenticator, error)
 }
@@ -66,6 +68,7 @@ const (
 	DefaultAuthKey = "https://" + name.DefaultRegistry + "/v1/"
 )
 
+// Resolve implements Keychain.
 func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	auths, err := dk.ResolveMany(target)
 	if err != nil {
@@ -75,7 +78,7 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	return auths[0], nil
 }
 
-// ResolveMany implements MultiKeychain.
+// ResolveMany implements KeychainMany.
 func (dk *defaultKeychain) ResolveMany(target Resource) ([]Authenticator, error) {
 	dk.mu.Lock()
 	defer dk.mu.Unlock()

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -44,6 +44,7 @@ type Keychain interface {
 	Resolve(Resource) (Authenticator, error)
 }
 
+// KeychainMany is an interface for resolving an image reference to multiple credentials.
 type KeychainMany interface {
 	ResolveMany(Resource) ([]Authenticator, error)
 }

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -44,6 +44,10 @@ type Keychain interface {
 	Resolve(Resource) (Authenticator, error)
 }
 
+type KeychainMany interface {
+	ResolveMany(Resource) ([]Authenticator, error)
+}
+
 // defaultKeychain implements Keychain with the semantics of the standard Docker
 // credential keychain.
 type defaultKeychain struct {
@@ -61,8 +65,17 @@ const (
 	DefaultAuthKey = "https://" + name.DefaultRegistry + "/v1/"
 )
 
-// Resolve implements Keychain.
 func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
+	auths, err := dk.ResolveMany(target)
+	if err != nil {
+		return nil, err
+	}
+
+	return auths[0], nil
+}
+
+// ResolveMany implements MultiKeychain.
+func (dk *defaultKeychain) ResolveMany(target Resource) ([]Authenticator, error) {
 	dk.mu.Lock()
 	defer dk.mu.Unlock()
 
@@ -98,7 +111,7 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	} else {
 		f, err := os.Open(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json"))
 		if err != nil {
-			return Anonymous, nil
+			return []Authenticator{Anonymous}, nil
 		}
 		defer f.Close()
 		cf, err = config.LoadFromReader(f)
@@ -110,7 +123,9 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 	// See:
 	// https://github.com/google/ko/issues/90
 	// https://github.com/moby/moby/blob/fc01c2b481097a6057bec3cd1ab2d7b4488c50c4/registry/config.go#L397-L404
-	var cfg, empty types.AuthConfig
+	var empty types.AuthConfig
+
+	var cfgs []types.AuthConfig
 	for _, key := range []string{
 		target.String(),
 		target.RegistryStr(),
@@ -119,25 +134,30 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 			key = DefaultAuthKey
 		}
 
-		cfg, err = cf.GetAuthConfig(key)
+		cfg, err := cf.GetAuthConfig(key)
 		if err != nil {
 			return nil, err
 		}
 		if cfg != empty {
-			break
+			cfgs = append(cfgs, cfg)
 		}
 	}
-	if cfg == empty {
-		return Anonymous, nil
+
+	if len(cfgs) == 0 {
+		return []Authenticator{Anonymous}, nil
 	}
 
-	return FromConfig(AuthConfig{
-		Username:      cfg.Username,
-		Password:      cfg.Password,
-		Auth:          cfg.Auth,
-		IdentityToken: cfg.IdentityToken,
-		RegistryToken: cfg.RegistryToken,
-	}), nil
+	auths := make([]Authenticator, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		auths = append(auths, FromConfig(AuthConfig{
+			Username:      cfg.Username,
+			Password:      cfg.Password,
+			Auth:          cfg.Auth,
+			IdentityToken: cfg.IdentityToken,
+			RegistryToken: cfg.RegistryToken,
+		}))
+	}
+	return auths, nil
 }
 
 // fileExists returns true if the given path exists and is not a directory.

--- a/pkg/authn/kubernetes/keychain.go
+++ b/pkg/authn/kubernetes/keychain.go
@@ -177,6 +177,7 @@ type keyring struct {
 	creds map[string][]authn.AuthConfig
 }
 
+// Resolve implements Keychain.
 func (keyring *keyring) Resolve(target authn.Resource) (authn.Authenticator, error) {
 	auths, err := keyring.ResolveMany(target)
 	if err != nil {
@@ -186,6 +187,7 @@ func (keyring *keyring) Resolve(target authn.Resource) (authn.Authenticator, err
 	return auths[0], nil
 }
 
+// ResolveMany implements KeychainMany.
 func (keyring *keyring) ResolveMany(target authn.Resource) ([]authn.Authenticator, error) {
 	image := target.String()
 	auths := []authn.AuthConfig{}
@@ -279,6 +281,7 @@ func urlsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
 	return true, nil
 }
 
+// toAuthenticators transform AuthConfig to Authenticator interface
 func toAuthenticators(configs []authn.AuthConfig) []authn.Authenticator {
 	auths := make([]authn.Authenticator, 0, len(configs))
 	for _, cfg := range configs {

--- a/pkg/authn/multikeychain.go
+++ b/pkg/authn/multikeychain.go
@@ -77,7 +77,7 @@ func (ma *multiAuthenticator) Authorization() (*AuthConfig, error) {
 }
 
 func (ma *multiAuthenticator) Authorizations() ([]AuthConfig, error) {
-	var auths []AuthConfig
+	auths := []AuthConfig{}
 	for _, a := range ma.auths {
 		a, err := a.Authorization()
 		if err != nil {

--- a/pkg/authn/multikeychain.go
+++ b/pkg/authn/multikeychain.go
@@ -68,6 +68,17 @@ type multiAuthenticator struct {
 	auths []Authenticator
 }
 
+// FromConfigs returns an Authenticator that returns the given multiple AuthConfig.
+func FromConfigs(cfgs []AuthConfig) Authenticator {
+	multiAuth := multiAuthenticator{auths: []Authenticator{}}
+	for _, cfg := range cfgs {
+		auth := FromConfig(cfg)
+		multiAuth.auths = append(multiAuth.auths, auth)
+	}
+	return &multiAuth
+}
+
+// Authorization implements Authenticator.
 func (ma *multiAuthenticator) Authorization() (*AuthConfig, error) {
 	auths, err := ma.Authorizations()
 	if err != nil {
@@ -76,6 +87,7 @@ func (ma *multiAuthenticator) Authorization() (*AuthConfig, error) {
 	return &auths[0], nil
 }
 
+// Authorizations implements get multiple Authenticator.
 func (ma *multiAuthenticator) Authorizations() ([]AuthConfig, error) {
 	auths := []AuthConfig{}
 	for _, a := range ma.auths {

--- a/pkg/authn/multikeychain_test.go
+++ b/pkg/authn/multikeychain_test.go
@@ -78,7 +78,7 @@ func TestMultiKeychain(t *testing.T) {
 			fixedKeychain{regOne: three, regTwo: two},
 			fixedKeychain{regOne: two},
 		),
-		want: one, // TODO: test that this actually has one,three,two internall and can return them all if asked.
+		want: one,
 	}}
 
 	for _, test := range tests {

--- a/pkg/authn/multikeychain_test.go
+++ b/pkg/authn/multikeychain_test.go
@@ -70,16 +70,33 @@ func TestMultiKeychain(t *testing.T) {
 			fixedKeychain{regOne: three, regTwo: two},
 		),
 		want: Anonymous,
+	}, {
+		name: "match multiple keychains, take the first",
+		reg:  regOne,
+		kc: NewMultiKeychain(
+			fixedKeychain{regOne: one},
+			fixedKeychain{regOne: three, regTwo: two},
+			fixedKeychain{regOne: two},
+		),
+		want: one, // TODO: test that this actually has one,three,two internall and can return them all if asked.
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.kc.Resolve(test.reg)
+			auth, err := test.kc.Resolve(test.reg)
 			if err != nil {
 				t.Errorf("Resolve() = %v", err)
 			}
-			if got != test.want {
-				t.Errorf("Resolve() = %v, wanted %v", got, test.want)
+			got, err := auth.Authorization()
+			if err != nil {
+				t.Errorf("Authorization() = %v", err)
+			}
+			want, err := test.want.Authorization()
+			if err != nil {
+				t.Errorf("want.Authorization() = %v", err)
+			}
+			if got.Username != want.Username || got.Password != want.Password {
+				t.Errorf("Resolve() = %+v, wanted %+v", got, test.want)
 			}
 		})
 	}

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -83,9 +83,15 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	}
 
 	var res *http.Response
-	var err error
 	var refreshed bool
-	for index, _ := range bt.bearer {
+	var err error
+	if len(bt.bearer) != len(bt.bearerTokenList) {
+		err = bt.refresh(in.Context())
+		if err != nil {
+			return nil, err
+		}
+	}
+	for index := range bt.bearer {
 		res, err = sendRequest(bt.bearerTokenList[index])
 		if err != nil {
 			return nil, err
@@ -106,7 +112,7 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		}
 	}
 
-	return res, err
+	return res, nil
 }
 
 // refreshWithChallenges implements token refresh if there are Challenges


### PR DESCRIPTION
Signed-off-by: jiang wei <jwcesign@gmail.com>

This is an attempt to allow our authn and transport packages to cooperate and allow for keychains (incl DefaultKeychain) to provide multiple creds, which will be tried in turn by the transport, until one succeeds.

This is not optimal so far, since each time through RoundTrip will try all the provided credentials from the start until one works, when it should "remember" which one worked for this registry+repo and reuse that if possible next time against that registry+repo.

This also doesn't support bearer auth yet, only basic auth, since bearer auth requires refreshing tokens before checking if they can be used. That should be doable though, it's just work.

This changes DefaultKeychain to provide creds for both "registry.com" and "registry.com/repo", and for backward compatibility adds an extension interface MultiAuthenticator which is an Authenticator capable of returning multiple auths.

We may also want to extend this to MultiKeychain so we can allow a multikeychain to try creds from the Docker config and then fallback to a cred helper if that first request fails -- today, we'll just fail if that first matching cred is invalid.

cc @jonjohnsonjr, @imjasonh, @dprotaso  for 👀

https://github.com/google/go-containerregistry/issues/1329
https://github.com/google/go-containerregistry/issues/1431
https://github.com/knative/serving/issues/13126


This PR is based on the ideas of https://github.com/google/go-containerregistry/pull/1439


