### PR TITLE
verify provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,15 @@ jobs:
       - name: Download assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
         run: |
           set -euo pipefail
           gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
-          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "multiple.intoto.jsonl"
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p $PROVENANCE
       - name: Verify assets
         env:
           CHECKSUMS: ${{ needs.goreleaser.outputs.hashes }}
-          PROVENANCE: "${{ needs.provenance.outputs.attestation-name }}"
+          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
         run: |
           set -euo pipefail
           checksums=$(echo "$CHECKSUMS" | base64 -d)


### PR DESCRIPTION
* upgrade the slsa-verifier installer action to the latest v2.1.0
* use the `PROVENANCE` variable in the `Download Assets` stage to avoid having hardcoded naming
* [`attestation-name` is now deprecated, we should use `provenance-name` instead.](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#workflow-outputs)

PTAL @jonjohnsonjr @imjasonh 