### PR TITLE
Support for OCI 1.1+ referrers via API

### DIFF
--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -377,12 +377,22 @@ func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request)
 
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	digestToManifestMap, repoExists := m.manifests[repo]
+	if !repoExists {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "NAME_UNKNOWN",
+			Message: "Unknown name",
+		}
+	}
+
 	im := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     types.OCIImageIndex,
 		Manifests:     []v1.Descriptor{},
 	}
-	for digest, manifest := range m.manifests[repo] {
+	for digest, manifest := range digestToManifestMap {
 		h, err := v1.NewHash(digest)
 		if err != nil {
 			continue

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -109,7 +109,7 @@ func Logger(l *log.Logger) Option {
 	}
 }
 
-// Logger overrides the logger used to record requests to the registry.
+// WithReferrersSupport enables the referrers API endpoint (OCI 1.1+)
 func WithReferrersSupport(enabled bool) Option {
 	return func(r *registry) {
 		r.referrersEnabled = enabled

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -30,9 +30,10 @@ import (
 )
 
 type registry struct {
-	log       *log.Logger
-	blobs     blobs
-	manifests manifests
+	log              *log.Logger
+	blobs            blobs
+	manifests        manifests
+	referrersEnabled bool
 }
 
 // https://docs.docker.com/registry/spec/api/#api-version-check
@@ -49,6 +50,9 @@ func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
 	}
 	if isCatalog(req) {
 		return r.manifests.handleCatalog(resp, req)
+	}
+	if r.referrersEnabled && isReferrers(req) {
+		return r.manifests.handleReferrers(resp, req)
 	}
 	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
@@ -102,5 +106,12 @@ func Logger(l *log.Logger) Option {
 		r.log = l
 		r.manifests.log = l
 		r.blobs.log = l
+	}
+}
+
+// Logger overrides the logger used to record requests to the registry.
+func WithReferrersSupport(enabled bool) Option {
+	return func(r *registry) {
+		r.referrersEnabled = enabled
 	}
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -467,6 +467,12 @@ func TestCalls(t *testing.T) {
 			},
 		},
 		{
+			Description: "fetch references, missing repo",
+			Method:      "GET",
+			URL:         "/v2/does-not-exist/referrers/sha256:" + sha256String("foo"),
+			Code:        http.StatusNotFound,
+		},
+		{
 			Description: "fetch references, bad target (tag vs. digest)",
 			Method:      "GET",
 			URL:         "/v2/foo/referrers/latest",

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -437,6 +437,41 @@ func TestCalls(t *testing.T) {
 			URL:         "/v2/_catalog?n=1000",
 			Code:        http.StatusOK,
 		},
+		{
+			Description: "fetch references",
+			Method:      "GET",
+			URL:         "/v2/foo/referrers/sha256:" + sha256String("foo"),
+			Code:        http.StatusOK,
+			Manifests: map[string]string{
+				"foo/manifests/image":           "foo",
+				"foo/manifests/points-to-image": "{\"subject\": {\"digest\": \"sha256:" + sha256String("foo") + "\"}}",
+			},
+		},
+		{
+			Description: "fetch references, subject pointing elsewhere",
+			Method:      "GET",
+			URL:         "/v2/foo/referrers/sha256:" + sha256String("foo"),
+			Code:        http.StatusOK,
+			Manifests: map[string]string{
+				"foo/manifests/image":           "foo",
+				"foo/manifests/points-to-image": "{\"subject\": {\"digest\": \"sha256:" + sha256String("nonexistant") + "\"}}",
+			},
+		},
+		{
+			Description: "fetch references, no results",
+			Method:      "GET",
+			URL:         "/v2/foo/referrers/sha256:" + sha256String("foo"),
+			Code:        http.StatusOK,
+			Manifests: map[string]string{
+				"foo/manifests/image": "foo",
+			},
+		},
+		{
+			Description: "fetch references, bad method",
+			Method:      "POST",
+			URL:         "/v2/foo/referrers/sha256:" + sha256String("foo"),
+			Code:        http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -444,10 +479,11 @@ func TestCalls(t *testing.T) {
 		var logger *log.Logger
 		testf := func(t *testing.T) {
 
-			r := registry.New()
+			opts := []registry.Option{registry.WithReferrersSupport(true)}
 			if logger != nil {
-				r = registry.New(registry.Logger(logger))
+				opts = append(opts, registry.Logger(logger))
 			}
+			r := registry.New(opts...)
 			s := httptest.NewServer(r)
 			defer s.Close()
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -467,6 +467,12 @@ func TestCalls(t *testing.T) {
 			},
 		},
 		{
+			Description: "fetch references, bad target (tag vs. digest)",
+			Method:      "GET",
+			URL:         "/v2/foo/referrers/latest",
+			Code:        http.StatusBadRequest,
+		},
+		{
 			Description: "fetch references, bad method",
 			Method:      "POST",
 			URL:         "/v2/foo/referrers/sha256:" + sha256String("foo"),

--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -30,134 +30,154 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-func TestReferrers_FallbackTag(t *testing.T) {
-	// Set up a fake registry that doesn't support the Referrers API.
-	s := httptest.NewServer(registry.New())
-	defer s.Close()
-	u, err := url.Parse(s.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	descriptor := func(img v1.Image) v1.Descriptor {
-		d, err := img.Digest()
+func TestReferrers(t *testing.T) {
+	// Run all tests against:
+	//
+	//   (1) A OCI 1.0 registry (without referrers API)
+	//   (2) An OCI 1.1+ registry (with referrers API)
+	//
+	for _, leg := range []struct {
+		server      *httptest.Server
+		tryFallback bool
+	}{
+		{
+			server:      httptest.NewServer(registry.New(registry.WithReferrersSupport(false))),
+			tryFallback: true,
+		},
+		{
+			server:      httptest.NewServer(registry.New(registry.WithReferrersSupport(true))),
+			tryFallback: false,
+		},
+	} {
+		s := leg.server
+		defer s.Close()
+		u, err := url.Parse(s.URL)
 		if err != nil {
 			t.Fatal(err)
 		}
-		sz, err := img.Size()
+
+		descriptor := func(img v1.Image) v1.Descriptor {
+			d, err := img.Digest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			sz, err := img.Size()
+			if err != nil {
+				t.Fatal(err)
+			}
+			mt, err := img.MediaType()
+			if err != nil {
+				t.Fatal(err)
+			}
+			return v1.Descriptor{
+				Digest:       d,
+				Size:         sz,
+				MediaType:    mt,
+				ArtifactType: "application/testing123",
+			}
+		}
+
+		// Push an image we'll attach things to.
+		// We'll copy from src to dst.
+		rootRef, err := name.ParseReference(fmt.Sprintf("%s/repo:root", u.Host))
 		if err != nil {
 			t.Fatal(err)
 		}
-		mt, err := img.MediaType()
+		rootImg, err := random.Image(10, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
-		return v1.Descriptor{
-			Digest:       d,
-			Size:         sz,
-			MediaType:    mt,
-			ArtifactType: "application/testing123",
+		rootImg = mutate.ConfigMediaType(rootImg, types.MediaType("application/testing123"))
+		if err := remote.Write(rootRef, rootImg); err != nil {
+			t.Fatal(err)
 		}
-	}
+		rootDesc := descriptor(rootImg)
+		t.Logf("root image is %s", rootDesc.Digest)
 
-	// Push an image we'll attach things to.
-	// We'll copy from src to dst.
-	rootRef, err := name.ParseReference(fmt.Sprintf("%s/repo:root", u.Host))
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootImg, err := random.Image(10, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootImg = mutate.ConfigMediaType(rootImg, types.MediaType("application/testing123"))
-	if err := remote.Write(rootRef, rootImg); err != nil {
-		t.Fatal(err)
-	}
-	rootDesc := descriptor(rootImg)
-	t.Logf("root image is %s", rootDesc.Digest)
+		// Push an image that refers to the root image as its subject.
+		leafRef, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf", u.Host))
+		if err != nil {
+			t.Fatal(err)
+		}
+		leafImg, err := random.Image(20, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		leafImg = mutate.ConfigMediaType(leafImg, types.MediaType("application/testing123"))
+		leafImg = mutate.Subject(leafImg, rootDesc).(v1.Image)
+		if err := remote.Write(leafRef, leafImg); err != nil {
+			t.Fatal(err)
+		}
+		leafDesc := descriptor(leafImg)
+		t.Logf("leaf image is %s", leafDesc.Digest)
 
-	// Push an image that refers to the root image as its subject.
-	leafRef, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf", u.Host))
-	if err != nil {
-		t.Fatal(err)
-	}
-	leafImg, err := random.Image(20, 20)
-	if err != nil {
-		t.Fatal(err)
-	}
-	leafImg = mutate.ConfigMediaType(leafImg, types.MediaType("application/testing123"))
-	leafImg = mutate.Subject(leafImg, rootDesc).(v1.Image)
-	if err := remote.Write(leafRef, leafImg); err != nil {
-		t.Fatal(err)
-	}
-	leafDesc := descriptor(leafImg)
-	t.Logf("leaf image is %s", leafDesc.Digest)
+		// Get the referrers of the root image, by digest.
+		rootRefDigest := rootRef.Context().Digest(rootDesc.Digest.String())
+		index, err := remote.Referrers(rootRefDigest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
+			t.Fatalf("referrers diff (-want,+got): %s", d)
+		}
 
-	// Get the referrers of the root image, by digest.
-	rootRefDigest := rootRef.Context().Digest(rootDesc.Digest.String())
-	index, err := remote.Referrers(rootRefDigest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
-		t.Fatalf("referrers diff (-want,+got): %s", d)
-	}
+		if leg.tryFallback {
+			// Get the referrers by querying the root image's fallback tag directly.
+			tag, err := name.ParseReference(fmt.Sprintf("%s/repo:sha256-%s", u.Host, rootDesc.Digest.Hex))
+			if err != nil {
+				t.Fatal(err)
+			}
+			idx, err := remote.Index(tag)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mf, err := idx.IndexManifest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := cmp.Diff(index.Manifests, mf.Manifests); d != "" {
+				t.Fatalf("fallback tag diff (-want,+got): %s", d)
+			}
+		}
 
-	// Get the referrers by querying the root image's fallback tag directly.
-	tag, err := name.ParseReference(fmt.Sprintf("%s/repo:sha256-%s", u.Host, rootDesc.Digest.Hex))
-	if err != nil {
-		t.Fatal(err)
-	}
-	idx, err := remote.Index(tag)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mf, err := idx.IndexManifest()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if d := cmp.Diff(index.Manifests, mf.Manifests); d != "" {
-		t.Fatalf("fallback tag diff (-want,+got): %s", d)
-	}
+		// Push the leaf image again, this time with a different tag.
+		// This shouldn't add another item to the root image's referrers,
+		// because it's the same digest.
+		// Push an image that refers to the root image as its subject.
+		leaf2Ref, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf2", u.Host))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := remote.Write(leaf2Ref, leafImg); err != nil {
+			t.Fatal(err)
+		}
+		// Get the referrers of the root image again, which should only have one entry.
+		rootRefDigest = rootRef.Context().Digest(rootDesc.Digest.String())
+		index, err = remote.Referrers(rootRefDigest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
+			t.Fatalf("referrers diff after second push (-want,+got): %s", d)
+		}
 
-	// Push the leaf image again, this time with a different tag.
-	// This shouldn't add another item to the root image's referrers,
-	// because it's the same digest.
-	// Push an image that refers to the root image as its subject.
-	leaf2Ref, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf2", u.Host))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := remote.Write(leaf2Ref, leafImg); err != nil {
-		t.Fatal(err)
-	}
-	// Get the referrers of the root image again, which should only have one entry.
-	rootRefDigest = rootRef.Context().Digest(rootDesc.Digest.String())
-	index, err = remote.Referrers(rootRefDigest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if d := cmp.Diff([]v1.Descriptor{leafDesc}, index.Manifests); d != "" {
-		t.Fatalf("referrers diff after second push (-want,+got): %s", d)
-	}
+		// Try applying filters and verify number of manifests and and annotations
+		index, err = remote.Referrers(rootRefDigest,
+			remote.WithFilter("artifactType", "application/testing123"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if numManifests := len(index.Manifests); numManifests == 0 {
+			t.Fatal("index contained 0 manifests")
+		}
 
-	// Try applying filters and verify number of manifests and and annotations
-	index, err = remote.Referrers(rootRefDigest,
-		remote.WithFilter("artifactType", "application/testing123"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if numManifests := len(index.Manifests); numManifests == 0 {
-		t.Fatal("index contained 0 manifests")
-	}
-
-	index, err = remote.Referrers(rootRefDigest,
-		remote.WithFilter("artifactType", "application/testing123BADDDD"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if numManifests := len(index.Manifests); numManifests != 0 {
-		t.Fatalf("expected index to contain 0 manifests, but had %d", numManifests)
+		index, err = remote.Referrers(rootRefDigest,
+			remote.WithFilter("artifactType", "application/testing123BADDDD"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if numManifests := len(index.Manifests); numManifests != 0 {
+			t.Fatalf("expected index to contain 0 manifests, but had %d", numManifests)
+		}
 	}
 }

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -580,19 +580,40 @@ func unpackTaggable(t Taggable) ([]byte, *v1.Descriptor, error) {
 }
 
 // commitSubjectReferrers is responsible for updating the fallback tag manifest to track descriptors referring to a subject for registries that don't yet support the Referrers API.
-// TODO: this method only uses the fallback tag for now
 // TODO: use conditional requests to avoid race conditions
 func (w *writer) commitSubjectReferrers(ctx context.Context, sub name.Digest, add v1.Descriptor) error {
-	// The registry doesn't support Referrers API, we need to update the manifest tagged with the fallback tag.
-	// Make the request to GET the current manifest.
-	t := fallbackTag(sub)
-	u := w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.repo.RepositoryStr(), t.Identifier()))
+	// Check if the registry supports Referrers API.
+	// TODO: This should be done once per registry, not once per subject.
+	u := w.url(fmt.Sprintf("/v2/%s/referrers/%s", w.repo.RepositoryStr(), sub.DigestStr()))
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Accept", string(types.OCIImageIndex))
 	resp, err := w.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound, http.StatusBadRequest); err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusOK {
+		// The registry supports Referrers API. The registry is responsible for updating the referrers list.
+		return nil
+	}
+
+	// The registry doesn't support Referrers API, we need to update the manifest tagged with the fallback tag.
+	// Make the request to GET the current manifest.
+	t := fallbackTag(sub)
+	u = w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.repo.RepositoryStr(), t.Identifier()))
+	req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", string(types.OCIImageIndex))
+	resp, err = w.client.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Follow-up to #1543, use the referrers API endpoint if the registry supports it, otherwise fallback to digest tag