### PR TITLE
check if tar is compressed on push

### DIFF
--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -223,7 +223,16 @@ func extractFileFromTar(opener Opener, filePath string) (io.ReadCloser, error) {
 			f.Close()
 		}
 	}()
-
+	iscompressed, err := gzip.Is(f)
+	if err != nil {
+		return nil, err
+	}
+	if iscompressed {
+		f, err = gzip.UnzipReadCloser(f)
+		if err != nil {
+			return nil, err
+		}
+	}
 	tf := tar.NewReader(f)
 	for {
 		hdr, err := tf.Next()

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -227,6 +227,10 @@ func extractFileFromTar(opener Opener, filePath string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	f, err = opener()
+	if err != nil {
+		return nil, err
+	}
 	if iscompressed {
 		f, err = gzip.UnzipReadCloser(f)
 		if err != nil {


### PR DESCRIPTION
Fix: Push compressed (tar.gz) image to docker registry using crane
