### PR TITLE
allow remote.DefaultTransport to be overridden by an http.RoundTripper

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -70,12 +70,16 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 
 			options = append(options, crane.WithPlatform(platform.platform))
 
-			transport := remote.DefaultTransport.Clone()
-			transport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: insecure, //nolint: gosec
+			var rt http.RoundTripper = remote.DefaultTransport
+			if t, ok := remote.DefaultTransport.(interface {
+				Clone() *http.Transport
+			}); ok {
+				t := t.Clone()
+				t.TLSClientConfig = &tls.Config{
+					InsecureSkipVerify: insecure, //nolint: gosec
+				}
 			}
 
-			var rt http.RoundTripper = transport
 			// Add any http headers if they are set in the config file.
 			cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))
 			if err != nil {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -84,7 +84,7 @@ const (
 
 // DefaultTransport is based on http.DefaultTransport with modifications
 // documented inline below.
-var DefaultTransport = &http.Transport{
+var DefaultTransport http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	DialContext: (&net.Dialer{
 		// By default we wrap the transport in retries, so reduce the


### PR DESCRIPTION
This mirrors the behavior of `http.DefaultTransport`, which is declared as an `http.RoundTripper` even though everyone basically assumes it's a `*http.Transport`.