### PR TITLE
crane: add --flatten for index append

### DIFF
--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -260,7 +260,7 @@ The platform for appended manifests is inferred from the config file or omitted 
 	cmd.Flags().StringVarP(&newTag, "tag", "t", "", "Tag to apply to resulting image")
 	cmd.Flags().StringSliceVarP(&newManifests, "manifest", "m", []string{}, "References to manifests to append to the base index")
 	cmd.Flags().BoolVar(&dockerEmptyBase, "docker-empty-base", false, "If true, empty base index will have Docker media types instead of OCI")
-	cmd.Flags().BoolVar(&flatten, "flatten", false, "If true, appending an index will append each of its children rather than the index itself")
+	cmd.Flags().BoolVar(&flatten, "flatten", true, "If true, appending an index will append each of its children rather than the index itself")
 
 	return cmd
 }

--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -112,7 +112,7 @@ func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
 func NewCmdIndexAppend(options *[]crane.Option) *cobra.Command {
 	var baseRef, newTag string
 	var newManifests []string
-	var dockerEmptyBase bool
+	var dockerEmptyBase, flatten bool
 
 	cmd := &cobra.Command{
 		Use:   "append",
@@ -194,9 +194,40 @@ The platform for appended manifests is inferred from the config file or omitted 
 					if err != nil {
 						return err
 					}
-					adds = append(adds, mutate.IndexAddendum{
-						Add: idx,
-					})
+					if flatten {
+						im, err := idx.IndexManifest()
+						if err != nil {
+							return err
+						}
+						for _, child := range im.Manifests {
+							switch {
+							case child.MediaType.IsImage():
+								img, err := idx.Image(child.Digest)
+								if err != nil {
+									return err
+								}
+								adds = append(adds, mutate.IndexAddendum{
+									Add:        img,
+									Descriptor: child,
+								})
+							case child.MediaType.IsIndex():
+								idx, err := idx.ImageIndex(child.Digest)
+								if err != nil {
+									return err
+								}
+								adds = append(adds, mutate.IndexAddendum{
+									Add:        idx,
+									Descriptor: child,
+								})
+							default:
+								return fmt.Errorf("unexpected child %q with media type %q", child.Digest, child.MediaType)
+							}
+						}
+					} else {
+						adds = append(adds, mutate.IndexAddendum{
+							Add: idx,
+						})
+					}
 				} else {
 					return fmt.Errorf("saw unexpected MediaType %q for %q", desc.MediaType, m)
 				}
@@ -229,6 +260,7 @@ The platform for appended manifests is inferred from the config file or omitted 
 	cmd.Flags().StringVarP(&newTag, "tag", "t", "", "Tag to apply to resulting image")
 	cmd.Flags().StringSliceVarP(&newManifests, "manifest", "m", []string{}, "References to manifests to append to the base index")
 	cmd.Flags().BoolVar(&dockerEmptyBase, "docker-empty-base", false, "If true, empty base index will have Docker media types instead of OCI")
+	cmd.Flags().BoolVar(&flatten, "flatten", false, "If true, appending an index will append each of its children rather than the index itself")
 
 	return cmd
 }

--- a/cmd/crane/doc/crane_index_append.md
+++ b/cmd/crane/doc/crane_index_append.md
@@ -26,7 +26,7 @@ crane index append [flags]
 
 ```
       --docker-empty-base   If true, empty base index will have Docker media types instead of OCI
-      --flatten             If true, appending an index will append each of its children rather than the index itself
+      --flatten             If true, appending an index will append each of its children rather than the index itself (default true)
   -h, --help                help for append
   -m, --manifest strings    References to manifests to append to the base index
   -t, --tag string          Tag to apply to resulting image

--- a/cmd/crane/doc/crane_index_append.md
+++ b/cmd/crane/doc/crane_index_append.md
@@ -26,6 +26,7 @@ crane index append [flags]
 
 ```
       --docker-empty-base   If true, empty base index will have Docker media types instead of OCI
+      --flatten             If true, appending an index will append each of its children rather than the index itself
   -h, --help                help for append
   -m, --manifest strings    References to manifests to append to the base index
   -t, --tag string          Tag to apply to resulting image

--- a/pkg/v1/zz_deepcopy_generated.go
+++ b/pkg/v1/zz_deepcopy_generated.go
@@ -99,6 +99,11 @@ func (in *ConfigFile) DeepCopyInto(out *ConfigFile) {
 	}
 	in.RootFS.DeepCopyInto(&out.RootFS)
 	in.Config.DeepCopyInto(&out.Config)
+	if in.OSFeatures != nil {
+		in, out := &in.OSFeatures, &out.OSFeatures
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
While it's possible that folks might want to append an index to an index, it's more likely that they would want to merge them. This flag gives them an option to do either.