### PR TITLE
crane: add catalog argument use annotation

### DIFF
--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -24,7 +24,7 @@ import (
 // NewCmdCatalog creates a new cobra.Command for the repos subcommand.
 func NewCmdCatalog(options *[]crane.Option) *cobra.Command {
 	return &cobra.Command{
-		Use:   "catalog",
+		Use:   "catalog {REGISTRY}",
 		Short: "List the repos in a registry",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -16,17 +16,31 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
 )
 
 // NewCmdCatalog creates a new cobra.Command for the repos subcommand.
-func NewCmdCatalog(options *[]crane.Option) *cobra.Command {
+func NewCmdCatalog(options *[]crane.Option, argv ...string) *cobra.Command {
+
+	if len(argv) == 0 {
+		argv = []string{os.Args[0]}
+	}
+
+	baseCmd := strings.Join(argv, " ")
+	eg := fmt.Sprintf(`  # list the repos for reg.example.com
+  $ echo "reg.example.com" | %s catalog
+  # or
+  $ %s catalog reg.example.com`, baseCmd, baseCmd)
+
 	return &cobra.Command{
-		Use:   "catalog {REGISTRY}",
-		Short: "List the repos in a registry",
-		Args:  cobra.ExactArgs(1),
+		Use:     "catalog [REGISTRY]",
+		Short:   "List the repos in a registry",
+		Example: eg,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			reg := args[0]
 			repos, err := crane.Catalog(reg, *options...)

--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -32,9 +32,7 @@ func NewCmdCatalog(options *[]crane.Option, argv ...string) *cobra.Command {
 
 	baseCmd := strings.Join(argv, " ")
 	eg := fmt.Sprintf(`  # list the repos for reg.example.com
-  $ echo "reg.example.com" | %s catalog
-  # or
-  $ %s catalog reg.example.com`, baseCmd, baseCmd)
+  $ %s catalog reg.example.com`, baseCmd)
 
 	return &cobra.Command{
 		Use:     "catalog [REGISTRY]",

--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -25,7 +25,6 @@ import (
 
 // NewCmdCatalog creates a new cobra.Command for the repos subcommand.
 func NewCmdCatalog(options *[]crane.Option, argv ...string) *cobra.Command {
-
 	if len(argv) == 0 {
 		argv = []string{os.Args[0]}
 	}

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -96,7 +96,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 		NewCmdAppend(&options),
 		NewCmdAuth(options, "crane", "auth"),
 		NewCmdBlob(&options),
-		NewCmdCatalog(&options),
+		NewCmdCatalog(&options, "crane"),
 		NewCmdConfig(&options),
 		NewCmdCopy(&options),
 		NewCmdDelete(&options),

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -3,7 +3,14 @@
 List the repos in a registry
 
 ```
-crane catalog [flags]
+crane catalog [REGISTRY] [flags]
+```
+
+### Examples
+
+```
+  # list the repos for reg.example.com
+  $ crane catalog reg.example.com
 ```
 
 ### Options


### PR DESCRIPTION
Following [Cobra Recommended Syntax](https://github.com/spf13/cobra/blob/main/command.go#L50) for "Use", I added the required argument annotation to the command.

While the registry argument may be assumed, I believe this improves the user experience by explicitly defining required arguments. Runtime without a registry `Error: accepts 1 arg(s), received 0` and use of the `--help` flag does not define what the expected argument should be.