### PR TITLE
Features: Allow eliding `serviceaccount` lookups.

### DIFF
--- a/pkg/authn/kubernetes/keychain.go
+++ b/pkg/authn/kubernetes/keychain.go
@@ -33,14 +33,28 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	// NoServiceAccount is a constant that can be passed via ServiceAccountName
+	// to tell the keychain that looking up the service account is unnecessary.
+	// This value cannot collide with an actual service account name because
+	// service accounts do not allow spaces.
+	NoServiceAccount = "no service account"
+)
+
 // Options holds configuration data for guiding credential resolution.
 type Options struct {
-	// Namespace holds the namespace inside of which we are resolving the
-	// image reference.  If empty, "default" is assumed.
+	// Namespace holds the namespace inside of which we are resolving service
+	// account and pull secret references to access the image.
+	// If empty, "default" is assumed.
 	Namespace string
-	// ServiceAccountName holds the serviceaccount as which the container
-	// will run (scoped to Namespace).  If empty, "default" is assumed.
+
+	// ServiceAccountName holds the serviceaccount (within Namespace) as which a
+	// Pod might access the image.  Service accounts may have image pull secrets
+	// attached, so we lookup the service account to complete the keychain.
+	// If empty, "default" is assumed.  To avoid a service account lookup, pass
+	// NoServiceAccount explicitly.
 	ServiceAccountName string
+
 	// ImagePullSecrets holds the names of the Kubernetes secrets (scoped to
 	// Namespace) containing credential data to use for the image pull.
 	ImagePullSecrets []string
@@ -76,23 +90,27 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 		pullSecrets = append(pullSecrets, *ps)
 	}
 
-	// Second, fetch all of the pull secrets attached to our service account.
-	sa, err := client.CoreV1().ServiceAccounts(opt.Namespace).Get(ctx, opt.ServiceAccountName, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
-		logs.Warn.Printf("serviceaccount %s/%s not found; ignoring", opt.Namespace, opt.ServiceAccountName)
-	} else if err != nil {
-		return nil, err
-	}
-	if sa != nil {
-		for _, localObj := range sa.ImagePullSecrets {
-			ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
-				continue
-			} else if err != nil {
-				return nil, err
+	// Second, fetch all of the pull secrets attached to our service account,
+	// unless the user has explicitly specified that no service account lookup
+	// is desired.
+	if opt.ServiceAccountName != NoServiceAccount {
+		sa, err := client.CoreV1().ServiceAccounts(opt.Namespace).Get(ctx, opt.ServiceAccountName, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			logs.Warn.Printf("serviceaccount %s/%s not found; ignoring", opt.Namespace, opt.ServiceAccountName)
+		} else if err != nil {
+			return nil, err
+		}
+		if sa != nil {
+			for _, localObj := range sa.ImagePullSecrets {
+				ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
+				if k8serrors.IsNotFound(err) {
+					logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
+					continue
+				} else if err != nil {
+					return nil, err
+				}
+				pullSecrets = append(pullSecrets, *ps)
 			}
-			pullSecrets = append(pullSecrets, *ps)
 		}
 	}
 

--- a/pkg/authn/kubernetes/keychain_test.go
+++ b/pkg/authn/kubernetes/keychain_test.go
@@ -89,16 +89,23 @@ func TestAnonymousFallback(t *testing.T) {
 	testResolve(t, kc, registry(t, "fake.registry.io"), authn.Anonymous)
 }
 
-func TestSecretNotFound(t *testing.T) {
-	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
-			Namespace: "default",
-		},
+func TestAnonymousFallbackNoServiceAccount(t *testing.T) {
+	kc, err := New(context.Background(), nil, Options{
+		ServiceAccountName: NoServiceAccount,
 	})
+	if err != nil {
+		t.Errorf("New() = %v", err)
+	}
+
+	testResolve(t, kc, registry(t, "fake.registry.io"), authn.Anonymous)
+}
+
+func TestSecretNotFound(t *testing.T) {
+	client := fakeclient.NewSimpleClientset()
 
 	kc, err := New(context.Background(), client, Options{
-		ImagePullSecrets: []string{"not-found"},
+		ServiceAccountName: NoServiceAccount,
+		ImagePullSecrets:   []string{"not-found"},
 	})
 	if err != nil {
 		t.Errorf("New() = %v", err)


### PR DESCRIPTION
:gift: There are contexts where it may be desirable to leverage the `kubernetes` keychain for authentication where `imagePullSecrets` are explicitly specified, but there isn't a `serviceaccount`.  However, currently there isn't a way to bypass the `default/default` `serviceaccount` lookup performed by this keychain.

This change introduces a new `NoServiceAccount` constant that may be passed via `ServiceAccountName` to elide the `serviceaccount` -> `imagePullSecrets` lookup.  The chosen constant is itself an invalid `serviceaccount` name, so this change is backwards compatible.

/kind feature