### PR TITLE
Bump slsa-framework/slsa-github-generator to 1.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
Our v0.12.1 failed to generate provenance because we're using a broken version. I checked for the latest release of this before cutting our release, but v1.2.2 is not marked as "latest" on GitHub, so I missed it.