### PR TITLE
crane: support --full-ref for crane ls

### DIFF
--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
 // NewCmdList creates a new cobra.Command for the ls subcommand.
 func NewCmdList(options *[]crane.Option) *cobra.Command {
-	return &cobra.Command{
+	var fullRef bool
+	cmd := &cobra.Command{
 		Use:   "ls REPO",
 		Short: "List the tags in a repo",
 		Args:  cobra.ExactArgs(1),
@@ -34,10 +36,21 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 				return fmt.Errorf("reading tags for %s: %w", repo, err)
 			}
 
+			r, err := name.NewRepository(repo)
+			if err != nil {
+				return err
+			}
+
 			for _, tag := range tags {
-				fmt.Println(tag)
+				if fullRef {
+					fmt.Println(r.Tag(tag))
+				} else {
+					fmt.Println(tag)
+				}
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
+	return cmd
 }

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -9,7 +9,8 @@ crane ls REPO [flags]
 ### Options
 
 ```
-  -h, --help   help for ls
+      --full-ref   (Optional) if true, print the full image reference
+  -h, --help       help for ls
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Before:

```
crane ls cgr.dev/chainguard/static
20220302
sha256-bab7d22b93180e8a05d0f02c739605cc7ed52b414b8f70ad6a173f2c0c8dc946.sig
sha256-e86edc0a7f00adb469d13b49192f38f992a981d778aa3f24525aa83b370b4001.sig
20220303
sha256-1535c58eb82f566a382131ba23583135aaba4e22fccccaadcd00b24286c47ad7.sig
...
```

After:

```
go run ./cmd/crane ls cgr.dev/chainguard/static --full-ref
cgr.dev/chainguard/static:20220302
cgr.dev/chainguard/static:sha256-bab7d22b93180e8a05d0f02c739605cc7ed52b414b8f70ad6a173f2c0c8dc946.sig
cgr.dev/chainguard/static:sha256-e86edc0a7f00adb469d13b49192f38f992a981d778aa3f24525aa83b370b4001.sig
cgr.dev/chainguard/static:20220303
cgr.dev/chainguard/static:sha256-1535c58eb82f566a382131ba23583135aaba4e22fccccaadcd00b24286c47ad7.sig
...
```