### PR TITLE
fix crane's root.go after DefaultTransport change

### DIFF
--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -70,15 +70,12 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 
 			options = append(options, crane.WithPlatform(platform.platform))
 
-			rt := remote.DefaultTransport
-			if t, ok := remote.DefaultTransport.(interface {
-				Clone() *http.Transport
-			}); ok {
-				t := t.Clone()
-				t.TLSClientConfig = &tls.Config{
-					InsecureSkipVerify: insecure, //nolint: gosec
-				}
+			transport := remote.DefaultTransport.(*http.Transport).Clone()
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: insecure, //nolint: gosec
 			}
+
+			var rt http.RoundTripper = transport
 
 			// Add any http headers if they are set in the config file.
 			cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))


### PR DESCRIPTION
https://github.com/google/go-containerregistry/pull/1449 changed `remote.DefaultTransport` to be a `http.RoundTripper` instead of a `*http.Transport`, and made a corresponding change in `crane` to call `Clone` only if the provided `RoundTripper` was also cloneable. It was overly clever, and unnecessary, and seems to have broken `crane`'s insecure repo support.