### PR TITLE
clarify crane download readme

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -19,7 +19,7 @@ $ curl -sL "https://github.com/google/go-containerregistry/releases/latest/downl
 
 Download a specific version:
 ```
-$ VERSION=TODO   # Version number without leading v 
+$ VERSION=TODO   # Version number without leading v
 $ OS=Linux       # or Darwin, Windows
 $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
 $ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz

--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -11,12 +11,18 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 
 ### Install from Releases
 Download [latest release](https://github.com/google/go-containerregistry/releases/latest):
-
 ```
-$ VERSION=TODO   # Latest, or other
 $ OS=Linux       # or Darwin, Windows
 $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-$ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${VERSION}_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+$ curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+```
+
+Download a specific version:
+```
+$ VERSION=TODO   # Version number without leading v 
+$ OS=Linux       # or Darwin, Windows
+$ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
+$ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
 ```
 
 We generate [SLSA 3 provenance](https://slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator). To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation) and verify as follows:


### PR DESCRIPTION
The download instructions include the $VERSION in the path twice, which isn't a valid link. 
After getting it to work for a specific release, I figured people might also want instructions to download the latest release, which uses a different URL path, so added that example as well.