### PR TITLE
Make ErrBadName checkable via errors.Is()

### DIFF
--- a/pkg/name/errors.go
+++ b/pkg/name/errors.go
@@ -28,6 +28,12 @@ func (e *ErrBadName) Error() string {
 	return e.info
 }
 
+// Is reports whether target is an error of type ErrBadName
+func (e *ErrBadName) Is(target error) bool {
+	var berr *ErrBadName
+	return errors.As(target, &berr)
+}
+
 // newErrBadName returns a ErrBadName which returns the given formatted string from Error().
 func newErrBadName(fmtStr string, args ...interface{}) *ErrBadName {
 	return &ErrBadName{fmt.Sprintf(fmtStr, args...)}

--- a/pkg/name/errors_test.go
+++ b/pkg/name/errors_test.go
@@ -31,4 +31,8 @@ func TestBadName(t *testing.T) {
 	if err.Error() != "could not parse reference: @@" {
 		t.Errorf("Unexpected string: %v", err)
 	}
+	//var cerr *ErrBadName
+	if !errors.Is(err, &ErrBadName{}) {
+		t.Errorf("Not an ErrBadName using errors.Is: %v", err)
+	}
 }

--- a/pkg/name/errors_test.go
+++ b/pkg/name/errors_test.go
@@ -31,7 +31,6 @@ func TestBadName(t *testing.T) {
 	if err.Error() != "could not parse reference: @@" {
 		t.Errorf("Unexpected string: %v", err)
 	}
-	//var cerr *ErrBadName
 	if !errors.Is(err, &ErrBadName{}) {
 		t.Errorf("Not an ErrBadName using errors.Is: %v", err)
 	}


### PR DESCRIPTION
The function IsErrBadName says it is deprecated and directs the user to
use errors.Is(), but that will never return true because this error is
custom based on the tag value.

This fixes that problem by implementing an Is() function on ErrBadName
so that errors.Is() can properly identify the error as an ErrBadName.
Usage can now be: errors.Is(err, &ErrBadName{})

This exact problem was actually discussed when the deprecated warning was introduced: https://github.com/google/go-containerregistry/pull/1164/files#r742970357