### PR TITLE
Make checkRegistry and checkRepository functions public

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -94,7 +94,8 @@ func (r Registry) Scheme() string {
 	return "https"
 }
 
-func checkRegistry(name string) error {
+// CheckRegistry validates a registry name is compliant to the RFC 3986.
+func CheckRegistry(name string) error {
 	// Per RFC 3986, registries (authorities) are required to be prefixed with "//"
 	// url.Host == hostname[:port] == authority
 	if url, err := url.Parse("//" + name); err != nil || url.Host != name {
@@ -111,7 +112,7 @@ func NewRegistry(name string, opts ...Option) (Registry, error) {
 		return Registry{}, newErrBadName("strict validation requires the registry to be explicitly defined")
 	}
 
-	if err := checkRegistry(name); err != nil {
+	if err := CheckRegistry(name); err != nil {
 		return Registry{}, err
 	}
 

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -64,7 +64,8 @@ func (r Repository) Scope(action string) string {
 	return fmt.Sprintf("repository:%s:%s", r.RepositoryStr(), action)
 }
 
-func checkRepository(repository string) error {
+// CheckRepository validates a repository matches character and length restrictions.
+func CheckRepository(repository string) error {
 	return checkElement("repository", repository, repositoryChars, 2, 255)
 }
 
@@ -86,7 +87,7 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 		repo = parts[1]
 	}
 
-	if err := checkRepository(repo); err != nil {
+	if err := CheckRepository(repo); err != nil {
 		return Repository{}, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

This PR aims to make these check functions public, so these validations can be easily reused from other packages/projects.

cc @mattmoor 