### PR TITLE
Refresh authn.DefaultKeychain creds every 5 min

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
@@ -52,7 +53,7 @@ type defaultKeychain struct {
 
 var (
 	// DefaultKeychain implements Keychain by interpreting the docker config file.
-	DefaultKeychain Keychain = &defaultKeychain{}
+	DefaultKeychain = RefreshingKeychain(&defaultKeychain{}, 5*time.Minute)
 )
 
 const (
@@ -177,4 +178,72 @@ func (w wrapper) Resolve(r Resource) (Authenticator, error) {
 		return FromConfig(AuthConfig{Username: u, IdentityToken: p}), nil
 	}
 	return FromConfig(AuthConfig{Username: u, Password: p}), nil
+}
+
+func RefreshingKeychain(inner Keychain, duration time.Duration) Keychain {
+	return &refreshingKeychain{
+		keychain: inner,
+		duration: duration,
+	}
+}
+
+type refreshingKeychain struct {
+	keychain Keychain
+	duration time.Duration
+	clock    func() time.Time
+}
+
+func (r *refreshingKeychain) Resolve(target Resource) (Authenticator, error) {
+	last := time.Now()
+	auth, err := r.keychain.Resolve(target)
+	if err != nil || auth == Anonymous {
+		return auth, err
+	}
+	return &refreshing{
+		target:   target,
+		keychain: r.keychain,
+		last:     last,
+		cached:   auth,
+		duration: r.duration,
+		clock:    r.clock,
+	}, nil
+}
+
+type refreshing struct {
+	sync.Mutex
+	target   Resource
+	keychain Keychain
+
+	duration time.Duration
+
+	last   time.Time
+	cached Authenticator
+
+	// for testing
+	clock func() time.Time
+}
+
+func (r *refreshing) Authorization() (*AuthConfig, error) {
+	r.Lock()
+	defer r.Unlock()
+	if r.cached == nil || r.expired() {
+		r.last = r.now()
+		auth, err := r.keychain.Resolve(r.target)
+		if err != nil {
+			return nil, err
+		}
+		r.cached = auth
+	}
+	return r.cached.Authorization()
+}
+
+func (r *refreshing) now() time.Time {
+	if r.clock == nil {
+		return time.Now()
+	}
+	return r.clock()
+}
+
+func (r *refreshing) expired() bool {
+	return r.now().Sub(r.last) > r.duration
 }


### PR DESCRIPTION
Sometimes Authenticators stick around for a while and eventually expire. This changes modifies Authenticators returned by DefaultKeychain to re-resolve after 5 minutes to ensure the underlying creds are fresh.

The hard-coded 5 minutes should prevent us from spamming the underlying Keychain (it can be expensive) while also preventing the creds from expiring.