### PR TITLE
Support for OCI 1.1+ referrers via fallback tag

### DIFF
--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -28,6 +28,7 @@ type Manifest struct {
 	Config        Descriptor        `json:"config"`
 	Layers        []Descriptor      `json:"layers"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
+	Subject       *Descriptor       `json:"subject,omitempty"`
 }
 
 // IndexManifest represents an OCI image index in a structured way.
@@ -36,6 +37,7 @@ type IndexManifest struct {
 	MediaType     types.MediaType   `json:"mediaType,omitempty"`
 	Manifests     []Descriptor      `json:"manifests"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
+	Subject       *Descriptor       `json:"subject,omitempty"`
 }
 
 // Descriptor holds a reference from the manifest to one of its constituent elements.

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -37,6 +37,7 @@ type image struct {
 	configMediaType *types.MediaType
 	diffIDMap       map[v1.Hash]v1.Layer
 	digestMap       map[v1.Hash]v1.Layer
+	subject         *v1.Descriptor
 }
 
 var _ v1.Image = (*image)(nil)
@@ -153,6 +154,7 @@ func (i *image) compute() error {
 			manifest.Annotations[k] = v
 		}
 	}
+	manifest.Subject = i.subject
 
 	i.configFile = configFile
 	i.manifest = manifest

--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -70,6 +70,7 @@ type index struct {
 	imageMap    map[v1.Hash]v1.Image
 	indexMap    map[v1.Hash]v1.ImageIndex
 	layerMap    map[v1.Hash]v1.Layer
+	subject     *v1.Descriptor
 }
 
 var _ v1.ImageIndex = (*index)(nil)
@@ -142,6 +143,7 @@ func (i *index) compute() error {
 			manifest.Annotations[k] = v
 		}
 	}
