### PR TITLE
Revert "docs: pull latest instead of debug (#1497)"

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -93,7 +93,7 @@ docker-tag-latest:
     refs:
       - main
   image:
-    name: gcr.io/go-containerregistry/crane:latest
+    name: gcr.io/go-containerregistry/crane:debug
     entrypoint: [""]
   script:
     - crane auth login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY


### PR DESCRIPTION
Fixes https://github.com/google/go-containerregistry/issues/1503

This reverts commit 37b993ac11d2c2f9708ed7927909d850b4a17bbe.