### PR TITLE
docs: Update crane installation and verification instructions

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -10,38 +10,46 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 ## Installation
 
 ### Install from Releases
-1. Download [latest release](https://github.com/google/go-containerregistry/releases/latest):
+
+1. Get the [latest release](https://github.com/google/go-containerregistry/releases/latest) version.
 
 ```sh
-$ OS=Linux       # or Darwin, Windows
-$ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-$ curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+$ VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
 ```
 
-Download a specific version:
+or set a specific version:
+
+```sh
+$ VERSION=vX.Y.Z   # Version number with a leading v
 ```
-$ VERSION=TODO   # Version number without leading v
+
+1. Download the release.
+
+```sh
 $ OS=Linux       # or Darwin, Windows
 $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
 $ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
 ```
 
-2. Verify the signature
-We generate [SLSA 3 provenance](https://slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator). To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation) and verify as follows:
+1. Verify the signature. We generate [SLSA 3 provenance](https://slsa.dev) using
+   the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator).
+   To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation)
+   and verify as follows:
 
 ```sh
-$ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/attestation.intoto.jsonl > provenance.intoto.jsonl
-$ slsa-verifier -artifact-path go-containerregistry.tar.gz -provenance provenance.intoto.jsonl -source github.com/google/go-containerregistry -tag "v${VERSION}"
+$ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
+$ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
   PASSED: Verified SLSA provenance
 ```
 
-3. Unpack it in the PATH.
+1. Unpack it in the PATH.
 
 ```sh
 $ tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
 ```
 
 ### Install manually
+
 Install manually:
 
 ```sh

--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -13,40 +13,40 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 
 1. Get the [latest release](https://github.com/google/go-containerregistry/releases/latest) version.
 
-```sh
-$ VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
-```
+   ```sh
+   $ VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
+   ```
 
-or set a specific version:
+   or set a specific version:
 
-```sh
-$ VERSION=vX.Y.Z   # Version number with a leading v
-```
+   ```sh
+   $ VERSION=vX.Y.Z   # Version number with a leading v
+   ```
 
 1. Download the release.
 
-```sh
-$ OS=Linux       # or Darwin, Windows
-$ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-$ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
-```
+   ```sh
+   $ OS=Linux       # or Darwin, Windows
+   $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
+   $ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+   ```
 
 1. Verify the signature. We generate [SLSA 3 provenance](https://slsa.dev) using
    the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator).
    To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation)
    and verify as follows:
 
-```sh
-$ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
-$ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
-  PASSED: Verified SLSA provenance
-```
+   ```sh
+   $ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
+   $ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
+     PASSED: Verified SLSA provenance
+   ```
 
 1. Unpack it in the PATH.
 
-```sh
-$ tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
-```
+   ```sh
+   $ tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
+   ```
 
 ### Install manually
 

--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -28,7 +28,7 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
    ```sh
    $ OS=Linux       # or Darwin, Windows
    $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-   $ curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+   $ curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
    ```
 
 1. Verify the signature. We generate [SLSA 3 provenance](https://slsa.dev) using
@@ -37,7 +37,8 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
    and verify as follows:
 
    ```sh
-   $ curl -sL https://github.com/google/go-containerregistry/releases/download/v${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
+   $ curl -sL https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
+   $ # NOTE: You may be using a different architecture.
    $ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
      PASSED: Verified SLSA provenance
    ```


### PR DESCRIPTION
Fixes #1565 

1. Updates the slsa-verifier command to use v2.
2. Instructions now ensure you set the `VERSION` environment variable.

Signed-off-by: Ian Lewis ianlewis@google.com