### PR TITLE
crane: add digest --full

### DIFF
--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
 // NewCmdDigest creates a new cobra.Command for the digest subcommand.
 func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 	var tarball string
+	var full bool
 	cmd := &cobra.Command{
 		Use:   "digest IMAGE",
 		Short: "Get the digest of an image",
@@ -36,17 +38,29 @@ func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 				}
 				return errors.New("image reference required without --tarball")
 			}
+			if full && tarball != "" {
+				return errors.New("cannot specify --full with --tarball")
+			}
 
 			digest, err := getDigest(tarball, args, options)
 			if err != nil {
 				return err
 			}
-			fmt.Println(digest)
+			if full {
+				ref, err := name.ParseReference(args[0])
+				if err != nil {
+					return err
+				}
+				fmt.Println(ref.Context().Digest(digest))
+			} else {
+				fmt.Println(digest)
+			}
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&tarball, "tarball", "", "(Optional) path to tarball containing the image")
+	cmd.Flags().BoolVar(&full, "full", false, "(Optional) if true, print the full image reference by digest")
 
 	return cmd
 }

--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -26,7 +26,7 @@ import (
 // NewCmdDigest creates a new cobra.Command for the digest subcommand.
 func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 	var tarball string
-	var full bool
+	var fullRef bool
 	cmd := &cobra.Command{
 		Use:   "digest IMAGE",
 		Short: "Get the digest of an image",
@@ -38,15 +38,15 @@ func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 				}
 				return errors.New("image reference required without --tarball")
 			}
-			if full && tarball != "" {
-				return errors.New("cannot specify --full with --tarball")
+			if fullRef && tarball != "" {
+				return errors.New("cannot specify --full-ref with --tarball")
 			}
 
 			digest, err := getDigest(tarball, args, options)
 			if err != nil {
 				return err
 			}
-			if full {
+			if fullRef {
 				ref, err := name.ParseReference(args[0])
 				if err != nil {
 					return err
@@ -60,7 +60,7 @@ func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&tarball, "tarball", "", "(Optional) path to tarball containing the image")
-	cmd.Flags().BoolVar(&full, "full", false, "(Optional) if true, print the full image reference by digest")
+	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference by digest")
 
 	return cmd
 }

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -9,6 +9,7 @@ crane digest IMAGE [flags]
 ### Options
 
 ```
+      --full-ref         (Optional) if true, print the full image reference by digest
   -h, --help             help for digest
       --tarball string   (Optional) path to tarball containing the image
 ```


### PR DESCRIPTION
```
$ crane digest cgr.dev/chainguard/static
sha256:0394eb00eabee3530bdfc0dd5845806e5badcc840cbd0746b0d5bd912c9d51fc

$ crane digest --full cgr.dev/chainguard/static
cgr.dev/chainguard/static@sha256:0394eb00eabee3530bdfc0dd5845806e5badcc840cbd0746b0d5bd912c9d51fc

$ crane digest --full cgr.dev/chainguard/static --platform=linux/arm64
cgr.dev/chainguard/static@sha256:694b43c7eca332b9a37d7767299d51ac336c2a2187acce230eb528a17ae3522d
```

I find myself wanting this sometimes, and I usually hack it together with bash and feel terrible about myself.