### PR TITLE
retry HTTP 499 errors by default

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -89,6 +89,7 @@ var retryableStatusCodes = []int{
 	http.StatusBadGateway,
 	http.StatusServiceUnavailable,
 	http.StatusGatewayTimeout,
+	499,
 }
 
 const (


### PR DESCRIPTION
HTTP 499 is a status code that nginx made up to indicate the client hung up before the server responded. See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#nginx

We're seeing this response relatively often coming from blob requests to Cloudflare R2, and retrying in general seems to work just fine.

If a 499 is encountered multiple times, the overall blob request will still fail, so a persistent 499 issue should be surfaced to the user after a brief delay, just like with 502, etc.

Since it's unofficial there's no Go const for 499. See https://pkg.go.dev/net/http#pkg-constants

