### PR TITLE
Make unit tests substantially faster

### DIFF
--- a/cmd/crane/depcheck_test.go
+++ b/cmd/crane/depcheck_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestDeps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow depcheck")
+	}
 	depcheck.AssertNoDependency(t, map[string][]string{
 		"github.com/google/go-containerregistry/cmd/crane": {
 			"github.com/google/go-containerregistry/pkg/v1/daemon",

--- a/cmd/gcrane/depcheck_test.go
+++ b/cmd/gcrane/depcheck_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestDeps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow depcheck")
+	}
 	depcheck.AssertNoDependency(t, map[string][]string{
 		"github.com/google/go-containerregistry/cmd/gcrane": {
 			"github.com/google/go-containerregistry/pkg/v1/daemon",

--- a/pkg/registry/blobs.go
+++ b/pkg/registry/blobs.go
@@ -155,6 +155,7 @@ type blobs struct {
 	// Each upload gets a unique id that writes occur to until finalized.
 	uploads map[string][]byte
 	lock    sync.Mutex
+	log     *log.Logger
 }
 
 func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {

--- a/pkg/registry/depcheck_test.go
+++ b/pkg/registry/depcheck_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestDeps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow depcheck")
+	}
 	depcheck.AssertOnlyDependencies(t, map[string][]string{
 		"github.com/google/go-containerregistry/pkg/registry": append(
 			depcheck.StdlibPackages(),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -79,6 +79,7 @@ func New(opts ...Option) http.Handler {
 		blobs: blobs{
 			blobHandler: &memHandler{m: map[string][]byte{}},
 			uploads:     map[string][]byte{},
+			log:         log.New(os.Stderr, "", log.LstdFlags),
 		},
 		manifests: manifests{
 			manifests: map[string]map[string]manifest{},
@@ -100,5 +101,6 @@ func Logger(l *log.Logger) Option {
 	return func(r *registry) {
 		r.log = l
 		r.manifests.log = l
+		r.blobs.log = l
 	}
 }

--- a/pkg/v1/partial/compressed_test.go
+++ b/pkg/v1/partial/compressed_test.go
@@ -16,6 +16,9 @@ package partial_test
 
 import (
 	"io"
+	"net/http/httptest"
+	"net/url"
+	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -32,26 +35,29 @@ import (
 
 // Remote leverages a lot of compressed partials.
 func TestRemote(t *testing.T) {
+	// Set up a fake registry.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	rnd, err := random.Image(1024, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := registry.TLS("gcr.io")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tr := s.Client().Transport
 
-	src := "gcr.io/test/compressed"
+	src := path.Join(u.Host, "test/compressed")
 	ref, err := name.ParseReference(src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := remote.Write(ref, rnd, remote.WithTransport(tr)); err != nil {
+	if err := remote.Write(ref, rnd); err != nil {
 		t.Fatal(err)
 	}
 
-	img, err := remote.Image(ref, remote.WithTransport(tr))
+	img, err := remote.Image(ref)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/partial/index_test.go
+++ b/pkg/v1/partial/index_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -75,14 +76,11 @@ func TestFindIndexes(t *testing.T) {
 		indexCount = 5
 		imageCount = 7
 	)
-	base, err := random.Index(0, 0, 0)
-	if err != nil {
-		t.Fatal("error creating random index:", err)
-	}
+	base := empty.Index
 	// we now have 5 indexes and 5 images, so wrap them into a single index
 	adds := []mutate.IndexAddendum{}
 	for i := 0; i < indexCount; i++ {
-		ii, err := random.Index(100, 5, 6)
+		ii, err := random.Index(100, 1, 1)
 		if err != nil {
 			t.Fatalf("%d: unable to create random index: %v", i, err)
 		}
@@ -94,7 +92,7 @@ func TestFindIndexes(t *testing.T) {
 		})
 	}
 	for i := 0; i < imageCount; i++ {
-		img, err := random.Image(100, 5)
+		img, err := random.Image(100, 1)
 		if err != nil {
 			t.Fatalf("%d: unable to create random image: %v", i, err)
 		}

--- a/pkg/v1/partial/uncompressed_test.go
+++ b/pkg/v1/partial/uncompressed_test.go
@@ -121,7 +121,7 @@ func TestLegacyWrite(t *testing.T) {
 	defer os.Remove(fp.Name())
 
 	// Make a random image + layer with Descriptor().
-	randImage, err := random.Image(256, 8)
+	randImage, err := random.Image(256, 2)
 	if err != nil {
 		t.Fatalf("Error creating random image: %v", err)
 	}

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -528,21 +528,24 @@ func TestValidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tag, err := name.NewTag("gcr.io/foo/bar")
+
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	reg, err := registry.TLS("gcr.io")
+	tag, err := name.NewTag(u.Host + "/foo/bar")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Write(tag, img, WithTransport(reg.Client().Transport)); err != nil {
+	if err := Write(tag, img); err != nil {
 		t.Fatal(err)
 	}
 
-	img, err = Image(tag, WithTransport(reg.Client().Transport))
+	img, err = Image(tag)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/remote/multi_write_test.go
+++ b/pkg/v1/remote/multi_write_test.go
@@ -186,7 +186,7 @@ func TestMultiWrite_Retry(t *testing.T) {
 		tag1 := mustNewTag(t, u.Host+"/repo:tag1")
 		if err := MultiWrite(map[name.Reference]Taggable{
 			tag1: img1,
-		}); err != nil {
+		}, WithRetryBackoff(fastBackoff)); err != nil {
 			t.Error("Write:", err)
 		}
 	})

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -74,6 +74,14 @@ var defaultRetryBackoff = Backoff{
 	Steps:    3,
 }
 
+// Useful for tests
+var fastBackoff = Backoff{
+	Duration: 1.0 * time.Millisecond,
+	Factor:   3.0,
+	Jitter:   0.1,
+	Steps:    3,
+}
+
 const (
 	defaultJobs = 4
 

--- a/pkg/v1/remote/progress_test.go
+++ b/pkg/v1/remote/progress_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestWriteLayer_Progress(t *testing.T) {
-	l, err := random.Layer(100000, types.OCIUncompressedLayer)
+	l, err := random.Layer(1000, types.OCIUncompressedLayer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestWriteLayer_Progress_Exists(t *testing.T) {
 }
 
 func TestWrite_Progress(t *testing.T) {
-	img, err := random.Image(100000, 10)
+	img, err := random.Image(1000, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestWrite_Progress_DedupeLayers(t *testing.T) {
 }
 
 func TestWriteIndex_Progress(t *testing.T) {
-	idx, err := random.Index(100000, 3, 10)
+	idx, err := random.Index(1000, 3, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestWriteIndex_Progress(t *testing.T) {
 }
 
 func TestMultiWrite_Progress(t *testing.T) {
-	idx, err := random.Index(100000, 10, 10)
+	idx, err := random.Index(1000, 3, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestMultiWrite_Progress(t *testing.T) {
 }
 
 func TestMultiWrite_Progress_Retry(t *testing.T) {
-	idx, err := random.Index(100000, 10, 10)
+	idx, err := random.Index(1000, 3, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestMultiWrite_Progress_Retry(t *testing.T) {
 	if err := MultiWrite(map[name.Reference]Taggable{
 		ref:  idx,
 		ref2: idx,
-	}, WithProgress(c)); err != nil {
+	}, WithProgress(c), WithRetryBackoff(fastBackoff)); err != nil {
 		t.Fatalf("MultiWrite: %v", err)
 	}
 
@@ -311,7 +311,7 @@ func TestWriteLayer_Progress_Retry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := WriteLayer(ref.Context(), l, WithProgress(c)); err != nil {
+	if err := WriteLayer(ref.Context(), l, WithProgress(c), WithRetryBackoff(fastBackoff)); err != nil {
 		t.Fatalf("WriteLayer: %v", err)
 	}
 

--- a/pkg/v1/tarball/progress_test.go
+++ b/pkg/v1/tarball/progress_test.go
@@ -21,29 +21,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 func ExampleWithProgress() {
-	/* calculations for this test:
-	The image we are using is docker.io/library/alpine:3.10
-	its size on disk is 2800640
-	The filesizes inside are:
-	-rw-r--r--  0 0      0        1509 Jan  1  1970 sha256:be4e4bea2c2e15b403bb321562e78ea84b501fb41497472e91ecb41504e8a27c
-	-rw-r--r--  0 0      0     2795580 Jan  1  1970 21c83c5242199776c232920ddb58cfa2a46b17e42ed831ca9001c8dbc532d22d.tar.gz
-	-rw-r--r--  0 0      0         216 Jan  1  1970 manifest.json
-	when rounding each to a 512-byte block, plus the header, we get:
-	1509    ->    1536 + 512 = 2048
-	2795580 -> 2796032 + 512 = 2796544
-	216     ->     512 + 512 = 1024
-	add in 2 blocks of all 0x00 to indicate end of archive
-	                         = 1024
-	                        -------
-	Total:                  2800640
-	*/
 	// buffered channel to make the example test easier
 	c := make(chan v1.Update, 200)
 	// Make a tempfile for tarball writes.
@@ -55,30 +37,16 @@ func ExampleWithProgress() {
 	defer fp.Close()
 	defer os.Remove(fp.Name())
 
-	tag, err := name.NewDigest("docker.io/library/alpine@sha256:f0e9534a598e501320957059cb2a23774b4d4072e37c7b2cf7e95b241f019e35", name.StrictValidation)
-	if err != nil {
-		fmt.Printf("error creating test tag: %v\n", err)
-		return
-	}
-	desc, err := remote.Get(tag)
-	if err != nil {
-		fmt.Printf("error getting manifest: %v", err)
-		return
-	}
-	img, err := desc.Image()
-	if err != nil {
-		fmt.Printf("error image: %v", err)
-		return
-	}
+	img, err := tarball.ImageFromPath("testdata/test_image_1.tar", nil)
 	go func() {
-		_ = tarball.WriteToFile(fp.Name(), tag, img, tarball.WithProgress(c))
+		_ = tarball.WriteToFile(fp.Name(), nil, img, tarball.WithProgress(c))
 	}()
 	for update := range c {
 		switch {
 		case update.Error != nil && errors.Is(update.Error, io.EOF):
 			fmt.Fprintf(os.Stderr, "receive error message: %v\n", err)
 			fmt.Printf("%d/%d", update.Complete, update.Total)
-			// Output: 2800640/2800640
+			// Output: 4096/4096
 			return
 		case update.Error != nil:
 			fmt.Printf("error writing tarball: %v\n", update.Error)


### PR DESCRIPTION
Before:
```
$ time go test -short -count=1 ./...
ok  	github.com/google/go-containerregistry/cmd/crane	0.843s
?   	github.com/google/go-containerregistry/cmd/crane/cmd	[no test files]
?   	github.com/google/go-containerregistry/cmd/crane/help	[no test files]
ok  	github.com/google/go-containerregistry/cmd/gcrane	0.883s
?   	github.com/google/go-containerregistry/cmd/gcrane/cmd	[no test files]
?   	github.com/google/go-containerregistry/cmd/registry	[no test files]
ok  	github.com/google/go-containerregistry/internal/and	0.028s
ok  	github.com/google/go-containerregistry/internal/cmd	1.638s
ok  	github.com/google/go-containerregistry/internal/compare	0.044s
ok  	github.com/google/go-containerregistry/internal/compression	0.024s
?   	github.com/google/go-containerregistry/internal/depcheck	[no test files]
?   	github.com/google/go-containerregistry/internal/editor	[no test files]
ok  	github.com/google/go-containerregistry/internal/estargz	0.041s
ok  	github.com/google/go-containerregistry/internal/gzip	0.019s
?   	github.com/google/go-containerregistry/internal/httptest	[no test files]
ok  	github.com/google/go-containerregistry/internal/legacy	0.046s
?   	github.com/google/go-containerregistry/internal/redact	[no test files]
ok  	github.com/google/go-containerregistry/internal/retry	0.031s
?   	github.com/google/go-containerregistry/internal/retry/wait	[no test files]
?   	github.com/google/go-containerregistry/internal/signal	[no test files]
ok  	github.com/google/go-containerregistry/internal/verify	0.032s
ok  	github.com/google/go-containerregistry/internal/windows	0.038s
ok  	github.com/google/go-containerregistry/internal/zstd	0.045s
ok  	github.com/google/go-containerregistry/pkg/authn	0.091s
ok  	github.com/google/go-containerregistry/pkg/authn/github	0.030s
?   	github.com/google/go-containerregistry/pkg/compression	[no test files]
ok  	github.com/google/go-containerregistry/pkg/crane	0.399s
ok  	github.com/google/go-containerregistry/pkg/gcrane	0.436s
?   	github.com/google/go-containerregistry/pkg/legacy	[no test files]
ok  	github.com/google/go-containerregistry/pkg/legacy/tarball	0.684s
?   	github.com/google/go-containerregistry/pkg/logs	[no test files]
ok  	github.com/google/go-containerregistry/pkg/name	0.025s
ok  	github.com/google/go-containerregistry/pkg/registry	1.415s
ok  	github.com/google/go-containerregistry/pkg/v1	0.023s
ok  	github.com/google/go-containerregistry/pkg/v1/cache	0.153s
ok  	github.com/google/go-containerregistry/pkg/v1/daemon	0.094s
ok  	github.com/google/go-containerregistry/pkg/v1/empty	0.058s
?   	github.com/google/go-containerregistry/pkg/v1/fake	[no test files]
ok  	github.com/google/go-containerregistry/pkg/v1/google	0.299s
ok  	github.com/google/go-containerregistry/pkg/v1/layout	0.171s
ok  	github.com/google/go-containerregistry/pkg/v1/match	0.037s
ok  	github.com/google/go-containerregistry/pkg/v1/mutate	0.252s
ok  	github.com/google/go-containerregistry/pkg/v1/partial	0.362s
ok  	github.com/google/go-containerregistry/pkg/v1/random	0.094s
ok  	github.com/google/go-containerregistry/pkg/v1/remote	4.883s
ok  	github.com/google/go-containerregistry/pkg/v1/remote/transport	0.073s
ok  	github.com/google/go-containerregistry/pkg/v1/static	0.023s
ok  	github.com/google/go-containerregistry/pkg/v1/stream	0.148s
ok  	github.com/google/go-containerregistry/pkg/v1/tarball	1.202s
ok  	github.com/google/go-containerregistry/pkg/v1/types	0.013s
?   	github.com/google/go-containerregistry/pkg/v1/validate	[no test files]

real	0m7.176s
user	0m22.449s
sys	0m6.404s
```

After
```
$ time go test -short -count=1 ./...
ok  	github.com/google/go-containerregistry/cmd/crane	0.048s
?   	github.com/google/go-containerregistry/cmd/crane/cmd	[no test files]
?   	github.com/google/go-containerregistry/cmd/crane/help	[no test files]
ok  	github.com/google/go-containerregistry/cmd/gcrane	0.082s
?   	github.com/google/go-containerregistry/cmd/gcrane/cmd	[no test files]
?   	github.com/google/go-containerregistry/cmd/registry	[no test files]
ok  	github.com/google/go-containerregistry/internal/and	0.013s
ok  	github.com/google/go-containerregistry/internal/cmd	0.098s
ok  	github.com/google/go-containerregistry/internal/compare	0.079s
ok  	github.com/google/go-containerregistry/internal/compression	0.022s
?   	github.com/google/go-containerregistry/internal/depcheck	[no test files]
?   	github.com/google/go-containerregistry/internal/editor	[no test files]
ok  	github.com/google/go-containerregistry/internal/estargz	0.047s
ok  	github.com/google/go-containerregistry/internal/gzip	0.017s
?   	github.com/google/go-containerregistry/internal/httptest	[no test files]
ok  	github.com/google/go-containerregistry/internal/legacy	0.045s
?   	github.com/google/go-containerregistry/internal/redact	[no test files]
ok  	github.com/google/go-containerregistry/internal/retry	0.054s
?   	github.com/google/go-containerregistry/internal/retry/wait	[no test files]
?   	github.com/google/go-containerregistry/internal/signal	[no test files]
ok  	github.com/google/go-containerregistry/internal/verify	0.027s
ok  	github.com/google/go-containerregistry/internal/windows	0.100s
ok  	github.com/google/go-containerregistry/internal/zstd	0.035s
ok  	github.com/google/go-containerregistry/pkg/authn	0.081s
ok  	github.com/google/go-containerregistry/pkg/authn/github	0.038s
?   	github.com/google/go-containerregistry/pkg/compression	[no test files]
ok  	github.com/google/go-containerregistry/pkg/crane	0.383s
ok  	github.com/google/go-containerregistry/pkg/gcrane	0.151s
?   	github.com/google/go-containerregistry/pkg/legacy	[no test files]
ok  	github.com/google/go-containerregistry/pkg/legacy/tarball	0.634s
?   	github.com/google/go-containerregistry/pkg/logs	[no test files]
ok  	github.com/google/go-containerregistry/pkg/name	0.058s
ok  	github.com/google/go-containerregistry/pkg/registry	0.209s
ok  	github.com/google/go-containerregistry/pkg/v1	0.049s
ok  	github.com/google/go-containerregistry/pkg/v1/cache	0.140s
ok  	github.com/google/go-containerregistry/pkg/v1/daemon	0.128s
ok  	github.com/google/go-containerregistry/pkg/v1/empty	0.036s
?   	github.com/google/go-containerregistry/pkg/v1/fake	[no test files]
ok  	github.com/google/go-containerregistry/pkg/v1/google	0.222s
ok  	github.com/google/go-containerregistry/pkg/v1/layout	0.193s
ok  	github.com/google/go-containerregistry/pkg/v1/match	0.013s
ok  	github.com/google/go-containerregistry/pkg/v1/mutate	0.284s
ok  	github.com/google/go-containerregistry/pkg/v1/partial	0.148s
ok  	github.com/google/go-containerregistry/pkg/v1/random	0.085s
ok  	github.com/google/go-containerregistry/pkg/v1/remote	0.820s
ok  	github.com/google/go-containerregistry/pkg/v1/remote/transport	0.076s
ok  	github.com/google/go-containerregistry/pkg/v1/static	0.044s
ok  	github.com/google/go-containerregistry/pkg/v1/stream	0.145s
ok  	github.com/google/go-containerregistry/pkg/v1/tarball	0.280s
ok  	github.com/google/go-containerregistry/pkg/v1/types	0.021s
?   	github.com/google/go-containerregistry/pkg/v1/validate	[no test files]

real	0m2.836s
user	0m16.766s
sys	0m4.375s
```