### PR TITLE
Support artifactType, for images whose config.mediaType is not a config

### DIFF
--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -47,6 +47,7 @@ type Descriptor struct {
 	URLs        []string          `json:"urls,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 	Platform    *Platform         `json:"platform,omitempty"`
+	ArtifactType string `json:"artifactType,omitempty"`
 }
 
 // ParseManifest parses the io.Reader's contents into a Manifest.

--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -40,14 +40,14 @@ type IndexManifest struct {
 
 // Descriptor holds a reference from the manifest to one of its constituent elements.
 type Descriptor struct {
-	MediaType   types.MediaType   `json:"mediaType"`
-	Size        int64             `json:"size"`
-	Digest      Hash              `json:"digest"`
-	Data        []byte            `json:"data,omitempty"`
-	URLs        []string          `json:"urls,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Platform    *Platform         `json:"platform,omitempty"`
-	ArtifactType string `json:"artifactType,omitempty"`
+	MediaType    types.MediaType   `json:"mediaType"`
+	Size         int64             `json:"size"`
+	Digest       Hash              `json:"digest"`
+	Data         []byte            `json:"data,omitempty"`
+	URLs         []string          `json:"urls,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	Platform     *Platform         `json:"platform,omitempty"`
+	ArtifactType string            `json:"artifactType,omitempty"`
 }
 
 // ParseManifest parses the io.Reader's contents into a Manifest.

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -500,6 +500,8 @@ func MediaType(img v1.Image, mt types.MediaType) v1.Image {
 }
 
 // ConfigMediaType modifies the MediaType() of the given image's Config.
+//
+// If !mt.IsConfig(), this will be the image's artifactType in any indexes it's a part of.
 func ConfigMediaType(img v1.Image, mt types.MediaType) v1.Image {
 	return &image{
 		base:            img,

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -337,7 +337,7 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 			mf, _ := Manifest(wrm)
 			// Failing to parse as a manifest should just be ignored.
 			// The manifest might not be valid, and that's okay.
-			if !mf.Config.MediaType.IsConfig() {
+			if mf != nil && !mf.Config.MediaType.IsConfig() {
 				desc.ArtifactType = string(mf.Config.MediaType)
 			}
 		}
@@ -425,7 +425,7 @@ func ArtifactType(w WithManifest) (string, error) {
 	mf, _ := w.Manifest()
 	// Failing to parse as a manifest should just be ignored.
 	// The manifest might not be valid, and that's okay.
-	if !mf.Config.MediaType.IsConfig() {
+	if mf != nil && !mf.Config.MediaType.IsConfig() {
 		return string(mf.Config.MediaType), nil
 	}
 	return "", nil

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -418,6 +418,10 @@ func unwrap(i any) any {
 	return i
 }
 
+// ArtifactType returns the artifact type for the given manifest.
+//
+// If the manifest reports its own artifact type, that's returned, otherwise
+// the manifest is parsed and, if successful, its config.mediaType is returned.
 func ArtifactType(w WithManifest) (string, error) {
 	if wat, ok := w.(withArtifactType); ok {
 		return wat.ArtifactType()

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -334,11 +334,9 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 		}
 	} else {
 		if wrm, ok := d.(WithRawManifest); ok && desc.MediaType.IsImage() {
-			mf, err := Manifest(wrm)
-			if err != nil {
-				// Failing to parse as a manifest should just be ignored.
-				// The manifest might not be valid, and that's okay.
-			}
+			mf, _ := Manifest(wrm)
+			// Failing to parse as a manifest should just be ignored.
+			// The manifest might not be valid, and that's okay.
 			if !mf.Config.MediaType.IsConfig() {
 				desc.ArtifactType = string(mf.Config.MediaType)
 			}
@@ -424,11 +422,10 @@ func ArtifactType(w WithManifest) (string, error) {
 	if wat, ok := w.(withArtifactType); ok {
 		return wat.ArtifactType()
 	}
-	mf, err := w.Manifest()
-	if err != nil {
-		// Failing to parse as a manifest should just be ignored.
-		// The manifest might not be valid, and that's okay.
-	} else if !mf.Config.MediaType.IsConfig() {
+	mf, _ := w.Manifest()
+	// Failing to parse as a manifest should just be ignored.
+	// The manifest might not be valid, and that's okay.
+	if !mf.Config.MediaType.IsConfig() {
 		return string(mf.Config.MediaType), nil
 	}
 	return "", nil

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -336,7 +336,8 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 		if wrm, ok := d.(WithRawManifest); ok && desc.MediaType.IsImage() {
 			mf, err := Manifest(wrm)
 			if err != nil {
-				// this is fine.
+				// Failing to parse as a manifest should just be ignored.
+				// The manifest might not be valid, and that's okay.
 			}
 			if !mf.Config.MediaType.IsConfig() {
 				desc.ArtifactType = string(mf.Config.MediaType)

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -288,7 +288,7 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 	mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
 	// Failing to parse as a manifest should just be ignored.
 	// The manifest might not be valid, and that's okay.
-	if !mf.Config.MediaType.IsConfig() {
+	if mf != nil && !mf.Config.MediaType.IsConfig() {
 		artifactType = string(mf.Config.MediaType)
 	}
 

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -283,6 +283,16 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
 		}
 	}
+
+	var artifactType string
+	mf, err := v1.ParseManifest(bytes.NewReader(manifest))
+	if err != nil {
+		// Failing to parse as a manifest should just be ignored.
+		// The manifest might not be valid, and that's okay.
+	} else if !mf.Config.MediaType.IsConfig() {
+		artifactType = string(mf.Config.MediaType)
+	}
+
 	// Do nothing for tags; I give up.
 	//
 	// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
@@ -293,9 +303,10 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 
 	// Return all this info since we have to calculate it anyway.
 	desc := v1.Descriptor{
-		Digest:    digest,
-		Size:      size,
-		MediaType: mediaType,
+		Digest:       digest,
+		Size:         size,
+		MediaType:    mediaType,
+		ArtifactType: artifactType,
 	}
 
 	return manifest, &desc, nil

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -285,11 +285,10 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 	}
 
 	var artifactType string
-	mf, err := v1.ParseManifest(bytes.NewReader(manifest))
-	if err != nil {
-		// Failing to parse as a manifest should just be ignored.
-		// The manifest might not be valid, and that's okay.
-	} else if !mf.Config.MediaType.IsConfig() {
+	mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
+	// Failing to parse as a manifest should just be ignored.
+	// The manifest might not be valid, and that's okay.
+	if !mf.Config.MediaType.IsConfig() {
 		artifactType = string(mf.Config.MediaType)
 	}
 

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -44,6 +44,16 @@ type remoteImage struct {
 	config       []byte
 	mediaType    types.MediaType
 	descriptor   *v1.Descriptor
+	artifactType string
+}
+
+func (r *remoteImage) ArtifactType() (string, error) {
+	// kind of a hack, but RawManifest does appropriate locking/memoization
+	// and makes sure r.descriptor is populated.
+	if _, err := r.RawManifest(); err != nil {
+		return "", err
+	}
+	return r.descriptor.ArtifactType, nil
 }
 
 var _ partial.CompressedImageCore = (*remoteImage)(nil)

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -44,7 +44,6 @@ type remoteImage struct {
 	config       []byte
 	mediaType    types.MediaType
 	descriptor   *v1.Descriptor
-	artifactType string
 }
 
 func (r *remoteImage) ArtifactType() (string, error) {

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -255,7 +255,7 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 		mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
 		// Failing to parse as a manifest should just be ignored.
 		// The manifest might not be valid, and that's okay.
-		if !mf.Config.MediaType.IsConfig() {
+		if mf != nil && !mf.Config.MediaType.IsConfig() {
 			child.ArtifactType = string(mf.Config.MediaType)
 		}
 	}

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -252,11 +252,10 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 	}
 
 	if child.MediaType.IsImage() {
-		mf, err := v1.ParseManifest(bytes.NewReader(manifest))
-		if err != nil {
-			// Failing to parse as a manifest should just be ignored.
-			// The manifest might not be valid, and that's okay.
-		} else if !mf.Config.MediaType.IsConfig() {
+		mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
+		// Failing to parse as a manifest should just be ignored.
+		// The manifest might not be valid, and that's okay.
+		if !mf.Config.MediaType.IsConfig() {
 			child.ArtifactType = string(mf.Config.MediaType)
 		}
 	}

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -250,6 +250,17 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 			return nil, err
 		}
 	}
+
+	if child.MediaType.IsImage() {
+		mf, err := v1.ParseManifest(bytes.NewReader(manifest))
+		if err != nil {
+			// Failing to parse as a manifest should just be ignored.
+			// The manifest might not be valid, and that's okay.
+		} else if !mf.Config.MediaType.IsConfig() {
+			child.ArtifactType = string(mf.Config.MediaType)
+		}
+	}
+
 	return &Descriptor{
 		fetcher: fetcher{
 			Ref:     ref,

--- a/pkg/v1/types/types.go
+++ b/pkg/v1/types/types.go
@@ -71,3 +71,12 @@ func (m MediaType) IsIndex() bool {
 	}
 	return false
 }
+
+// IsConfig returns true if the mediaType represents a config, as opposed to something else, like an image.
+func (m MediaType) IsConfig() bool {
+	switch m {
+	case OCIConfigJSON, DockerConfigJSON:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
If an index contains an image whose config.mediaType is not the normal config type (i.e., it's an artifact, packaged as an image for registry compatibility), the index's descriptor for the image will include `artifactType`.

This is work toward supporting the OCI 1.1 referrers fallback tag scheme, where referrers are managed by the client and pushed as indexes to the registry, tagged with `:sha256-abcdef...`.

cc @jdolitsky