### PR TITLE
docs: pull latest instead of debug

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -93,7 +93,7 @@ docker-tag-latest:
     refs:
       - main
   image:
-    name: gcr.io/go-containerregistry/crane:debug
+    name: gcr.io/go-containerregistry/crane:latest
     entrypoint: [""]
   script:
     - crane auth login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY


### PR DESCRIPTION
I don't think it is standard to advise people to pull the debug image. I would imagine that would be like giving people the beta as the standard