### PR TITLE
crane: support --omit-digest-tags in crane ls

### DIFF
--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -24,7 +25,7 @@ import (
 
 // NewCmdList creates a new cobra.Command for the ls subcommand.
 func NewCmdList(options *[]crane.Option) *cobra.Command {
-	var fullRef bool
+	var fullRef, omitDigestTags bool
 	cmd := &cobra.Command{
 		Use:   "ls REPO",
 		Short: "List the tags in a repo",
@@ -42,6 +43,10 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 			}
 
 			for _, tag := range tags {
+				if omitDigestTags && strings.HasPrefix(tag, "sha256-") {
+					continue
+				}
+
 				if fullRef {
 					fmt.Println(r.Tag(tag))
 				} else {
@@ -52,5 +57,6 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
+	cmd.Flags().BoolVar(&omitDigestTags, "omit-digest-tags", false, "(Optional), if true, omit digest tags (e.g., ':sha256-...')")
 	return cmd
 }

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -9,8 +9,9 @@ crane ls REPO [flags]
 ### Options
 
 ```
-      --full-ref   (Optional) if true, print the full image reference
-  -h, --help       help for ls
+      --full-ref           (Optional) if true, print the full image reference
+  -h, --help               help for ls
+      --omit-digest-tags   (Optional), if true, omit digest tags (e.g., ':sha256-...')
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Before:

```
$ crane ls cgr.dev/chainguard/static | head -n 10
20220302
sha256-bab7d22b93180e8a05d0f02c739605cc7ed52b414b8f70ad6a173f2c0c8dc946.sig
sha256-e86edc0a7f00adb469d13b49192f38f992a981d778aa3f24525aa83b370b4001.sig
20220303
sha256-1535c58eb82f566a382131ba23583135aaba4e22fccccaadcd00b24286c47ad7.sig
sha256-061d30276694f8ae8e6a47eec9e7b7526d5e0c89436217907cac09cc19d9a953.sig
20220304
sha256-6168c94e3afa1b01a090632f77309ce541e1f502d8783071d026eb97a211b723.sig
sha256-8953bc492aebe6574d8735174000a7cea046de6ec8b6b28501ae27110352bc11.sig
20220305
$ crane ls cgr.dev/chainguard/static | wc -l
7890
```

After:

```
$ go run ./cmd/crane ls cgr.dev/chainguard/static --omit-digest-tags | head -n 10
20220302
20220303
20220304
20220305
20220306
20220307
20220308
20220309
20220310
20220311
$ go run ./cmd/crane ls cgr.dev/chainguard/static --omit-digest-tags | wc -l     
     369
```

(This image is built and tagged daily)