### PR TITLE
Fix DNS lookup failure caused by too-short dial timeout

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -106,7 +106,10 @@ var DefaultTransport http.RoundTripper = &http.Transport{
 		// By default we wrap the transport in retries, so reduce the
 		// default dial timeout to 5s to avoid 5x 30s of connection
 		// timeouts when doing the "ping" on certain http registries.
-		Timeout:   5 * time.Second,
+		// Note that the default DNS failover timeout is 5 seconds; we must keep
+		// the dial timeout above 15 seconds to allow resolution to fail over
+		// through up to 3 backup nameservers.
+		Timeout:   16 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext,
 	ForceAttemptHTTP2:     true,


### PR DESCRIPTION
If the user's primary nameserver is unavailable, and they are using the default resolver timeout of 5 seconds, the dial will fail before it can attempt to use any backup nameservers.

This change raises the dial timeout to a value that should allow failover through multiple nameservers. With a value of 16 seconds, the 4th nameserver has 1 second to respond before the dial times out.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>