### PR TITLE
Revert plugin scope hack

### DIFF
--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -209,28 +209,6 @@ func (d *Descriptor) remoteIndex() *remoteIndex {
 	}
 }
 
-// https://github.com/docker/hub-feedback/issues/2107#issuecomment-1371293316
-//
-// DockerHub supports plugins, which look like normal manifests, but will
-// return a 401 with an incorrect challenge if you attempt to fetch them.
-//
-// They require you send, e.g.:
-// 'repository(plugin):vieux/sshfs:pull' not 'repository:vieux/sshfs:pull'.
-//
-// Hack around this by always including the plugin-ified version in the initial
-// scopes. The request will succeed with the correct subset, so it is safe to
-// have extraneous scopes here.
-func fixPluginScopes(ref name.Reference, scopes []string) []string {
-	if ref.Context().Registry.String() == name.DefaultRegistry {
-		for _, scope := range scopes {
-			if strings.HasPrefix(scope, "repository") {
-				scopes = append(scopes, strings.Replace(scope, "repository", "repository(plugin)", 1))
-			}
-		}
-	}
-	return scopes
-}
-
 // fetcher implements methods for reading from a registry.
 type fetcher struct {
 	Ref     name.Reference
@@ -239,10 +217,7 @@ type fetcher struct {
 }
 
 func makeFetcher(ref name.Reference, o *options) (*fetcher, error) {
-	scopes := []string{ref.Scope(transport.PullScope)}
-	scopes = fixPluginScopes(ref, scopes)
-
-	tr, err := transport.NewWithContext(o.context, ref.Context().Registry, o.auth, o.transport, scopes)
+	tr, err := transport.NewWithContext(o.context, ref.Context().Registry, o.auth, o.transport, []string{ref.Scope(transport.PullScope)})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
DockerHub has rolled out a fix for this:

```
$ cat .git/HEAD
ref: refs/heads/plugins

$ go run ./cmd/crane/ manifest vieux/sshfs
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.plugin.v1+json",
      "size": 1055,
      "digest": "sha256:b336e50d046bfb078f0b2eced46851322603342c34ae25ca6cc4712253344ae1"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 8820470,
         "digest": "sha256:52d435ada6a4127b66e31157e3ad0f4db3f4b61c7c380ffd89d065fc24faa339"
      }
   ]
}
```