### PR TITLE
Add support for zstd compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.16+incompatible
 	github.com/google/go-cmp v0.5.8
+	github.com/klauspost/compress v1.15.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
 	github.com/spf13/cobra v1.4.0
@@ -27,7 +28,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/klauspost/compress v1.15.4 // indirect
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -1,0 +1,84 @@
+package compression
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/google/go-containerregistry/internal/gzip"
+	"github.com/google/go-containerregistry/internal/zstd"
+	"io"
+)
+
+type Compression string
+
+// The collection of known MediaType values.
+const (
+	None Compression = "none"
+	GZip Compression = "gzip"
+	ZStd Compression = "zstd"
+)
+
+type Opener = func() (io.ReadCloser, error)
+
+func GetCompression(opener Opener) (Compression, error) {
+	rc, err := opener()
+	if err != nil {
+		return None, err
+	}
+	defer rc.Close()
+
+	compression, _, err := PeekCompression(rc)
+	if err != nil {
+		return None, err
+	}
+
+	return compression, nil
+}
+
+// PeekReader is an io.Reader that also implements Peek a la bufio.Reader.
+type PeekReader interface {
+	io.Reader
+	Peek(n int) ([]byte, error)
+}
+
+// PeekCompression detects whether the input stream is compressed and which algorithm is used.
+//
+// If r implements Peek, we will use that directly, otherwise a small number
+// of bytes are buffered to Peek at the gzip header, and the returned
+// PeekReader can be used as a replacement for the consumed input io.Reader.
+func PeekCompression(r io.Reader) (Compression, PeekReader, error) {
+	var pr PeekReader
+	if p, ok := r.(PeekReader); ok {
+		pr = p
+	} else {
+		pr = bufio.NewReader(r)
+	}
+
+	var header []byte
+	var err error
+
+	if header, err = pr.Peek(2); err != nil {
+		// https://github.com/google/go-containerregistry/issues/367
+		if err == io.EOF {
+			return None, pr, nil
+		}
+		return None, pr, err
+	}
+
+	if bytes.Equal(header, gzip.MagicHeader) {
+		return GZip, pr, nil
+	}
+
+	if header, err = pr.Peek(4); err != nil {
+		// https://github.com/google/go-containerregistry/issues/367
+		if err == io.EOF {
+			return None, pr, nil
+		}
+		return None, pr, err
+	}
+
+	if bytes.Equal(header, zstd.MagicHeader) {
+		return ZStd, pr, nil
+	}
+
+	return None, pr, nil
+}

