### PR TITLE
hash: use generic instantiation

### DIFF
--- a/pkg/legacy/tarball/write.go
+++ b/pkg/legacy/tarball/write.go
@@ -17,8 +17,6 @@ package tarball
 import (
 	"archive/tar"
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -63,8 +61,9 @@ func v1LayerID(layer v1.Layer, parentID string, rawConfig []byte) (string, error
 	if len(rawConfig) != 0 {
 		s = fmt.Sprintf("%s %s", s, string(rawConfig))
 	}
-	rawDigest := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(rawDigest[:]), nil
+
+	h, _, _ := v1.SHA256(strings.NewReader(s))
+	return h.Hex, nil
 }
 
 // newTopV1Layer creates a new v1Layer for a layer other than the top layer in a v1 image tarball.

--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -16,8 +16,6 @@ package registry
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -110,9 +108,8 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 				Message: "Unknown manifest",
 			}
 		}
-		rd := sha256.Sum256(m.blob)
-		d := "sha256:" + hex.EncodeToString(rd[:])
-		resp.Header().Set("Docker-Content-Digest", d)
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
 		resp.Header().Set("Content-Type", m.contentType)
 		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
 		resp.WriteHeader(http.StatusOK)
@@ -137,9 +134,8 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 				Message: "Unknown manifest",
 			}
 		}
-		rd := sha256.Sum256(m.blob)
-		d := "sha256:" + hex.EncodeToString(rd[:])
-		resp.Header().Set("Docker-Content-Digest", d)
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
 		resp.Header().Set("Content-Type", m.contentType)
 		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
 		resp.WriteHeader(http.StatusOK)
@@ -153,8 +149,8 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 		}
 		b := &bytes.Buffer{}
 		io.Copy(b, req.Body)
-		rd := sha256.Sum256(b.Bytes())
-		digest := "sha256:" + hex.EncodeToString(rd[:])
+		h, _, _ := v1.SHA256(bytes.NewReader(b.Bytes()))
+		digest := h.String()
 		mf := manifest{
 			blob:        b.Bytes(),
 			contentType: req.Header.Get("Content-Type"),

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -15,8 +15,7 @@
 package registry_test
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 const (
@@ -47,8 +47,8 @@ const (
 )
 
 func sha256String(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:])
+	h, _, _ := v1.SHA256(bytes.NewReader([]byte(s)))
+	return h.Hex
 }
 
 func TestCalls(t *testing.T) {

--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -15,7 +15,7 @@
 package v1
 
 import (
-	"crypto/sha256"
+	"crypto"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -78,7 +78,7 @@ func (h *Hash) UnmarshalText(text []byte) error {
 func Hasher(name string) (hash.Hash, error) {
 	switch name {
 	case "sha256":
-		return sha256.New(), nil
+		return crypto.SHA256.New(), nil
 	default:
 		return nil, fmt.Errorf("unsupported hash: %q", name)
 	}
@@ -111,7 +111,7 @@ func (h *Hash) parse(unquoted string) error {
 
 // SHA256 computes the Hash of the provided io.Reader's content.
 func SHA256(r io.Reader) (Hash, int64, error) {
-	hasher := sha256.New()
+	hasher := crypto.SHA256.New()
 	n, err := io.Copy(hasher, r)
 	if err != nil {
 		return Hash{}, 0, err

--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -17,8 +17,8 @@ package random
 import (
 	"archive/tar"
 	"bytes"
+	"crypto"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -85,7 +85,7 @@ func Layer(byteSize int64, mt types.MediaType) (v1.Layer, error) {
 
 	// Hash the contents as we write it out to the buffer.
 	var b bytes.Buffer
-	hasher := sha256.New()
+	hasher := crypto.SHA256.New()
 	mw := io.MultiWriter(&b, hasher)
 
 	// Write a single file with a random name and random contents.

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -17,7 +17,7 @@ package remote
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -573,7 +573,7 @@ func TestStreamLayer(t *testing.T) {
 			t.Errorf("URL; got %v, want %v", r.URL.Path, expectedPath)
 		}
 
-		h := sha256.New()
+		h := crypto.SHA256.New()
 		s, err := io.Copy(h, r.Body)
 		if err != nil {
 			t.Errorf("Reading body: %v", err)

--- a/pkg/v1/stream/layer.go
+++ b/pkg/v1/stream/layer.go
@@ -17,7 +17,7 @@ package stream
 import (
 	"bufio"
 	"compress/gzip"
-	"crypto/sha256"
+	"crypto"
 	"encoding/hex"
 	"errors"
 	"hash"
@@ -156,8 +156,8 @@ type compressedReader struct {
 func newCompressedReader(l *Layer) (*compressedReader, error) {
 	// Collect digests of compressed and uncompressed stream and size of
 	// compressed stream.
-	h := sha256.New()
-	zh := sha256.New()
+	h := crypto.SHA256.New()
+	zh := crypto.SHA256.New()
 	count := &countWriter{}
 
 	// gzip.Writer writes to the output stream via pipe, a hasher to

--- a/pkg/v1/validate/layer.go
+++ b/pkg/v1/validate/layer.go
@@ -17,7 +17,7 @@ package validate
 import (
 	"archive/tar"
 	"compress/gzip"
-	"crypto/sha256"
+	"crypto"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -105,7 +105,7 @@ func computeLayer(layer v1.Layer) (*computedLayer, error) {
 	}
 
 	// Keep track of compressed digest.
-	digester := sha256.New()
+	digester := crypto.SHA256.New()
 	// Everything read from compressed is written to digester to compute digest.
 	hashCompressed := io.TeeReader(compressed, digester)
 
@@ -133,7 +133,7 @@ func computeLayer(layer v1.Layer) (*computedLayer, error) {
 	if err != nil {
 		return nil, err
 	}
-	diffider := sha256.New()
+	diffider := crypto.SHA256.New()
 	hashUncompressed := io.TeeReader(uncompressed, diffider)
 
 	// Ensure there aren't duplicate file paths.


### PR DESCRIPTION
This enables doing something like
https://github.com/opencontainers/go-digest/issues/71#issuecomment-1330069987 to override the hashing method (example: replace with sha256simd).

When an importer does not overriden, the library should behave exactly the same.

See https://github.com/google/go-containerregistry/issues/1330