### PR TITLE
copy: Add auth-pairs keychain to support multi-repo auth

### DIFF
--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -32,7 +32,7 @@ func NewCmdCopy(options *[]crane.Option) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
 
-			*options = append(*options, crane.WithAuthFromKeychain(authn.NewAuthPairsKeychain(authn.WithAuthPairs(authPairs.authPairs))))
+			*options = append(*options, crane.WithAuthFromKeychain(authn.NewAuthPairsKeychain(authPairs.authPairs)))
 
 			return crane.Copy(src, dst, *options...)
 		},

--- a/cmd/crane/cmd/util.go
+++ b/cmd/crane/cmd/util.go
@@ -15,8 +15,10 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -83,4 +85,25 @@ func parsePlatform(platform string) (*v1.Platform, error) {
 	}
 
 	return v1.ParsePlatform(platform)
+}
+
+type authPairsValue struct {
+	authPairs authn.AuthPairs
+}
+
+func (apv *authPairsValue) Set(authPair string) (err error) {
+	apv.authPairs, err = authn.ParseAuthPair(apv.authPairs, authPair)
+	return
+}
+
+func (apv *authPairsValue) String() string {
+	ss := make([]string, 0, len(apv.authPairs))
+	for k, v := range apv.authPairs {
+		ss = append(ss, fmt.Sprintf("%s:%s", k, v))
+	}
+	return strings.Join(ss, ",")
+}
+
+func (apv *authPairsValue) Type() string {
+	return "auth-pair(s)"
 }

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -68,27 +68,10 @@ type authPairsKeychain struct {
 
 var _ Keychain = (*authPairsKeychain)(nil)
 
-type authPairsKeychainOptions struct {
-	AuthPairs map[string]string
-}
-
-type AuthPairsKeychainOption func(options *authPairsKeychainOptions)
-
-func WithAuthPairs(ap map[string]string) AuthPairsKeychainOption {
-	return func(o *authPairsKeychainOptions) {
-		o.AuthPairs = ap
-	}
-}
-
-func NewAuthPairsKeychain(opts ...AuthPairsKeychainOption) Keychain {
-	o := &authPairsKeychainOptions{}
-	for _, opt := range opts {
-		opt(o)
-	}
-
+func NewAuthPairsKeychain(authPairs AuthPairs) Keychain {
 	return &authPairsKeychain{
 		cache:     make(map[string]Authenticator),
-		authPairs: o.AuthPairs,
+		authPairs: authPairs,
 	}
 }
 

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -90,7 +90,7 @@ func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 		return DefaultKeychain.Resolve(target)
 	}
 
-	dc := mk.authPairs.Dir(target)
+	dir := mk.authPairs.Dir(target)
 
 	var (
 		cf  *configfile.ConfigFile
@@ -98,13 +98,13 @@ func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 	)
 
 	// Check for Docker config file first, then for Podman auth file
-	if fileExists(filepath.Join(dc, config.ConfigFileName)) {
-		cf, err = config.Load(dc)
+	if fileExists(filepath.Join(dir, config.ConfigFileName)) {
+		cf, err = config.Load(dir)
 		if err != nil {
 			return nil, err
 		}
-	} else if podmanAuthFile := filepath.Join(dc, "auth.json"); fileExists(podmanAuthFile) {
-		cf, err = config.Load(dc)
+	} else if podmanAuthFile := filepath.Join(dir, "auth.json"); fileExists(podmanAuthFile) {
+		cf, err = config.Load(dir)
 		f, err := os.Open(podmanAuthFile)
 		if err != nil {
 			return nil, err

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -15,7 +15,6 @@
 package authn
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -99,22 +98,13 @@ func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 
 	// Check for Docker config file first, then for Podman auth file
 	if fileExists(filepath.Join(dir, config.ConfigFileName)) {
-		cf, err = config.Load(dir)
-		if err != nil {
-			return nil, err
-		}
+		cf, err = loadDockerConfig(dir)
 	} else if podmanAuthFile := filepath.Join(dir, "auth.json"); fileExists(podmanAuthFile) {
-		cf, err = config.Load(dir)
-		f, err := os.Open(podmanAuthFile)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
+		cf, err = loadPodmanConfig(podmanAuthFile)
+	}
 
-		cf, err = config.LoadFromReader(f)
-		if err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
 	}
 
 	if cf == nil {

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -77,19 +77,19 @@ func NewAuthPairsKeychain(authPairs AuthPairs) Keychain {
 	}
 }
 
-func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
-	mk.mu.Lock()
-	defer mk.mu.Unlock()
+func (apk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
+	apk.mu.Lock()
+	defer apk.mu.Unlock()
 
-	if authenticator, ok := mk.cache[target.String()]; ok {
+	if authenticator, ok := apk.cache[target.String()]; ok {
 		return authenticator, nil
 	}
 
-	if !mk.authPairs.Has(target) {
+	if !apk.authPairs.Has(target) {
 		return DefaultKeychain.Resolve(target)
 	}
 
-	dir := mk.authPairs.Dir(target)
+	dir := apk.authPairs.Dir(target)
 
 	var (
 		cf  *configfile.ConfigFile
@@ -116,7 +116,7 @@ func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 		return nil, err
 	}
 
-	mk.cache[target.String()] = auth
+	apk.cache[target.String()] = auth
 
 	return auth, nil
 }

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -40,7 +40,7 @@ func (ap AuthPairs) Has(target Resource) bool {
 	return ok
 }
 
-func (ap AuthPairs) GetDockerConfig(target Resource) string {
+func (ap AuthPairs) Dir(target Resource) string {
 	if ap == nil {
 		return ""
 	}
@@ -90,7 +90,7 @@ func (mk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 		return DefaultKeychain.Resolve(target)
 	}
 
-	dc := mk.authPairs.GetDockerConfig(target)
+	dc := mk.authPairs.Dir(target)
 
 	var (
 		cf  *configfile.ConfigFile

--- a/pkg/authn/authpairs_keychain.go
+++ b/pkg/authn/authpairs_keychain.go
@@ -107,11 +107,14 @@ func (apk *authPairsKeychain) Resolve(target Resource) (Authenticator, error) {
 		return nil, err
 	}
 
+	var auth Authenticator
+
 	if cf == nil {
-		return Anonymous, nil
+		auth, err = DefaultKeychain.Resolve(target)
+	} else {
+		auth, err = getAuthenticator(cf, target)
 	}
 
-	auth, err := getAuthenticator(cf, target)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authn/authpairs_keychain_test.go
+++ b/pkg/authn/authpairs_keychain_test.go
@@ -27,10 +27,13 @@ func TestAuthPairsKeychainResolvesWithAuthPairs(t *testing.T) {
 		repo2, _ = name.NewRepository("test.io/my-repo2", name.WeakValidation)
 		repo3, _ = name.NewRepository("test.io/my-repo3", name.WeakValidation)
 
-		// Set up the default docker config dir last, so DOCKER_CONFIG env var is set to an empty dir
 		cd1 = setupConfigFile(t, fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`, encode("user1", "pass1")))
-		cd2 = setupConfigFile(t, fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`, encode("user2", "pass2")))
-		_   = setupConfigDir(t)
+		cd2 = setupPodmanFile(t, fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`, encode("user2", "pass2"))) + "/containers"
+
+		// Set up the Docker and Podman dirs again.
+		// This way DOCKER_CONFIG and XDG_RUNTIME_DIR env vars are set to empty dirs
+		_ = setupConfigDir(t)
+		_ = setupPodmanDir(t)
 	)
 
 	kc := NewAuthPairsKeychain(map[string]string{

--- a/pkg/authn/authpairs_keychain_test.go
+++ b/pkg/authn/authpairs_keychain_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestAuthPairsKeychainResolvesWithAuthPairs(t *testing.T) {
+	var (
+		repo1, _ = name.NewRepository("test.io/my-repo1", name.WeakValidation)
+		repo2, _ = name.NewRepository("test.io/my-repo2", name.WeakValidation)
+		repo3, _ = name.NewRepository("test.io/my-repo3", name.WeakValidation)
+
+		// Set up the default docker config dir last, so DOCKER_CONFIG env var is set to an empty dir
+		cd1 = setupConfigFile(t, fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`, encode("user1", "pass1")))
+		cd2 = setupConfigFile(t, fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`, encode("user2", "pass2")))
+		_   = setupConfigDir(t)
+	)
+
+	kc := NewAuthPairsKeychain(WithAuthPairs(map[string]string{
+		repo1.String(): cd1,
+		repo2.String(): cd2,
+	}))
+
+	checkResolveRepo := func(t *testing.T, repo name.Repository, want string) {
+		t.Helper()
+
+		auth, err := kc.Resolve(repo)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", repo, err)
+		}
+
+		if want == "" {
+			if auth != Anonymous {
+				t.Errorf("expected Anonymous, got %v", auth)
+			}
+			return
+		}
+
+		cfg, err := auth.Authorization()
+		if err != nil {
+			t.Fatalf("Authorization: %v", err)
+		}
+		if got := fmt.Sprintf("%s:%s", cfg.Username, cfg.Password); got != want {
+			t.Errorf("Auth: got %q, want %q", got, want)
+		}
+	}
+
+	checkResolveRepo(t, repo1, "user1:pass1")
+	checkResolveRepo(t, repo2, "user2:pass2")
+	checkResolveRepo(t, repo3, "")
+}

--- a/pkg/authn/authpairs_keychain_test.go
+++ b/pkg/authn/authpairs_keychain_test.go
@@ -33,10 +33,10 @@ func TestAuthPairsKeychainResolvesWithAuthPairs(t *testing.T) {
 		_   = setupConfigDir(t)
 	)
 
-	kc := NewAuthPairsKeychain(WithAuthPairs(map[string]string{
+	kc := NewAuthPairsKeychain(map[string]string{
 		repo1.String(): cd1,
 		repo2.String(): cd2,
-	}))
+	})
 
 	checkResolveRepo := func(t *testing.T, repo name.Repository, want string) {
 		t.Helper()

--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -107,10 +107,18 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 		}
 	}
 
+	return getAuthenticator(cf, target)
+}
+
+func getAuthenticator(cf *configfile.ConfigFile, target Resource) (Authenticator, error) {
+	var (
+		err        error
+		cfg, empty types.AuthConfig
+	)
+
 	// See:
 	// https://github.com/google/ko/issues/90
 	// https://github.com/moby/moby/blob/fc01c2b481097a6057bec3cd1ab2d7b4488c50c4/registry/config.go#L397-L404
-	var cfg, empty types.AuthConfig
 	for _, key := range []string{
 		target.String(),
 		target.RegistryStr(),
@@ -131,6 +139,7 @@ func (dk *defaultKeychain) Resolve(target Resource) (Authenticator, error) {
 			break
 		}
 	}
+
 	if cfg == empty {
 		return Anonymous, nil
 	}

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -77,6 +77,32 @@ func setupConfigFile(t *testing.T, content string) string {
 	return cd
 }
 
+func setupPodmanDir(t *testing.T) string {
+	tmpdir := os.Getenv("TEST_TMPDIR")
+	if tmpdir == "" {
+		tmpdir = t.TempDir()
+	}
+
+	fresh++
+	p := filepath.Join(tmpdir, fmt.Sprintf("%d", fresh))
+	t.Logf("XDG_RUNTIME_DIR=%s", p)
+	t.Setenv("XDG_RUNTIME_DIR", p)
+	if err := os.MkdirAll(filepath.Join(p, "containers"), 0777); err != nil {
+		t.Fatalf("mkdir %s/containers: %v", p, err)
+	}
+	return p
+}
+
+func setupPodmanFile(t *testing.T, content string) string {
+	cd := setupPodmanDir(t)
+	p := filepath.Join(cd, "containers/auth.json")
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatalf("write %q: %v", p, err)
+	}
+
+	return cd
+}
+
 func TestNoConfig(t *testing.T) {
 	cd := setupConfigDir(t)
 	defer os.RemoveAll(filepath.Dir(cd))


### PR DESCRIPTION
Signed-off-by: Joseda Rios <jdrios@vmware.com>

This PR adds a new `Keychain` to handle multiple repository authentication. See https://github.com/google/go-containerregistry/issues/1329.

The underlying implementation caches `Authenticator`s after a target is attempted to be resolved to avoid unnecessary I/O. It also fallbacks to the `DefaultKeychain` if no auth pairs match the target.

This is useful when a process requires using different auth for the same registry (host). For example, today is not possible to copy an image between two different GCR projects unless your service account has Reader/Writer roles in both projects, which is unlikely.

## Current Behavior

`crane` fails accessing the destination repository.

```shell
❯ crane auth login -u _json_key -p "$(cat jotadrilo-svc-account.json)" gcr.io
2023/02/22 20:13:46 logged in via /Users/jotadrilo/.docker/config.json

❯ crane \
     copy \
     gcr.io/jotadrilo/demo/busybox:latest \
     gcr.io/jotadrilo2/demo/busybox:test

2023/02/22 20:10:31 Copying from gcr.io/jotadrilo/demo/busybox:latest to gcr.io/jotadrilo2/demo/busybox:test
Error: failed to copy index: GET https://gcr.io/v2/token?scope=repository%3Ajotadrilo2%2Fdemo%2Fbusybox%3Apush%2Cpull&service=gcr.io: DENIED: Token exchange failed for project 'jotadrilo2'. Caller does not have permission 'storage.buckets.get'. To configure permissions, follow instructions at: https://cloud.google.com/container-registry/docs/access-control
exit status 1
```

## New Behavior

`crane` copies the image successfully.

```shell
❯ crane auth login -u _json_key -p "$(cat jotadrilo-svc-account.json)" gcr.io
2023/02/22 20:13:46 logged in via /Users/jotadrilo/.docker/config.json

❯ DOCKER_CONFIG="${PWD}/jotadrilo2" crane auth login -u _json_key -p "$(cat jotadrilo2-svc-account.json)" gcr.io
2023/02/22 20:13:46 logged in via /Users/jotadrilo/personal/go-containerregistry/cmd/crane/jotadrilo2/config.json

❯ crane \
      copy \
      gcr.io/jotadrilo/demo/busybox:latest \
      gcr.io/jotadrilo2/demo/busybox:test \
      --auth-pair gcr.io/jotadrilo2/demo/busybox:jotadrilo2

2023/02/22 20:20:24 Copying from gcr.io/jotadrilo/demo/busybox:latest to gcr.io/jotadrilo2/demo/busybox:test
2023/02/22 21:00:18 existing blob: sha256:f78e6840ded1aafb6c9f265f52c2fc7c0a990813ccf96702df84a7dcdbe48bea
2023/02/22 21:00:20 pushed blob: sha256:c00904b679bb7edaf852620402b7eb164ceea14d9338240addfed833061c36ca
2023/02/22 21:00:22 gcr.io/jotadrilo2/demo/busybox@sha256:7b74ce83a3a90d10e9b4c7473dd3dbec515a409b0cedfb0de342832bb582c26e: digest: sha256:7b74ce83a3a90d10e9b4c7473dd3dbec515a409b0cedfb0de342832bb582c26e size: 502
2023/02/22 21:00:23 existing blob: sha256:205dae5015e78dd8c4d302e3db4eb31576fac715b46d099fe09680ba28093a7a
2023/02/22 21:00:26 pushed blob: sha256:04bfb6f8e19b909595598e4a8f068f337df3a299b637daaf937fb80e004dfae2
2023/02/22 21:00:27 gcr.io/jotadrilo2/demo/busybox@sha256:417bf965b4178fd94d3cbaf8e16b3c3a500e2b2cca000e8fe9a24e8403bbfbe9: digest: sha256:417bf965b4178fd94d3cbaf8e16b3c3a500e2b2cca000e8fe9a24e8403bbfbe9 size: 502
2023/02/22 20:20:27 gcr.io/jotadrilo2/demo/busybox:test: digest: sha256:7d80e0e207005f658e9b6ddffa577f2d1ddc1f7c9f7da3f0c2bec99f01bfdbd9 size: 683
```
