### PR TITLE
Add partial.Manifests for lazy index access

### DIFF
--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -123,22 +123,13 @@ func push(flat partial.Describable, ref name.Reference, o crane.Options) error {
 	return fmt.Errorf("can't push %T", flat)
 }
 
-type remoteIndex interface {
-	Manifests() ([]partial.Describable, error)
-}
-
 func flattenIndex(old v1.ImageIndex, repo name.Repository, use string, o crane.Options) (partial.Describable, error) {
-	ri, ok := old.(remoteIndex)
-	if !ok {
-		return nil, fmt.Errorf("unexpected index")
-	}
-
 	m, err := old.IndexManifest()
 	if err != nil {
 		return nil, err
 	}
 
-	manifests, err := ri.Manifests()
+	manifests, err := partial.Manifests(old)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -16,6 +16,7 @@ package mutate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -23,6 +24,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -207,4 +209,24 @@ func (i *index) RawManifest() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(i.manifest)
+}
+
+func (i *index) Manifests() ([]partial.Describable, error) {
+	if err := i.compute(); errors.Is(err, stream.ErrNotComputed) {
+		// Index contains a streamable layer which has not yet been
+		// consumed. Just return the manifests we have in case the caller
+		// is going to consume the streamable layers.
+		manifests, err := partial.Manifests(i.base)
+		if err != nil {
+			return nil, err
+		}
+		for _, add := range i.adds {
+			manifests = append(manifests, add.Add)
+		}
+		return manifests, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return partial.ComputeManifests(i)
 }

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -148,40 +148,6 @@ func (r *remoteIndex) Layer(h v1.Hash) (v1.Layer, error) {
 	return nil, fmt.Errorf("layer not found: %s", h)
 }
 
-// Experiment with a better API for v1.ImageIndex. We might want to move this
-// to partial?
-func (r *remoteIndex) Manifests() ([]partial.Describable, error) {
-	m, err := r.IndexManifest()
-	if err != nil {
-		return nil, err
-	}
-	manifests := []partial.Describable{}
-	for _, desc := range m.Manifests {
-		switch {
-		case desc.MediaType.IsImage():
-			img, err := r.Image(desc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			manifests = append(manifests, img)
-		case desc.MediaType.IsIndex():
-			idx, err := r.ImageIndex(desc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			manifests = append(manifests, idx)
-		default:
-			layer, err := r.Layer(desc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			manifests = append(manifests, layer)
-		}
-	}
-
-	return manifests, nil
-}
-
 func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
 	desc, err := r.childByPlatform(platform)
 	if err != nil {


### PR DESCRIPTION
This allows us to manipulate an index that contains an image that contains a streaming layer.