+	manifest.Subject = i.subject
 
 	i.manifest = manifest
 	i.computed = true

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -279,7 +280,7 @@ func TestAnnotations(t *testing.T) {
 
 	for _, c := range []struct {
 		desc string
-		in   mutate.Annotatable
+		in   partial.WithRawManifest
 		want string
 	}{{
 		desc: "image",

--- a/pkg/v1/remote/delete.go
+++ b/pkg/v1/remote/delete.go
@@ -54,4 +54,8 @@ func Delete(ref name.Reference, options ...Option) error {
 	defer resp.Body.Close()
 
 	return transport.CheckError(resp, http.StatusOK, http.StatusAccepted)
+
+	// TODO(jason): If the manifest had a `subject`, and if the registry
+	// doesn't support Referrers, update the index pointed to by the
+	// subject's fallback tag to remove the descriptor for this manifest.
 }

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -17,6 +17,8 @@ package remote
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,7 +61,7 @@ type Descriptor struct {
 	v1.Descriptor
 	Manifest []byte
 
-	// So we can share this implementation with Image..
+	// So we can share this implementation with Image.
 	platform v1.Platform
 }
 
@@ -235,6 +237,45 @@ func (f *fetcher) url(resource, identifier string) url.URL {
 		Host:   f.Ref.Context().RegistryStr(),
 		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
 	}
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#referrers-tag-schema
+func fallbackTag(d name.Digest) name.Tag {
+	return d.Context().Tag(strings.Replace(d.DigestStr(), ":", "-", 1))
+}
+
+func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, d name.Digest) (*v1.IndexManifest, error) {
+	// Assume the registry doesn't support the Referrers API endpoint, so we'll use the fallback tag scheme.
+	b, _, err := f.fetchManifest(fallbackTag(d), []types.MediaType{types.OCIImageIndex})
+	if err != nil {
+		return nil, err
+	}
+	var terr *transport.Error
+	if ok := errors.As(err, &terr); ok && terr.StatusCode == http.StatusNotFound {
+		// Not found just means there are no attachments yet. Start with an empty manifest.
+		return &v1.IndexManifest{MediaType: types.OCIImageIndex}, nil
+	}
+
+	var im v1.IndexManifest
+	if err := json.Unmarshal(b, &im); err != nil {
+		return nil, err
+	}
+
+	// If filter applied, filter out by artifactType and add annotation
+	// See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+	if filter != nil {
+		if v, ok := filter["artifactType"]; ok {
+			tmp := []v1.Descriptor{}
+			for _, desc := range im.Manifests {
+				if desc.ArtifactType == v {
+					tmp = append(tmp, desc)
+				}
+			}
+			im.Manifests = tmp
+		}
+	}
+
+	return &im, nil
 }
 
 func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType) ([]byte, *v1.Descriptor, error) {

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -46,6 +46,7 @@ type options struct {
 	pageSize                       int
 	retryBackoff                   Backoff
 	retryPredicate                 retry.Predicate
+	filter                         map[string]string
 }
 
 var defaultPlatform = v1.Platform{
@@ -300,6 +301,17 @@ func WithRetryBackoff(backoff Backoff) Option {
 func WithRetryPredicate(predicate retry.Predicate) Option {
 	return func(o *options) error {
 		o.retryPredicate = predicate
+		return nil
+	}
+}
+
+// WithFilter sets the filter querystring for HTTP operations.
+func WithFilter(key string, value string) Option {
+	return func(o *options) error {
+		if o.filter == nil {
+			o.filter = map[string]string{}
+		}
+		o.filter[key] = value
 		return nil
 	}
 }

--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Referrers returns a list of descriptors that refer to the given manifest digest.
+//
+// The subject manifest doesn't have to exist in the registry for there to be descriptors that refer to it.
+func Referrers(d name.Digest, options ...Option) (*v1.IndexManifest, error) {
+	o, err := makeOptions(d.Context(), options...)
+	if err != nil {
+		return nil, err
+	}
+	f, err := makeFetcher(d, o)
+	if err != nil {
+		return nil, err
+	}
+	return f.fetchReferrers(o.context, o.filter, d)
+}

--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -1,0 +1,163 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestReferrers_FallbackTag(t *testing.T) {
+	// Set up a fake registry that doesn't support the Referrers API.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	descriptor := func(img v1.Image) v1.Descriptor {
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sz, err := img.Size()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt, err := img.MediaType()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v1.Descriptor{
+			Digest:       d,
+			Size:         sz,
+			MediaType:    mt,
+			ArtifactType: "application/testing123",
+		}
+	}
+
+	// Push an image we'll attach things to.
+	// We'll copy from src to dst.
+	rootRef, err := name.ParseReference(fmt.Sprintf("%s/repo:root", u.Host))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootImg, err := random.Image(10, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootImg = mutate.ConfigMediaType(rootImg, types.MediaType("application/testing123"))
+	if err := remote.Write(rootRef, rootImg); err != nil {
+		t.Fatal(err)
+	}
+	rootDesc := descriptor(rootImg)
+	t.Logf("root image is %s", rootDesc.Digest)
+
+	// Push an image that refers to the root image as its subject.
+	leafRef, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf", u.Host))
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafImg, err := random.Image(20, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafImg = mutate.ConfigMediaType(leafImg, types.MediaType("application/testing123"))
+	leafImg = mutate.Subject(leafImg, rootDesc).(v1.Image)
+	if err := remote.Write(leafRef, leafImg); err != nil {
+		t.Fatal(err)
+	}
+	leafDesc := descriptor(leafImg)
+	t.Logf("leaf image is %s", leafDesc.Digest)
+
+	// Get the referrers of the root image, by digest.
+	rootRefDigest := rootRef.Context().Digest(rootDesc.Digest.String())
+	index, err := remote.Referrers(rootRefDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
+		t.Fatalf("referrers diff (-want,+got): %s", d)
+	}
+
+	// Get the referrers by querying the root image's fallback tag directly.
+	tag, err := name.ParseReference(fmt.Sprintf("%s/repo:sha256-%s", u.Host, rootDesc.Digest.Hex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx, err := remote.Index(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff(index.Manifests, mf.Manifests); d != "" {
+		t.Fatalf("fallback tag diff (-want,+got): %s", d)
+	}
+
+	// Push the leaf image again, this time with a different tag.
+	// This shouldn't add another item to the root image's referrers,
+	// because it's the same digest.
+	// Push an image that refers to the root image as its subject.
+	leaf2Ref, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf2", u.Host))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(leaf2Ref, leafImg); err != nil {
+		t.Fatal(err)
+	}
+	// Get the referrers of the root image again, which should only have one entry.
+	rootRefDigest = rootRef.Context().Digest(rootDesc.Digest.String())
+	index, err = remote.Referrers(rootRefDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
+		t.Fatalf("referrers diff after second push (-want,+got): %s", d)
+	}
+
+	// Try applying filters and verify number of manifests and and annotations
+	index, err = remote.Referrers(rootRefDigest,
+		remote.WithFilter("artifactType", "application/testing123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numManifests := len(index.Manifests); numManifests == 0 {
+		t.Fatal("index contained 0 manifests")
+	}
+
+	index, err = remote.Referrers(rootRefDigest,
+		remote.WithFilter("artifactType", "application/testing123BADDDD"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numManifests := len(index.Manifests); numManifests != 0 {
+		t.Fatalf("expected index to contain 0 manifests, but had %d", numManifests)
+	}
+}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -17,11 +17,13 @@ package remote
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/google/go-containerregistry/internal/redact"
@@ -577,8 +579,92 @@ func unpackTaggable(t Taggable) ([]byte, *v1.Descriptor, error) {
 	}, nil
 }
 
+// commitSubjectReferrers is responsible for updating the fallback tag manifest to track descriptors referring to a subject for registries that don't yet support the Referrers API.
+// TODO: this method only uses the fallback tag for now
+// TODO: use conditional requests to avoid race conditions
+func (w *writer) commitSubjectReferrers(ctx context.Context, sub name.Digest, add v1.Descriptor) error {
+	// The registry doesn't support Referrers API, we need to update the manifest tagged with the fallback tag.
+	// Make the request to GET the current manifest.
+	t := fallbackTag(sub)
+	u := w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.repo.RepositoryStr(), t.Identifier()))
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", string(types.OCIImageIndex))
+	resp, err := w.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var im v1.IndexManifest
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound); err != nil {
+		return err
+	} else if resp.StatusCode == http.StatusNotFound {
+		// Not found just means there are no attachments. Start with an empty index.
+		im = v1.IndexManifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIImageIndex,
+			Manifests:     []v1.Descriptor{add},
+		}
+	} else {
+		if err := json.NewDecoder(resp.Body).Decode(&im); err != nil {
+			return err
+		}
+		if im.SchemaVersion != 2 {
+			return fmt.Errorf("fallback tag manifest is not a schema version 2: %d", im.SchemaVersion)
+		}
+		if im.MediaType != types.OCIImageIndex {
+			return fmt.Errorf("fallback tag manifest is not an OCI image index: %s", im.MediaType)
+		}
+		for _, desc := range im.Manifests {
+			if desc.Digest == add.Digest {
+				// The digest is already attached, nothing to do.
+				logs.Progress.Printf("fallback tag %s already had referrer", t.Identifier())
+				return nil
+			}
+		}
+		// Append the new descriptor to the index.
+		im.Manifests = append(im.Manifests, add)
+	}
+
+	// Sort the manifests for reproducibility.
+	sort.Slice(im.Manifests, func(i, j int) bool {
+		return im.Manifests[i].Digest.String() < im.Manifests[j].Digest.String()
+	})
+	logs.Progress.Printf("updating fallback tag %s with new referrer", t.Identifier())
+	if err := w.commitManifest(ctx, fallbackTaggable{im}, t); err != nil {
+		return err
+	}
+	return nil
+}
+
+type fallbackTaggable struct {
+	im v1.IndexManifest
+}
+
+func (f fallbackTaggable) RawManifest() ([]byte, error)        { return json.Marshal(f.im) }
+func (f fallbackTaggable) MediaType() (types.MediaType, error) { return types.OCIImageIndex, nil }
+
 // commitManifest does a PUT of the image's manifest.
 func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Reference) error {
+	// If the manifest refers to a subject, we need to check whether we need to update the fallback tag manifest.
+	raw, err := t.RawManifest()
+	if err != nil {
+		return err
+	}
+	var mf struct {
+		MediaType types.MediaType `json:"mediaType"`
+		Subject   *v1.Descriptor  `json:"subject,omitempty"`
+		Config    struct {
+			MediaType types.MediaType `json:"mediaType"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		return err
+	}
+
 	tryUpload := func() error {
 		ctx := retry.Never(ctx)
 		raw, desc, err := unpackTaggable(t)
@@ -603,6 +689,26 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 
 		if err := transport.CheckError(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted); err != nil {
 			return err
+		}
+
+		// If the manifest referred to a subject, we may need to update the fallback tag manifest.
+		// TODO: If this fails, we'll retry the whole upload. We should retry just this part.
+		if mf.Subject != nil {
+			h, size, err := v1.SHA256(bytes.NewReader(raw))
+			if err != nil {
+				return err
+			}
+			desc := v1.Descriptor{
+				ArtifactType: string(mf.Config.MediaType),
+				MediaType:    mf.MediaType,
+				Digest:       h,
+				Size:         size,
+			}
+			if err := w.commitSubjectReferrers(ctx,
+				ref.Context().Digest(mf.Subject.Digest.String()),
+				desc); err != nil {
+				return err
+			}
 		}
 
 		// The image was successfully pushed!


### PR DESCRIPTION
Builds on top of #1541 

Crane subcommands "attach" and "refs" dropped in this PR, but can be found here: https://github.com/google/go-containerregistry/compare/main...jdolitsky:attach-pt-3?expand=1

cc @imjasonh 