### PR TITLE
Implement crane index subcommand

### DIFF
--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -1,0 +1,259 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdIndex creates a new cobra.Command for the index subcommand.
+func NewCmdIndex(options *[]crane.Option) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "index",
+		Short: "Modify an image index.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Usage()
+		},
+	}
+	cmd.AddCommand(NewCmdIndexFilter(options), NewCmdIndexAppend(options))
+	return cmd
+}
+
+// NewCmdIndexFilter creates a new cobra.Command for the index filter subcommand.
+func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
+	var newTag string
+	platforms := &platformsValue{}
+
+	cmd := &cobra.Command{
+		Use:   "filter",
+		Short: "Modifies a remote index by filtering based on platform.",
+		Example: `  # Filter out weird platforms from ubuntu, copy result to example.com/ubuntu
+  crane index filter ubuntu --platform linux/amd64 --platform linux/arm64 -t example.com/ubuntu
+
+  # Filter out any non-linux platforms, push to example.com/hello-world
+  crane index filter hello-world --platform linux -t example.com/hello-world
+
+  # Same as above, but in-place
+  crane index filter example.com/hello-world:some-tag --platform linux`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			o := crane.GetOptions(*options...)
+			baseRef := args[0]
+
+			ref, err := name.ParseReference(baseRef)
+			if err != nil {
+				return err
+			}
+			base, err := remote.Index(ref, o.Remote...)
+			if err != nil {
+				return fmt.Errorf("pulling %s: %w", baseRef, err)
+			}
+
+			idx := filterIndex(base, platforms.platforms)
+
+			digest, err := idx.Digest()
+			if err != nil {
+				return err
+			}
+
+			if newTag != "" {
+				ref, err = name.ParseReference(newTag)
+				if err != nil {
+					return fmt.Errorf("parsing reference %s: %w", newTag, err)
+				}
+			} else {
+				if _, ok := ref.(name.Digest); ok {
+					ref = ref.Context().Digest(digest.String())
+				}
+			}
+
+			if err := remote.WriteIndex(ref, idx, o.Remote...); err != nil {
+				return fmt.Errorf("pushing image %s: %w", newTag, err)
+			}
+			fmt.Println(ref.Context().Digest(digest.String()))
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&newTag, "tag", "t", "", "Tag to apply to resulting image")
+
+	// Consider reusing the persistent flag for this, it's separate so we can have multiple values.
+	cmd.Flags().Var(platforms, "platform", "Specifies the platform(s) to keep from base in the form os/arch[/variant][:osversion][,<platform>] (e.g. linux/amd64).")
+
+	return cmd
+}
+
+// NewCmdIndexAppend creates a new cobra.Command for the index append subcommand.
+func NewCmdIndexAppend(options *[]crane.Option) *cobra.Command {
+	var baseRef, newTag string
+	var newManifests []string
+	var dockerEmptyBase bool
+
+	cmd := &cobra.Command{
+		Use:   "append",
+		Short: "Append manifests to a remote index.",
+		Long: `This sub-command pushes an index based on an (optional) base index, with appended manifests.
+
+The platform for appended manifests is inferred from the config file or omitted if that is infeasible.`,
+		Example: ` # Append a windows hello-world image to ubuntu, push to example.com/hello-world:weird
+  crane index append ubuntu -m hello-world@sha256:87b9ca29151260634b95efb84d43b05335dc3ed36cc132e2b920dd1955342d20 -t example.com/hello-world:weird
+
+  # Create an index from scratch for etcd.
+  crane index append -m registry.k8s.io/etcd-amd64:3.4.9 -m registry.k8s.io/etcd-arm64:3.4.9 -t example.com/etcd`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				baseRef = args[0]
+			}
+			o := crane.GetOptions(*options...)
+
+			var (
+				base v1.ImageIndex
+				err  error
+				ref  name.Reference
+			)
+
+			if baseRef == "" {
+				if newTag == "" {
+					return errors.New("at least one of --base or --tag must be specified")
+				}
+
+				logs.Warn.Printf("base unspecified, using empty index")
+				base = empty.Index
+				if dockerEmptyBase {
+					base = mutate.IndexMediaType(base, types.DockerManifestList)
+				}
+			} else {
+				ref, err = name.ParseReference(baseRef)
+				if err != nil {
+					return err
+				}
+				base, err = remote.Index(ref, o.Remote...)
+				if err != nil {
+					return fmt.Errorf("pulling %s: %w", baseRef, err)
+				}
+			}
+
+			adds := make([]mutate.IndexAddendum, 0, len(newManifests))
+
+			for _, m := range newManifests {
+				ref, err := name.ParseReference(m)
+				if err != nil {
+					return err
+				}
+				desc, err := remote.Get(ref, o.Remote...)
+				if err != nil {
+					return err
+				}
+				if desc.MediaType.IsImage() {
+					img, err := desc.Image()
+					if err != nil {
+						return err
+					}
+
+					cf, err := img.ConfigFile()
+					if err != nil {
+						return err
+					}
+					newDesc, err := partial.Descriptor(img)
+					if err != nil {
+						return err
+					}
+					newDesc.Platform = cf.Platform()
+					adds = append(adds, mutate.IndexAddendum{
+						Add:        img,
+						Descriptor: *newDesc,
+					})
+				} else if desc.MediaType.IsIndex() {
+					idx, err := desc.ImageIndex()
+					if err != nil {
+						return err
+					}
+					adds = append(adds, mutate.IndexAddendum{
+						Add: idx,
+					})
+				} else {
+					return fmt.Errorf("saw unexpected MediaType %q for %q", desc.MediaType, m)
+				}
+			}
+
+			idx := mutate.AppendManifests(base, adds...)
+			digest, err := idx.Digest()
+			if err != nil {
+				return err
+			}
+
+			if newTag != "" {
+				ref, err = name.ParseReference(newTag)
+				if err != nil {
+					return fmt.Errorf("parsing reference %s: %w", newTag, err)
+				}
+			} else {
+				if _, ok := ref.(name.Digest); ok {
+					ref = ref.Context().Digest(digest.String())
+				}
+			}
+
+			if err := remote.WriteIndex(ref, idx, o.Remote...); err != nil {
+				return fmt.Errorf("pushing image %s: %w", newTag, err)
+			}
+			fmt.Println(ref.Context().Digest(digest.String()))
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&newTag, "tag", "t", "", "Tag to apply to resulting image")
+	cmd.Flags().StringSliceVarP(&newManifests, "manifest", "m", []string{}, "References to manifests to append to the base index")
+	cmd.Flags().BoolVar(&dockerEmptyBase, "docker-empty-base", false, "If true, empty base index will have Docker media types instead of OCI")
+
+	return cmd
+}
+
+func filterIndex(idx v1.ImageIndex, platforms []v1.Platform) v1.ImageIndex {
+	matcher := not(satisfiesPlatforms(platforms))
+	return mutate.RemoveManifests(idx, matcher)
+}
+
+func satisfiesPlatforms(platforms []v1.Platform) match.Matcher {
+	return func(desc v1.Descriptor) bool {
+		if desc.Platform == nil {
+			return false
+		}
+		for _, p := range platforms {
+			if desc.Platform.Satisfies(p) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func not(in match.Matcher) match.Matcher {
+	return func(desc v1.Descriptor) bool {
+		return !in(desc)
+	}
+}

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -106,6 +106,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 		cmd.NewCmdEdit(&options),
 		NewCmdExport(&options),
 		NewCmdFlatten(&options),
+		NewCmdIndex(&options),
 		NewCmdList(&options),
 		NewCmdManifest(&options),
 		NewCmdMutate(&options),

--- a/cmd/crane/cmd/util.go
+++ b/cmd/crane/cmd/util.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -75,14 +74,7 @@ func platformToString(p *v1.Platform) string {
 	if p == nil {
 		return "all"
 	}
-	platform := ""
-	if p.OS != "" && p.Architecture != "" {
-		platform = p.OS + "/" + p.Architecture
-	}
-	if p.Variant != "" {
-		platform += "/" + p.Variant
-	}
-	return platform
+	return p.String()
 }
 
 func parsePlatform(platform string) (*v1.Platform, error) {
@@ -90,26 +82,5 @@ func parsePlatform(platform string) (*v1.Platform, error) {
 		return nil, nil
 	}
 
-	p := &v1.Platform{}
-
-	parts := strings.SplitN(platform, ":", 2)
-	if len(parts) == 2 {
-		p.OSVersion = parts[1]
-	}
-
-	parts = strings.Split(parts[0], "/")
-
-	if len(parts) > 3 {
-		return nil, fmt.Errorf("failed to parse platform '%s': too many slashes", platform)
-	}
-
-	p.OS = parts[0]
-	if len(parts) > 1 {
-		p.Architecture = parts[1]
-	}
-	if len(parts) > 2 {
-		p.Variant = parts[2]
-	}
-
-	return p, nil
+	return v1.ParsePlatform(platform)
 }

--- a/cmd/crane/cmd/util.go
+++ b/cmd/crane/cmd/util.go
@@ -21,6 +21,35 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+type platformsValue struct {
+	platforms []v1.Platform
+}
+
+func (ps *platformsValue) Set(platform string) error {
+	if ps.platforms == nil {
+		ps.platforms = []v1.Platform{}
+	}
+	p, err := parsePlatform(platform)
+	if err != nil {
+		return err
+	}
+	pv := platformValue{p}
+	ps.platforms = append(ps.platforms, *pv.platform)
+	return nil
+}
+
+func (ps *platformsValue) String() string {
+	ss := make([]string, 0, len(ps.platforms))
+	for _, p := range ps.platforms {
+		ss = append(ss, p.String())
+	}
+	return strings.Join(ss, ",")
+}
+
+func (ps *platformsValue) Type() string {
+	return "platform(s)"
+}
+
 type platformValue struct {
 	platform *v1.Platform
 }
@@ -70,15 +99,14 @@ func parsePlatform(platform string) (*v1.Platform, error) {
 
 	parts = strings.Split(parts[0], "/")
 
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("failed to parse platform '%s': expected format os/arch[/variant]", platform)
-	}
 	if len(parts) > 3 {
 		return nil, fmt.Errorf("failed to parse platform '%s': too many slashes", platform)
 	}
 
 	p.OS = parts[0]
-	p.Architecture = parts[1]
+	if len(parts) > 1 {
+		p.Architecture = parts[1]
+	}
 	if len(parts) > 2 {
 		p.Variant = parts[2]
 	}

--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -28,6 +28,7 @@ crane [flags]
 * [crane digest](crane_digest.md)	 - Get the digest of an image
 * [crane export](crane_export.md)	 - Export filesystem of a container image as a tarball
 * [crane flatten](crane_flatten.md)	 - Flatten an image's layers into a single layer
+* [crane index](crane_index.md)	 - Modify an image index.
 * [crane ls](crane_ls.md)	 - List the tags in a repo
 * [crane manifest](crane_manifest.md)	 - Get the manifest of an image
 * [crane mutate](crane_mutate.md)	 - Modify image labels and annotations. The container must be pushed to a registry, and the manifest is updated there.

--- a/cmd/crane/doc/crane_index.md
+++ b/cmd/crane/doc/crane_index.md
@@ -1,0 +1,29 @@
+## crane index
+
+Modify an image index.
+
+```
+crane index [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for index
+```
+
+### Options inherited from parent commands
+
+```
+      --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --insecure                           Allow image references to be fetched without TLS
+      --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
+  -v, --verbose                            Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane](crane.md)	 - Crane is a tool for managing container images
+* [crane index append](crane_index_append.md)	 - Append manifests to a remote index.
+* [crane index filter](crane_index_filter.md)	 - Modifies a remote index by filtering based on platform.
+

--- a/cmd/crane/doc/crane_index_append.md
+++ b/cmd/crane/doc/crane_index_append.md
@@ -1,0 +1,46 @@
+## crane index append
+
+Append manifests to a remote index.
+
+### Synopsis
+
+This sub-command pushes an index based on an (optional) base index, with appended manifests.
+
+The platform for appended manifests is inferred from the config file or omitted if that is infeasible.
+
+```
+crane index append [flags]
+```
+
+### Examples
+
+```
+ # Append a windows hello-world image to ubuntu, push to example.com/hello-world:weird
+  crane index append ubuntu -m hello-world@sha256:87b9ca29151260634b95efb84d43b05335dc3ed36cc132e2b920dd1955342d20 -t example.com/hello-world:weird
+
+  # Create an index from scratch for etcd.
+  crane index append -m registry.k8s.io/etcd-amd64:3.4.9 -m registry.k8s.io/etcd-arm64:3.4.9 -t example.com/etcd
+```
+
+### Options
+
+```
+      --docker-empty-base   If true, empty base index will have Docker media types instead of OCI
+  -h, --help                help for append
+  -m, --manifest strings    References to manifests to append to the base index
+  -t, --tag string          Tag to apply to resulting image
+```
+
+### Options inherited from parent commands
+
+```
+      --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --insecure                           Allow image references to be fetched without TLS
+      --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
+  -v, --verbose                            Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane index](crane_index.md)	 - Modify an image index.
+

--- a/cmd/crane/doc/crane_index_filter.md
+++ b/cmd/crane/doc/crane_index_filter.md
@@ -1,0 +1,41 @@
+## crane index filter
+
+Modifies a remote index by filtering based on platform.
+
+```
+crane index filter [flags]
+```
+
+### Examples
+
+```
+  # Filter out weird platforms from ubuntu, copy result to example.com/ubuntu
+  crane index filter ubuntu --platform linux/amd64 --platform linux/arm64 -t example.com/ubuntu
+
+  # Filter out any non-linux platforms, push to example.com/hello-world
+  crane index filter hello-world --platform linux -t example.com/hello-world
+
+  # Same as above, but in-place
+  crane index filter example.com/hello-world:some-tag --platform linux
+```
+
+### Options
+
+```
+  -h, --help                   help for filter
+      --platform platform(s)   Specifies the platform(s) to keep from base in the form os/arch[/variant][:osversion][,<platform>] (e.g. linux/amd64).
+  -t, --tag string             Tag to apply to resulting image
+```
+
+### Options inherited from parent commands
+
+```
+      --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --insecure                           Allow image references to be fetched without TLS
+  -v, --verbose                            Enable debug logs
+```
+
+### SEE ALSO
+
+* [crane index](crane_index.md)	 - Modify an image index.
+

--- a/cmd/crane/recipes.md
+++ b/cmd/crane/recipes.md
@@ -79,3 +79,27 @@ crane manifest gcr.io/buildpacks/builder:v1 | jq '.config.size + ([.layers[].siz
 ```
 
 For image indexes, you can pass the `--platform` flag to `crane` to get a platform-specific image.
+
+### Filter irrelevant platforms from a multi-platform image
+
+Perhaps you use a base image that supports a wide variety of exotic platforms, but you only care about linux/amd64 and linux/arm64.
+If you want to copy that base image into a different registry, you will end up with a bunch of images you don't use.
+You can filter the base to include only platforms that are relevant to you.
+
+```
+crane index filter ubuntu --platform linux/amd64 --platform linux/arm64 -t ${IMAGE}
+```
+
+Note that this will obviously modify the digest of the multi-platform image you're using, so this may invalidate other artifacts that reference it, e.g. signatures.
+
+### Create a multi-platform image from scratch
+
+If you have a bunch of platform-specific images that you want to turn into a multi-platform image, `crane index append` can do that:
+
+```
+crane index append -t ${IMAGE} \
+  -m ubuntu@sha256:c985bc3f77946b8e92c9a3648c6f31751a7dd972e06604785e47303f4ad47c4c \
+  -m ubuntu@sha256:61bd0b97000996232eb07b8d0e9375d14197f78aa850c2506417ef995a7199a7
+```
+
+Note that this is less flexible than [`manifest-tool`](https://github.com/estesp/manifest-tool) because it derives the platform from each image's config file, but it should work in most cases.

--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -38,6 +38,21 @@ type ConfigFile struct {
 	Config        Config    `json:"config"`
 	OSVersion     string    `json:"os.version,omitempty"`
 	Variant       string    `json:"variant,omitempty"`
+	OSFeatures    []string  `json:"os.features,omitempty"`
+}
+
+// Platform attempts to generates a Platform from the ConfigFile fields.
+func (cf *ConfigFile) Platform() *Platform {
+	if cf.OS == "" && cf.Architecture == "" && cf.OSVersion == "" && cf.Variant == "" && len(cf.OSFeatures) == 0 {
+		return nil
+	}
+	return &Platform{
+		OS:           cf.OS,
+		Architecture: cf.Architecture,
+		OSVersion:    cf.OSVersion,
+		Variant:      cf.Variant,
+		OSFeatures:   cf.OSFeatures,
+	}
 }
 
 // History is one entry of a list recording how this container image was built.

--- a/pkg/v1/platform.go
+++ b/pkg/v1/platform.go
@@ -85,6 +85,47 @@ func (p Platform) Equals(o Platform) bool {
 		stringSliceEqualIgnoreOrder(p.Features, o.Features)
 }
 
+// Satisfies returns true if this Platform "satisfies" the given spec Platform.
+//
+// Note that this is different from Equals and that Satisfies is not reflexive.
+//
+// The given spec represents "requirements" such that any missing values in the
+// spec are not compared.
+//
+// For OSFeatures and Features, Satisfies will return true if this Platform's
+// fields contain a superset of the values in the spec's fields (order ignored).
+func (p Platform) Satisfies(spec Platform) bool {
+	return satisfies(spec.OS, p.OS) &&
+		satisfies(spec.Architecture, p.Architecture) &&
+		satisfies(spec.Variant, p.Variant) &&
+		satisfies(spec.OSVersion, p.OSVersion) &&
+		satisfiesList(spec.OSFeatures, p.OSFeatures) &&
+		satisfiesList(spec.Features, p.Features)
+}
+
+func satisfies(want, have string) bool {
+	return want == "" || want == have
+}
+
+func satisfiesList(want, have []string) bool {
+	if len(want) == 0 {
+		return true
+	}
+
+	set := map[string]struct{}{}
+	for _, h := range have {
+		set[h] = struct{}{}
+	}
+
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // stringSliceEqual compares 2 string slices and returns if their contents are identical.
 func stringSliceEqual(a, b []string) bool {
 	if len(a) != len(b) {

--- a/pkg/v1/platform_test.go
+++ b/pkg/v1/platform_test.go
@@ -149,3 +149,87 @@ func TestPlatformEquals(t *testing.T) {
 		}
 	}
 }
+
+func TestPlatformSatisfies(t *testing.T) {
+	tests := []struct {
+		have, spec v1.Platform
+		sat        bool
+	}{{
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		v1.Platform{Architecture: "arm64", OS: "linux"},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		v1.Platform{Architecture: "amd64", OS: "darwin"},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSVersion: "5.0"},
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSVersion: "5.0"},
+		v1.Platform{Architecture: "amd64", OS: "linux", OSVersion: "3.6"},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Variant: "pios"},
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Variant: "pios"},
+		v1.Platform{Architecture: "amd64", OS: "linux", Variant: "ubuntu"},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Variant: "pios"},
+		v1.Platform{Architecture: "amd64", OS: "linux", Variant: "pios"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"ac", "bd"}},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", OSFeatures: []string{"b", "a"}},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		true,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"ac", "bd"}},
+		false,
+	}, {
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"a", "b"}},
+		v1.Platform{Architecture: "amd64", OS: "linux", Features: []string{"b", "a"}},
+		true,
+	}}
+	for i, tt := range tests {
+		if sat := tt.have.Satisfies(tt.spec); sat != tt.sat {
+			t.Errorf("%d: mismatched was %v expected %v; original (-want +got) %s", i, sat, tt.sat, cmp.Diff(tt.have, tt.spec))
+		}
+	}
+}


### PR DESCRIPTION
crane index filter allows platform-based filtering of manifests in an index. This is primarily useful for folks who want to use only some entries in a base image without having to copy irrelevant platforms.

crane index append allows appending manifests to an existing index or creating a new index from scratch.

Fixes https://github.com/google/go-containerregistry/issues/1144
Fixes https://github.com/google/go-containerregistry/issues/1143
Fixes https://github.com/google/go-containerregistry/issues/1557

See also:
* https://github.com/google/go-containerregistry/pull/891
* https://github.com/google/go-containerregistry/issues/1144#issuecomment-1044845681