### PR TITLE
Allow paths in registries

### DIFF
--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -24,6 +24,7 @@ var goodStrictValidationRegistryNames = []string{
 	"index.docker.io",
 	"us.gcr.io",
 	"example.text",
+	"example.com/path/to/registry",
 	"localhost",
 	"localhost:9090",
 }
@@ -35,6 +36,8 @@ var goodWeakValidationRegistryNames = []string{
 var badRegistryNames = []string{
 	"white space",
 	"gcr?com",
+	"example.com/path/to/registry#fragment",
+	"example.com/path/to/registry?value=something",
 }
 
 func TestNewRegistryStrictValidation(t *testing.T) {

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -231,10 +231,12 @@ func makeFetcher(ref name.Reference, o *options) (*fetcher, error) {
 
 // url returns a url.Url for the specified path in the context of this remote image reference.
 func (f *fetcher) url(resource, identifier string) url.URL {
+	domain, pathPrefix := f.Ref.Context().SplitURL()
+	pathPrefix = pathPrefix + "/v2"
 	return url.URL{
 		Scheme: f.Ref.Context().Registry.Scheme(),
-		Host:   f.Ref.Context().RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
+		Host:   domain,
+		Path:   fmt.Sprintf("%s/%s/%s/%s", pathPrefix, f.Ref.Context().RepositoryStr(), resource, identifier),
 	}
 }
 

--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -70,7 +71,7 @@ func TestGetSchema1(t *testing.T) {
 
 	want := `unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377`
 	// Should fail based on media type.
-	if _, err := desc.Image(); err != nil {
+	if _, err = desc.Image(); err != nil {
 		if errors.Is(err, &ErrSchema1{}) {
 			t.Errorf("Image() = %v, expected remote.ErrSchema1", err)
 		}
@@ -82,7 +83,7 @@ func TestGetSchema1(t *testing.T) {
 	}
 
 	// Should fail based on media type.
-	if _, err := desc.ImageIndex(); err != nil {
+	if _, err = desc.ImageIndex(); err != nil {
 		var s1err ErrSchema1
 		if errors.Is(err, &s1err) {
 			t.Errorf("ImageImage() = %v, expected remote.ErrSchema1", err)
@@ -125,7 +126,7 @@ func TestGetImageAsIndex(t *testing.T) {
 	}
 
 	// Should fail based on media type.
-	if _, err := desc.ImageIndex(); err == nil {
+	if _, err = desc.ImageIndex(); err == nil {
 		t.Errorf("ImageIndex() = %v, expected err", err)
 	}
 }
@@ -213,7 +214,7 @@ func TestHead_MissingHeaders(t *testing.T) {
 
 	for _, repo := range []string{missingType, missingLength, missingDigest} {
 		tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, repo))
-		if _, err := Head(tag); err == nil {
+		if _, err = Head(tag); err == nil {
 			t.Errorf("Head(%q): expected error, got nil", tag)
 		}
 	}
@@ -256,4 +257,66 @@ func (errTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}, nil
 	}
 	return nil, fmt.Errorf("error reaching %s", req.URL.String())
+}
+
+func TestGetRegistryWithPath(t *testing.T) {
+	registryPath := "/path/to/registry"
+	expectedRepo := "foo/bar"
+	fakeDigest := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case registryPath + "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case registryPath + manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema1Signed))
+			w.Header().Set("Docker-Content-Digest", fakeDigest)
+			w.Write([]byte("doesn't matter"))
+		case "/v2/":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	repository := mustNewRegistry(t, u.Host+registryPath).
+		Repository(expectedRepo)
+
+	t.Run("Build", func(tt *testing.T) {
+		tag := repository.Tag("latest")
+
+		// Get should succeed even for invalid json. We don't parse the response.
+		_, err = Get(tag)
+		if err != nil {
+			tt.Fatalf("Get(%s) = %v", tag, err)
+		}
+	})
+
+	t.Run("Replace", func(tt *testing.T) {
+		tag := mustNewTag(t, fmt.Sprintf("%s/%s/%s:latest", u.Host, registryPath, expectedRepo))
+		tag.Repository = repository
+
+		_, err = Get(tag)
+		if err != nil {
+			tt.Fatalf("Get(%s) = %v", tag, err)
+		}
+	})
+
+	t.Run("Default", func(tt *testing.T) {
+		// The "naive" construction of a tag assumes the registry is just the host.
+		tag := mustNewTag(t, fmt.Sprintf("%s%s/%s:latest", u.Host, registryPath, expectedRepo))
+		_, err = Get(tag)
+		if err == nil {
+			tt.Fatalf("Get(%s) should've failed", tag)
+		}
+	})
 }

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	authchallenge "github.com/docker/distribution/registry/client/auth/challenge"
+
 	"github.com/google/go-containerregistry/internal/redact"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -188,9 +189,10 @@ func (bt *bearerTransport) refresh(ctx context.Context) error {
 }
 
 func matchesHost(reg name.Registry, in *http.Request, scheme string) bool {
+	domain, _ := reg.SplitURL()
+	canonicalRegistryHost := canonicalAddress(domain, scheme)
 	canonicalHeaderHost := canonicalAddress(in.Host, scheme)
 	canonicalURLHost := canonicalAddress(in.URL.Host, scheme)
-	canonicalRegistryHost := canonicalAddress(reg.RegistryStr(), scheme)
 	return canonicalHeaderHost == canonicalRegistryHost || canonicalURLHost == canonicalRegistryHost
 }
 

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -46,6 +47,14 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
+
+func mustNewRegistry(t *testing.T, s string) name.Registry {
+	registry, err := name.NewRegistry(s, name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewTag(%v) = %v", s, err)
+	}
+	return registry
+}
 
 func mustNewTag(t *testing.T, s string) name.Tag {
 	tag, err := name.NewTag(s, name.WeakValidation)


### PR DESCRIPTION
This fixes #1464.

I've opted to allow manually constructing the reference from a `Registry` by adding the `Repository` method. This of course assumes the user of the library knows about this case and how to handle it.

Another way of going about it would be to split the entire path and iterate the placement of `/v2` until we hit a `200 OK`, but I don't think a default behavior of "path knocking" on registries would be desired. We can consider adding this as a utility function perhaps.

Notice that because `Registry` is embedded `Repository`, this also added a `Repository` to that struct.

So we allow two ways of constructing a reference: One is through `registry.Repository("name").Tag("latest")`, and the other is by replacing the `Repository` as suggested in #1089.

The second part here is adding `SplitURL` to construct resources' URLs properly (in `fetcher.url`) and matching against the correct hostname in `matchesHost`.

I haven't tested all the cases here, only the one I was interested in, so it's quite possible that more changes are required for other types of authentication or different areas of the libraries.