### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -53,11 +53,7 @@ func TestMain(m *testing.M) {
 func setupConfigDir(t *testing.T) string {
 	tmpdir := os.Getenv("TEST_TMPDIR")
 	if tmpdir == "" {
-		var err error
-		tmpdir, err = os.MkdirTemp("", "keychain_test")
-		if err != nil {
-			t.Fatalf("creating temp dir: %v", err)
-		}
+		tmpdir = t.TempDir()
 	}
 
 	fresh++
@@ -98,11 +94,7 @@ func TestNoConfig(t *testing.T) {
 func TestPodmanConfig(t *testing.T) {
 	tmpdir := os.Getenv("TEST_TMPDIR")
 	if tmpdir == "" {
-		var err error
-		tmpdir, err = os.MkdirTemp("", "keychain_test")
-		if err != nil {
-			t.Fatalf("creating temp dir: %v", err)
-		}
+		tmpdir = t.TempDir()
 	}
 	fresh++
 	p := filepath.Join(tmpdir, fmt.Sprintf("%d", fresh))

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -401,11 +401,7 @@ func TestCraneSaveLegacy(t *testing.T) {
 func TestCraneSaveOCI(t *testing.T) {
 	t.Parallel()
 	// Write an image as an OCI image layout.
-	tmp, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	img, err := random.Image(1024, 5)
 	if err != nil {

--- a/pkg/v1/cache/fs_test.go
+++ b/pkg/v1/cache/fs_test.go
@@ -27,11 +27,7 @@ import (
 )
 
 func TestFilesystemCache(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ggcr-cache")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	numLayers := 5
 	img, err := random.Image(10, int64(numLayers))
@@ -155,11 +151,7 @@ func TestFilesystemCache(t *testing.T) {
 }
 
 func TestErrNotFound(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ggcr-cache")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	os.RemoveAll(dir) // Remove the tempdir.
+	dir := t.TempDir()
 
 	c := NewFilesystemCache(dir)
 	h := v1.Hash{Algorithm: "fake", Hex: "not-found"}
@@ -172,11 +164,7 @@ func TestErrNotFound(t *testing.T) {
 }
 
 func TestErrUnexpectedEOF(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ggcr-cache")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir) // Remove the tempdir.
+	dir := t.TempDir()
 
 	// create a random layer
 	l, err := random.Layer(10, types.DockerLayer)

--- a/pkg/v1/layout/write_test.go
+++ b/pkg/v1/layout/write_test.go
@@ -35,12 +35,7 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "write-index-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	original, err := ImageIndexFromPath(testPath)
 	if err != nil {
@@ -78,12 +73,7 @@ func TestWriteErrors(t *testing.T) {
 }
 
 func TestAppendDescriptorInitializesIndex(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "write-index-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	temp, err := Write(tmp, empty.Index)
 	if err != nil {
 		t.Fatal(err)
@@ -115,12 +105,7 @@ func TestAppendDescriptorInitializesIndex(t *testing.T) {
 }
 
 func TestRoundtrip(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "write-index-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	original, err := ImageIndexFromPath(testPath)
 	if err != nil {
@@ -150,10 +135,7 @@ func TestRoundtrip(t *testing.T) {
 }
 
 func TestOptions(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "write-index-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmp := t.TempDir()
 	temp, err := Write(tmp, empty.Index)
 	if err != nil {
 		t.Fatal(err)
@@ -229,12 +211,7 @@ func TestDeduplicatedWrites(t *testing.T) {
 
 func TestRemoveDescriptor(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "remove-descriptor-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex
 	ii = empty.Index
@@ -290,12 +267,7 @@ func TestRemoveDescriptor(t *testing.T) {
 
 func TestReplaceIndex(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "replace-index-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex
 	ii = empty.Index
@@ -365,12 +337,7 @@ func TestReplaceIndex(t *testing.T) {
 
 func TestReplaceImage(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "replace-image-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex
 	ii = empty.Index
@@ -440,12 +407,7 @@ func TestReplaceImage(t *testing.T) {
 
 func TestRemoveBlob(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "remove-blob-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex = empty.Index
 	l, err := Write(tmp, ii)
@@ -483,12 +445,7 @@ func TestRemoveBlob(t *testing.T) {
 
 func TestStreamingWriteLayer(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "streaming-write-layer-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex = empty.Index
 	l, err := Write(tmp, ii)
@@ -546,12 +503,7 @@ func TestStreamingWriteLayer(t *testing.T) {
 
 func TestOverwriteWithWriteLayer(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "overwrite-with-write-layer-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex = empty.Index
 	l, err := Write(tmp, ii)
@@ -642,12 +594,7 @@ func TestOverwriteWithWriteLayer(t *testing.T) {
 
 func TestOverwriteWithReplaceImage(t *testing.T) {
 	// need to set up a basic path
-	tmp, err := os.MkdirTemp("", "overwrite-with-replace-image-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var ii v1.ImageIndex = empty.Index
 	l, err := Write(tmp, ii)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```