### PR TITLE
fix(mutate): also set timestamps only present in some formats

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -437,6 +437,13 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 		}
 
 		header.ModTime = t
+
+		//PAX and GNU Format support additional timestamps in the header
+		if header.Format == tar.FormatPAX || header.Format == tar.FormatGNU {
+			header.AccessTime = t
+			header.ChangeTime = t
+		}
+
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return nil, fmt.Errorf("writing tar header: %w", err)
 		}


### PR DESCRIPTION
fixes #1523 

Currently, layerTime only mutates the modification timestamp which is present in all tar formats. When working with layers GNU or PAX header formats, access and change timestamps are also generated/recorded. This breaks functionality like reproducible builds which rely on having control over all variable fields (esp. timestamps)  in the layers

This commit adds a special case to the layerTime(Layer, Time) function which will also set the additional timestamps if the header is of GNU or PAX format

Signed-off-by: Joel Pepper <pepper@bronze-deer.de>