### PR TITLE
Use the default retry predicate in transport

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -76,3 +76,19 @@ func Retry(f func() error, p Predicate, backoff wait.Backoff) (err error) {
 	wait.ExponentialBackoff(backoff, condition)
 	return
 }
+
+type contextKey string
+
+var key = contextKey("never")
+
+// Never returns a context that signals something should not be retried.
+// This is a hack and can be used to communicate across package boundaries
+// to avoid retry amplification.
+func Never(ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, true)
+}
+
+// Ever returns true if the context was wrapped by Never.
+func Ever(ctx context.Context) bool {
+	return ctx.Value(key) == nil
+}

--- a/pkg/v1/remote/check.go
+++ b/pkg/v1/remote/check.go
@@ -35,11 +35,10 @@ func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTrip
 	// authorize a push. Figure out how to return early here when we can,
 	// to avoid a roundtrip for spec-compliant registries.
 	w := writer{
-		repo:    ref.Context(),
-		client:  &http.Client{Transport: tr},
-		context: context.Background(),
+		repo:   ref.Context(),
+		client: &http.Client{Transport: tr},
 	}
-	loc, _, err := w.initiateUpload("", "", "")
+	loc, _, err := w.initiateUpload(context.Background(), "", "", "")
 	if loc != "" {
 		// Since we're only initiating the upload to check whether we
 		// can, we should attempt to cancel it, in case initiating

--- a/pkg/v1/remote/multi_write.go
+++ b/pkg/v1/remote/multi_write.go
@@ -89,7 +89,6 @@ func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
 	w := writer{
 		repo:      repo,
 		client:    &http.Client{Transport: tr},
-		context:   o.context,
 		backoff:   o.retryBackoff,
 		predicate: o.retryPredicate,
 	}

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -82,6 +82,14 @@ var fastBackoff = Backoff{
 	Steps:    3,
 }
 
+var retryableStatusCodes = []int{
+	http.StatusRequestTimeout,
+	http.StatusInternalServerError,
+	http.StatusBadGateway,
+	http.StatusServiceUnavailable,
+	http.StatusGatewayTimeout,
+}
+
 const (
 	defaultJobs = 4
 
@@ -151,7 +159,7 @@ func makeOptions(target authn.Resource, opts ...Option) (*options, error) {
 		}
 
 		// Wrap the transport in something that can retry network flakes.
-		o.transport = transport.NewRetry(o.transport)
+		o.transport = transport.NewRetry(o.transport, transport.WithRetryPredicate(defaultRetryPredicate), transport.WithRetryStatusCodes(retryableStatusCodes...))
 
 		// Wrap this last to prevent transport.New from double-wrapping.
 		if o.userAgent != "" {

--- a/pkg/v1/remote/transport/retry.go
+++ b/pkg/v1/remote/transport/retry.go
@@ -21,12 +21,12 @@ import (
 	"github.com/google/go-containerregistry/internal/retry"
 )
 
-// Sleep for 0.1, 0.3, 0.9, 2.7 seconds. This should cover networking blips.
+// Sleep for 0.1 then 0.3 seconds. This should cover networking blips.
 var defaultBackoff = retry.Backoff{
 	Duration: 100 * time.Millisecond,
 	Factor:   3.0,
 	Jitter:   0.1,
-	Steps:    5,
+	Steps:    3,
 }
 
 var _ http.RoundTripper = (*retryTransport)(nil)
@@ -36,6 +36,7 @@ type retryTransport struct {
 	inner     http.RoundTripper
 	backoff   retry.Backoff
 	predicate retry.Predicate
+	codes     []int
 }
 
 // Option is a functional option for retryTransport.
@@ -44,6 +45,7 @@ type Option func(*options)
 type options struct {
 	backoff   retry.Backoff
 	predicate retry.Predicate
+	codes     []int
 }
 
 // Backoff is an alias of retry.Backoff to expose this configuration option to consumers of this lib
@@ -63,6 +65,13 @@ func WithRetryPredicate(predicate func(error) bool) Option {
 	}
 }
 
+// WithRetryStatusCodes sets which http response codes will be retried.
+func WithRetryStatusCodes(codes ...int) Option {
+	return func(o *options) {
+		o.codes = codes
+	}
+}
+
 // NewRetry returns a transport that retries errors.
 func NewRetry(inner http.RoundTripper, opts ...Option) http.RoundTripper {
 	o := &options{
@@ -78,12 +87,23 @@ func NewRetry(inner http.RoundTripper, opts ...Option) http.RoundTripper {
 		inner:     inner,
 		backoff:   o.backoff,
 		predicate: o.predicate,
+		codes:     o.codes,
 	}
 }
 
 func (t *retryTransport) RoundTrip(in *http.Request) (out *http.Response, err error) {
 	roundtrip := func() error {
 		out, err = t.inner.RoundTrip(in)
+		if !retry.Ever(in.Context()) {
+			return nil
+		}
+		if out != nil {
+			for _, code := range t.codes {
+				if out.StatusCode == code {
+					return CheckError(out)
+				}
+			}
+		}
 		return err
 	}
 	retry.Retry(roundtrip, t.predicate, t.backoff)

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -169,7 +169,6 @@ func setupWriterWithServer(server *httptest.Server, repo string) (*writer, close
 	return &writer{
 		repo:      tag.Context(),
 		client:    http.DefaultClient,
-		context:   context.Background(),
 		predicate: defaultRetryPredicate,
 		backoff:   defaultRetryBackoff,
 	}, server, nil
@@ -217,7 +216,7 @@ func TestCheckExistingBlob(t *testing.T) {
 			}
 			defer closer.Close()
 
-			existing, err := w.checkExistingBlob(h)
+			existing, err := w.checkExistingBlob(context.Background(), h)
 			if test.existing != existing {
 				t.Errorf("checkExistingBlob() = %v, want %v", existing, test.existing)
 			}
@@ -257,7 +256,7 @@ func TestInitiateUploadNoMountsExists(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
+	_, mounted, err := w.initiateUpload(context.Background(), "baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -295,7 +294,7 @@ func TestInitiateUploadNoMountsInitiated(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
+	location, mounted, err := w.initiateUpload(context.Background(), "baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -334,7 +333,7 @@ func TestInitiateUploadNoMountsBadStatus(t *testing.T) {
 	}
 	defer closer.Close()
 
-	location, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
+	location, mounted, err := w.initiateUpload(context.Background(), "baz/bar", h.String(), "")
 	if err == nil {
 		t.Errorf("intiateUpload() = %v, %v; wanted error", location, mounted)
 	}
@@ -367,7 +366,7 @@ func TestInitiateUploadMountsWithMountFromDifferentRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload("baz/bar", h.String(), "")
+	_, mounted, err := w.initiateUpload(context.Background(), "baz/bar", h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -407,7 +406,7 @@ func TestInitiateUploadMountsWithMountFromTheSameRegistry(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String(), "")
+	_, mounted, err := w.initiateUpload(context.Background(), expectedMountRepo, h.String(), "")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -449,7 +448,7 @@ func TestInitiateUploadMountsWithOrigin(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String(), "fakeOrigin")
+	_, mounted, err := w.initiateUpload(context.Background(), expectedMountRepo, h.String(), "fakeOrigin")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -499,7 +498,7 @@ func TestInitiateUploadMountsWithOriginFallback(t *testing.T) {
 	}
 	defer closer.Close()
 
-	_, mounted, err := w.initiateUpload(expectedMountRepo, h.String(), "fakeOrigin")
+	_, mounted, err := w.initiateUpload(context.Background(), expectedMountRepo, h.String(), "fakeOrigin")
 	if err != nil {
 		t.Errorf("intiateUpload() = %v", err)
 	}
@@ -721,7 +720,7 @@ func TestCommitBlob(t *testing.T) {
 
 	commitLocation := w.url(expectedPath)
 
-	if err := w.commitBlob(commitLocation.String(), h.String()); err != nil {
+	if err := w.commitBlob(context.Background(), commitLocation.String(), h.String()); err != nil {
 		t.Errorf("commitBlob() = %v", err)
 	}
 }
@@ -1264,7 +1263,7 @@ func TestCheckExistingManifest(t *testing.T) {
 			}
 			defer closer.Close()
 
-			existing, err := w.checkExistingManifest(h, mt)
+			existing, err := w.checkExistingManifest(context.Background(), h, mt)
 			if test.existing != existing {
 				t.Errorf("checkExistingManifest() = %v, want %v", existing, test.existing)
 			}


### PR DESCRIPTION
We have two levels of retries here.

The first is in the retryTransport, which currently just tests IsTemporary. This has a short backoff and was intended to handle blips in the network.

The second level was intended for higher level issues, e.g. if an upload PUT failed, we have to retry more than just a single HTTP request, because we might have to restart the upload with a new POST and PATCH.

This change propagates the default retryable predicate (from the scond level) down to the retryTransport. This also adds a list of HTTP codes that are retryable, so that the retryTransport can also handle server-side errors that should be retried.

Note that this doesn't respect remote.WithRetry{Backoff,Predicate} because callers can just override the entire transport via remote.WithTransport. This change tries to do the right thing by default without changing behavior for folks who seem to already know what they're doing.

Originally, I started down the path of wrapping various remote methods in a retry.Retry function (similar to writes) and decided against it due to the size of the change and how difficult it would be to maintain.

In order to reduce retry ampliciation, this adds a little context wrapper to signal to retryTransport not to retry (because the retry is happening at a higher level).

This also reduces the number of steps in the default backoff for retryTransport because more kinds of things are being retried, and I want to reduce the blast radius if something is erroneously retried.