### PR TITLE
Make credential warning slightly more accurate

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -268,7 +268,9 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if err := CheckError(resp, http.StatusOK); err != nil {
-		logs.Warn.Printf("No matching credentials were found for %q", bt.registry)
+		if bt.basic == authn.Anonymous {
+			logs.Warn.Printf("No matching credentials were found for %q", bt.registry)
+		}
 		return nil, err
 	}
 
@@ -308,7 +310,9 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if err := CheckError(resp, http.StatusOK); err != nil {
-		logs.Warn.Printf("No matching credentials were found for %q", bt.registry)
+		if bt.basic == authn.Anonymous {
+			logs.Warn.Printf("No matching credentials were found for %q", bt.registry)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
We hit this if the auth handshake fails, but this says "no matching credentials", which isn't necessarily true. Check for authn.Anonymous before saying they weren't found.