--- a/internal/zstd/zstd_test.go
+++ b/internal/zstd/zstd_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zstd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	want := "This is the input string."
+	buf := bytes.NewBufferString(want)
+	zipped := ReadCloser(io.NopCloser(buf))
+	unzipped, err := UnzipReadCloser(zipped)
+	if err != nil {
+		t.Error("UnzipReadCloser() =", err)
+	}
+
+	b, err := io.ReadAll(unzipped)
+	if err != nil {
+		t.Error("ReadAll() =", err)
+	}
+	if got := string(b); got != want {
+		t.Errorf("ReadAll(); got %q, want %q", got, want)
+	}
+	if err := unzipped.Close(); err != nil {
+		t.Error("Close() =", err)
+	}
+}
+
+func TestIs(t *testing.T) {
+	tests := []struct {
+		in  []byte
+		out bool
+		err error
+	}{
+		{[]byte{}, false, nil},
+		{[]byte{'\x00', '\x00', '\x00', '\x00', '\x00'}, false, nil},
+		{[]byte{'\x28', '\xb5', '\x2f', '\xfd', '\x1b'}, true, nil},
+	}
+	for _, test := range tests {
+		reader := bytes.NewReader(test.in)
+		got, err := Is(reader)
+		if got != test.out {
+			t.Errorf("Is; n: got %v, wanted %v\n", got, test.out)
+		}
+		if err != test.err {
+			t.Errorf("Is; err: got %v, wanted %v\n", err, test.err)
+		}
+	}
+}
+
+var (
+	errRead = fmt.Errorf("read failed")
+)
+
+type failReader struct{}
+
+func (f failReader) Read(_ []byte) (int, error) {
+	return 0, errRead
+}
+
+func TestReadErrors(t *testing.T) {
+	fr := failReader{}
+	if _, err := Is(fr); err != errRead {
+		t.Error("Is: expected errRead, got", err)
+	}
+
+	frc := io.NopCloser(fr)
+	if r, err := UnzipReadCloser(frc); err != errRead {
+		data := make([]byte, 100)
+		_, err := r.Read(data)
+		if err != errRead {
+			t.Error("UnzipReadCloser: expected errRead, got", err)
+		}
+	}
+
+	zr := ReadCloser(io.NopCloser(fr))
+	if _, err := zr.Read(nil); err != errRead {
+		t.Error("ReadCloser: expected errRead, got", err)
+	}
+
+	//zr = ReadCloserLevel(io.NopCloser(strings.NewReader("zip me")), -10)
+	//if _, err := zr.Read(nil); err == nil {
+	//	t.Error("Expected invalid level error, got:", err)
+	//}
+}

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"time"
@@ -126,15 +125,15 @@ type Annotatable interface {
 // The annotatable input is expected to be a v1.Image or v1.ImageIndex, and
 // returns the same type. You can type-assert the result like so:
 //
-//     img := Annotations(empty.Image, map[string]string{
-//         "foo": "bar",
-//     }).(v1.Image)
+//	img := Annotations(empty.Image, map[string]string{
+//	    "foo": "bar",
+//	}).(v1.Image)
 //
 // Or for an index:
 //
-//     idx := Annotations(empty.Index, map[string]string{
-//         "foo": "bar",
-//     }).(v1.ImageIndex)
+//	idx := Annotations(empty.Index, map[string]string{
+//	    "foo": "bar",
+//	}).(v1.ImageIndex)
 //
 // If the input Annotatable is not an Image or ImageIndex, the result will
 // attempt to lazily annotate the raw manifest.
@@ -423,7 +422,7 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 	b := w.Bytes()
 	// gzip the contents, then create the layer
 	opener := func() (io.ReadCloser, error) {
-		return gzip.ReadCloser(ioutil.NopCloser(bytes.NewReader(b))), nil
+		return gzip.ReadCloser(io.NopCloser(bytes.NewReader(b))), nil
 	}
 	layer, err = tarball.LayerFromOpener(opener)
 	if err != nil {

--- a/pkg/v1/partial/compressed.go
+++ b/pkg/v1/partial/compressed.go
@@ -18,7 +18,9 @@ import (
 	"io"
 
 	"github.com/google/go-containerregistry/internal/and"
+	"github.com/google/go-containerregistry/internal/compression"
 	"github.com/google/go-containerregistry/internal/gzip"
+	"github.com/google/go-containerregistry/internal/zstd"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -51,10 +53,10 @@ func (cle *compressedLayerExtender) Uncompressed() (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	// Often, the "compressed" bytes are not actually gzip-compressed.
+	// Often, the "compressed" bytes are not actually-compressed.
 	// Peek at the first two bytes to determine whether or not it's correct to
-	// wrap this with gzip.UnzipReadCloser.
-	gzipped, pr, err := gzip.Peek(rc)
+	// wrap this with gzip.UnzipReadCloser or zstd.UnzipReadCloser.
+	cp, pr, err := compression.PeekCompression(rc)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +65,14 @@ func (cle *compressedLayerExtender) Uncompressed() (io.ReadCloser, error) {
 		CloseFunc: rc.Close,
 	}
 
-	if !gzipped {
+	switch cp {
+	case compression.GZip:
+		return gzip.UnzipReadCloser(prc)
+	case compression.ZStd:
+		return zstd.UnzipReadCloser(prc)
+	default:
 		return prc, nil
 	}
-
-	return gzip.UnzipReadCloser(prc)
 }
 
 // DiffID implements v1.Layer

--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-containerregistry/internal/gzip"
+	"github.com/google/go-containerregistry/internal/compression"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -166,7 +166,13 @@ func (i *image) areLayersCompressed() (bool, error) {
 		return false, err
 	}
 	defer blob.Close()
-	return gzip.Is(blob)
+
+	cp, _, err := compression.PeekCompression(blob)
+	if err != nil {
+		return false, err
+	}
+
+	return cp != compression.None, nil
 }
 
 func (i *image) loadTarDescriptorAndConfig() error {

--- a/pkg/v1/types/types.go
+++ b/pkg/v1/types/types.go
@@ -24,7 +24,9 @@ const (
 	OCIManifestSchema1             MediaType = "application/vnd.oci.image.manifest.v1+json"
 	OCIConfigJSON                  MediaType = "application/vnd.oci.image.config.v1+json"
 	OCILayer                       MediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+	OCILayerZStd                   MediaType = "application/vnd.oci.image.layer.v1.tar+zstd"
 	OCIRestrictedLayer             MediaType = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+	OCIRestrictedLayerZStd         MediaType = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
 	OCIUncompressedLayer           MediaType = "application/vnd.oci.image.layer.v1.tar"
 	OCIUncompressedRestrictedLayer MediaType = "application/vnd.oci.image.layer.nondistributable.v1.tar"
 


### PR DESCRIPTION
This PR adds support for zstandard compression to the tarball layer implementation. It adds the application/vnd.oci.image.layer.v1.tar+zstd media type, a LayerCompression type and some extra logic in the tarball package. Moreover, this PR modifies [pkg/v1/partial/compressed.go](https://github.com/northflank/go-containerregistry/pull/2/files#diff-6632d2ac8e3d36f5972180430ed71640533372e8e1e3da9b377e8a5e7641c5af) so that it is able to unpack zstd compressed layers.

When creating a tarball layer, one can specify the compression algorithm using WithCompression and the compression level with WithCompressionLevel. By default it will still use gzip compression.
The changes should be fully backwards compatible.