### PR TITLE
Treat empty registry config as anonymous

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -123,6 +123,10 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
+		// cf.GetAuthConfig automatically sets the ServerAddress attribute. Since
+		// we don't make use of it, clear the value for a proper "is-empty" test.
+		// See: https://github.com/google/go-containerregistry/issues/1510
+		cfg.ServerAddress = ""
 		if cfg != empty {
 			break
 		}

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -195,11 +195,12 @@ func encode(user, pass string) string {
 
 func TestVariousPaths(t *testing.T) {
 	tests := []struct {
-		desc    string
-		content string
-		wantErr bool
-		target  Resource
-		cfg     *AuthConfig
+		desc      string
+		content   string
+		wantErr   bool
+		target    Resource
+		cfg       *AuthConfig
+		anonymous bool
 	}{{
 		desc:    "invalid config file",
 		target:  testRegistry,
@@ -264,6 +265,17 @@ func TestVariousPaths(t *testing.T) {
 			Username: "foo",
 			Password: "bar",
 		},
+	}, {
+		desc:   "ignore unrelated repo",
+		target: testRepo,
+		content: fmt.Sprintf(`{
+  "auths": {
+    "test.io/another-repo": {"auth": %q},
+	"test.io": {}
+  }
+}`, encode("bar", "baz")),
+		cfg:       &AuthConfig{},
+		anonymous: true,
 	}}
 
 	for _, test := range tests {
@@ -291,6 +303,10 @@ func TestVariousPaths(t *testing.T) {
 
 			if !reflect.DeepEqual(cfg, test.cfg) {
 				t.Errorf("got %+v, want %+v", cfg, test.cfg)
+			}
+
+			if test.anonymous != (auth == Anonymous) {
+				t.Fatalf("unexpected anonymous authenticator")
 			}
 		})
 	}


### PR DESCRIPTION
Make DefaultKeychain return the Anonymous authenticator when the config for a registry is empty.

Fixes #1510

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>