### PR TITLE
Implement remote.Pusher

### DIFF
--- a/pkg/v1/remote/multi_write.go
+++ b/pkg/v1/remote/multi_write.go
@@ -15,277 +15,32 @@
 package remote
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/partial"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
 )
 
 // MultiWrite writes the given Images or ImageIndexes to the given refs, as
-// efficiently as possible, by deduping shared layer blobs and uploading layers
-// in parallel, then uploading all manifests in parallel.
-//
-// Current limitations:
-// - All refs must share the same repository.
-// - Images cannot consist of stream.Layers.
-func MultiWrite(m map[name.Reference]Taggable, options ...Option) (rerr error) {
-	// Determine the repository being pushed to; if asked to push to
-	// multiple repositories, give up.
-	var repo, zero name.Repository
-	for ref := range m {
-		if repo == zero {
-			repo = ref.Context()
-		} else if ref.Context() != repo {
-			return fmt.Errorf("MultiWrite can only push to the same repository (saw %q and %q)", repo, ref.Context())
-		}
-	}
-
+// efficiently as possible, by deduping shared layer blobs while uploading them
+// in parallel.
+func MultiWrite(todo map[name.Reference]Taggable, options ...Option) (rerr error) {
 	o, err := makeOptions(options...)
 	if err != nil {
 		return err
 	}
-
-	// Collect unique blobs (layers and config blobs).
-	blobs := map[v1.Hash]v1.Layer{}
-	newManifests := []map[name.Reference]Taggable{}
-	// Separate originally requested images and indexes, so we can push images first.
-	images, indexes := map[name.Reference]Taggable{}, map[name.Reference]Taggable{}
-	for ref, i := range m {
-		if img, ok := i.(v1.Image); ok {
-			images[ref] = i
-			if err := addImageBlobs(img, blobs, o.allowNondistributableArtifacts); err != nil {
-				return err
-			}
-			continue
-		}
-		if idx, ok := i.(v1.ImageIndex); ok {
-			indexes[ref] = i
-			newManifests, err = addIndexBlobs(idx, blobs, repo, newManifests, 0, o.allowNondistributableArtifacts)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		return fmt.Errorf("pushable resource was not Image or ImageIndex: %T", i)
+	if o.progress != nil {
+		defer func() { o.progress.Close(rerr) }()
 	}
+	p := newPusher(o)
 
-	// Determine if any of the layers are Mountable, because if so we need
-	// to request Pull scope too.
-	ls := []v1.Layer{}
-	for _, l := range blobs {
-		ls = append(ls, l)
-	}
-	w, err := makeWriter(o.context, repo, ls, o)
-	if err != nil {
-		return err
-	}
+	g, ctx := errgroup.WithContext(o.context)
+	g.SetLimit(o.jobs)
 
-	// Collect the total size of blobs and manifests we're about to write.
-	if w.progress != nil {
-		defer func() { w.progress.Close(rerr) }()
-
-		for _, b := range blobs {
-			size, err := b.Size()
-			if err != nil {
-				return err
-			}
-			w.progress.total(size)
-		}
-		countManifest := func(t Taggable) error {
-			b, err := t.RawManifest()
-			if err != nil {
-				return err
-			}
-			w.progress.total(int64(len(b)))
-			return nil
-		}
-		for _, i := range images {
-			if err := countManifest(i); err != nil {
-				return err
-			}
-		}
-		for _, nm := range newManifests {
-			for _, i := range nm {
-				if err := countManifest(i); err != nil {
-					return err
-				}
-			}
-		}
-		for _, i := range indexes {
-			if err := countManifest(i); err != nil {
-				return err
-			}
-		}
-	}
-
-	// Upload individual blobs and collect any errors.
-	blobChan := make(chan v1.Layer, 2*o.jobs)
-	ctx := o.context
-	g, gctx := errgroup.WithContext(o.context)
-	for i := 0; i < o.jobs; i++ {
-		// Start N workers consuming blobs to upload.
+	for ref, t := range todo {
+		ref, t := ref, t
 		g.Go(func() error {
-			for b := range blobChan {
-				if err := w.uploadOne(gctx, b); err != nil {
-					return err
-				}
-			}
-			return nil
+			return p.Push(ctx, ref, t)
 		})
 	}
-	g.Go(func() error {
-		defer close(blobChan)
-		for _, b := range blobs {
-			select {
-			case blobChan <- b:
-			case <-gctx.Done():
-				return gctx.Err()
-			}
-		}
-		return nil
-	})
-	if err := g.Wait(); err != nil {
-		return err
-	}
 
-	commitMany := func(ctx context.Context, m map[name.Reference]Taggable) error {
-		g, ctx := errgroup.WithContext(ctx)
-		// With all of the constituent elements uploaded, upload the manifests
-		// to commit the images and indexes, and collect any errors.
-		type task struct {
-			i   Taggable
-			ref name.Reference
-		}
-		taskChan := make(chan task, 2*o.jobs)
-		for i := 0; i < o.jobs; i++ {
-			// Start N workers consuming tasks to upload manifests.
-			g.Go(func() error {
-				for t := range taskChan {
-					if err := w.commitManifest(ctx, t.i, t.ref); err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-		}
-		go func() {
-			for ref, i := range m {
-				taskChan <- task{i, ref}
-			}
-			close(taskChan)
-		}()
-		return g.Wait()
-	}
-	// Push originally requested image manifests. These have no
-	// dependencies.
-	if err := commitMany(ctx, images); err != nil {
-		return err
-	}
-	// Push new manifests from lowest levels up.
-	for i := len(newManifests) - 1; i >= 0; i-- {
-		if err := commitMany(ctx, newManifests[i]); err != nil {
-			return err
-		}
-	}
-	// Push originally requested index manifests, which might depend on
-	// newly discovered manifests.
-
-	return commitMany(ctx, indexes)
-}
-
-// addIndexBlobs adds blobs to the set of blobs we intend to upload, and
-// returns the latest copy of the ordered collection of manifests to upload.
-func addIndexBlobs(idx v1.ImageIndex, blobs map[v1.Hash]v1.Layer, repo name.Repository, newManifests []map[name.Reference]Taggable, lvl int, allowNondistributableArtifacts bool) ([]map[name.Reference]Taggable, error) {
-	if lvl > len(newManifests)-1 {
-		newManifests = append(newManifests, map[name.Reference]Taggable{})
-	}
-
-	im, err := idx.IndexManifest()
-	if err != nil {
-		return nil, err
-	}
-	for _, desc := range im.Manifests {
-		switch desc.MediaType {
-		case types.OCIImageIndex, types.DockerManifestList:
-			idx, err := idx.ImageIndex(desc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			newManifests, err = addIndexBlobs(idx, blobs, repo, newManifests, lvl+1, allowNondistributableArtifacts)
-			if err != nil {
-				return nil, err
-			}
-
-			// Also track the sub-index manifest to upload later by digest.
-			newManifests[lvl][repo.Digest(desc.Digest.String())] = idx
-		case types.OCIManifestSchema1, types.DockerManifestSchema2:
-			img, err := idx.Image(desc.Digest)
-			if err != nil {
-				return nil, err
-			}
-			if err := addImageBlobs(img, blobs, allowNondistributableArtifacts); err != nil {
-				return nil, err
-			}
-
-			// Also track the sub-image manifest to upload later by digest.
-			newManifests[lvl][repo.Digest(desc.Digest.String())] = img
-		default:
-			// Workaround for #819.
-			if wl, ok := idx.(withLayer); ok {
-				layer, err := wl.Layer(desc.Digest)
-				if err != nil {
-					return nil, err
-				}
-				if err := addLayerBlob(layer, blobs, allowNondistributableArtifacts); err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, fmt.Errorf("unknown media type: %v", desc.MediaType)
-			}
-		}
-	}
-	return newManifests, nil
-}
-
-func addLayerBlob(l v1.Layer, blobs map[v1.Hash]v1.Layer, allowNondistributableArtifacts bool) error {
-	// Ignore foreign layers.
-	mt, err := l.MediaType()
-	if err != nil {
-		return err
-	}
-
-	if mt.IsDistributable() || allowNondistributableArtifacts {
-		d, err := l.Digest()
-		if err != nil {
-			return err
-		}
-
-		blobs[d] = l
-	}
-
-	return nil
-}
-
-func addImageBlobs(img v1.Image, blobs map[v1.Hash]v1.Layer, allowNondistributableArtifacts bool) error {
-	ls, err := img.Layers()
-	if err != nil {
-		return err
-	}
-	// Collect all layers.
-	for _, l := range ls {
-		if err := addLayerBlob(l, blobs, allowNondistributableArtifacts); err != nil {
-			return err
-		}
-	}
-
-	// Collect config blob.
-	cl, err := partial.ConfigLayer(img)
-	if err != nil {
-		return err
-	}
-	return addLayerBlob(cl, blobs, allowNondistributableArtifacts)
+	return g.Wait()
 }

--- a/pkg/v1/remote/progress_test.go
+++ b/pkg/v1/remote/progress_test.go
@@ -15,7 +15,6 @@
 package remote
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -437,15 +436,11 @@ func checkUpdates(updates <-chan v1.Update) error {
 			return u.Error
 		}
 
-		if u.Total == 0 {
-			return errors.New("saw zero total")
-		}
-
-		if total == 0 {
-			total = u.Total
-		} else if u.Total != total {
+		if u.Total < total {
 			return fmt.Errorf("total changed: was %d, saw %d", total, u.Total)
 		}
+
+		total = u.Total
 
 		if u.Complete < high {
 			return fmt.Errorf("saw progress revert: was high of %d, saw %d", high, u.Complete)

--- a/pkg/v1/remote/pusher.go
+++ b/pkg/v1/remote/pusher.go
@@ -1,0 +1,515 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/sync/errgroup"
+)
+
+type manifest interface {
+	Taggable
+	partial.Describable
+}
+
+// key is either v1.Hash or v1.Layer (for stream.Layer)
+type workers struct {
+	// map[v1.Hash|v1.Layer]*sync.Once
+	onces sync.Map
+
+	// map[v1.Hash|v1.Layer]error
+	errors sync.Map
+}
+
+func nop() error {
+	return nil
+}
+
+func (w *workers) err(digest v1.Hash) error {
+	v, ok := w.errors.Load(digest)
+	if !ok || v == nil {
+		return nil
+	}
+	return v.(error)
+}
+
+func (w *workers) Do(digest v1.Hash, f func() error) error {
+	// We don't care if it was loaded or not because the sync.Once will do it for us.
+	once, _ := w.onces.LoadOrStore(digest, &sync.Once{})
+
+	once.(*sync.Once).Do(func() {
+		w.errors.Store(digest, f())
+	})
+
+	err := w.err(digest)
+	if err != nil {
+		// Allow this to be retried by another caller.
+		w.onces.Delete(digest)
+	}
+	return err
+}
+
+func (w *workers) Stream(layer v1.Layer, f func() error) error {
+	// We don't care if it was loaded or not because the sync.Once will do it for us.
+	once, _ := w.onces.LoadOrStore(layer, &sync.Once{})
+
+	once.(*sync.Once).Do(func() {
+		w.errors.Store(layer, f())
+	})
+
+	v, ok := w.errors.Load(layer)
+	if !ok || v == nil {
+		return nil
+	}
+
+	return v.(error)
+}
+
+type Pusher struct {
+	o *options
+
+	// map[name.Repository]*repoWriter
+	writers sync.Map
+}
+
+func NewPusher(options ...Option) (*Pusher, error) {
+	o, err := makeOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return newPusher(o), nil
+}
+
+func newPusher(o *options) *Pusher {
+	return &Pusher{
+		o: o,
+	}
+}
+
+func (p *Pusher) writer(ctx context.Context, repo name.Repository, o *options) (*repoWriter, error) {
+	v, _ := p.writers.LoadOrStore(repo, &repoWriter{
+		repo: repo,
+		o:    o,
+	})
+	rw := v.(*repoWriter)
+	return rw, rw.init(ctx)
+}
+
+func (p *Pusher) Push(ctx context.Context, ref name.Reference, t Taggable) error {
+	w, err := p.writer(ctx, ref.Context(), p.o)
+	if err != nil {
+		return err
+	}
+	return w.writeManifest(ctx, ref, t)
+}
+
+func (p *Pusher) Upload(ctx context.Context, repo name.Repository, l v1.Layer) error {
+	w, err := p.writer(ctx, repo, p.o)
+	if err != nil {
+		return err
+	}
+	return w.writeLayer(ctx, l)
+}
+
+type repoWriter struct {
+	repo name.Repository
+	o    *options
+	once sync.Once
+
+	w   *writer
+	err error
+
+	work *workers
+}
+
+// this will run once per repoWriter instance
+func (rw *repoWriter) init(ctx context.Context) error {
+	rw.once.Do(func() {
+		rw.work = &workers{}
+		rw.w, rw.err = makeWriter(ctx, rw.repo, nil, rw.o)
+	})
+	return rw.err
+}
+
+func (rw *repoWriter) writeDeps(ctx context.Context, m manifest) error {
+	if img, ok := m.(v1.Image); ok {
+		return rw.writeLayers(ctx, img)
+	}
+
+	if idx, ok := m.(v1.ImageIndex); ok {
+		return rw.writeChildren(ctx, idx)
+	}
+
+	// This has no deps, not an error (e.g. something you want to just PUT).
+	return nil
+}
+
+type describable struct {
+	desc v1.Descriptor
+}
+
+func (d describable) Digest() (v1.Hash, error) {
+	return d.desc.Digest, nil
+}
+
+func (d describable) Size() (int64, error) {
+	return d.desc.Size, nil
+}
+
+func (d describable) MediaType() (types.MediaType, error) {
+	return d.desc.MediaType, nil
+}
+
+type tagManifest struct {
+	Taggable
+	partial.Describable
+}
+
+func taggableToManifest(t Taggable) (manifest, error) {
+	if m, ok := t.(manifest); ok {
+		return m, nil
+	}
+
+	if d, ok := t.(*Descriptor); ok {
+		if d.MediaType.IsIndex() {
+			return d.ImageIndex()
+		}
+
+		if d.MediaType.IsImage() {
+			return d.Image()
+		}
+
+		if d.MediaType.IsSchema1() {
+			return d.Schema1()
+		}
+
+		return tagManifest{t, describable{d.toDesc()}}, nil
+	}
+
+	desc := v1.Descriptor{
+		// A reasonable default if Taggable doesn't implement MediaType.
+		MediaType: types.DockerManifestSchema2,
+	}
+
+	b, err := t.RawManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if wmt, ok := t.(withMediaType); ok {
+		desc.MediaType, err = wmt.MediaType()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	desc.Digest, desc.Size, err = v1.SHA256(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+
+	return tagManifest{t, describable{desc}}, nil
+}
+
+func (rw *repoWriter) writeManifest(ctx context.Context, ref name.Reference, t Taggable) error {
+	m, err := taggableToManifest(t)
+	if err != nil {
+		return err
+	}
+
+	needDeps := true
+
+	digest, err := m.Digest()
+	if errors.Is(err, stream.ErrNotComputed) {
+		if err := rw.writeDeps(ctx, m); err != nil {
+			return err
+		}
+
+		needDeps = false
+
+		digest, err = m.Digest()
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	// This may be a lazy child where we have no ref until digest is computed.
+	if ref == nil {
+		ref = rw.repo.Digest(digest.String())
+	}
+
+	// For tags, we want to do this check outside of our Work.Do closure because
+	// we don't want to dedupe based on the manifest digest.
+	_, byTag := ref.(name.Tag)
+	if byTag {
+		if exists, err := rw.manifestExists(ctx, ref, t); err != nil {
+			return err
+		} else if exists {
+			return nil
+		}
+	}
+
+	// The following work.Do will get deduped by digest, so it won't happen unless
+	// this tag happens to be the first commitManifest to run for that digest.
+	needPut := byTag
+
+	if err := rw.work.Do(digest, func() error {
+		if !byTag {
+			if exists, err := rw.manifestExists(ctx, ref, t); err != nil {
+				return err
+			} else if exists {
+				return nil
+			}
+		}
+
+		if needDeps {
+			if err := rw.writeDeps(ctx, m); err != nil {
+				return err
+			}
+		}
+
+		needPut = false
+		return rw.commitManifest(ctx, ref, m)
+	}); err != nil {
+		return err
+	}
+
+	if !needPut {
+		return nil
+	}
+
+	// Only runs for tags that got deduped by digest.
+	return rw.commitManifest(ctx, ref, m)
+}
+
+func (rw *repoWriter) writeChildren(ctx context.Context, idx v1.ImageIndex) error {
+	children, err := partial.Manifests(idx)
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(rw.o.jobs)
+
+	for _, child := range children {
+		child := child
+		if err := rw.writeChild(ctx, child, g); err != nil {
+			return err
+		}
+	}
+
+	return g.Wait()
+}
+
+func (rw *repoWriter) writeChild(ctx context.Context, child partial.Describable, g *errgroup.Group) error {
+	switch child := child.(type) {
+	case v1.ImageIndex:
+		// For recursive index, we want to do a depth-first launching of goroutines
+		// to avoid deadlocking.
+		//
+		// Note that this is rare, so the impact of this should be really small.
+		return rw.writeManifest(ctx, nil, child)
+	case v1.Image:
+		g.Go(func() error {
+			return rw.writeManifest(ctx, nil, child)
+		})
+	case v1.Layer:
+		g.Go(func() error {
+			return rw.writeLayer(ctx, child)
+		})
+	default:
+		// This can't happen.
+		return fmt.Errorf("encountered unknown child: %T", child)
+	}
+	return nil
+}
+
+func (rw *repoWriter) manifestExists(ctx context.Context, ref name.Reference, t Taggable) (bool, error) {
+	f := &fetcher{
+		target:  ref.Context(),
+		client:  rw.w.client,
+		context: ctx,
+	}
+
+	m, err := taggableToManifest(t)
+	if err != nil {
+		return false, err
+	}
+
+	digest, err := m.Digest()
+	if err != nil {
+		// Possibly due to streaming layers.
+		return false, nil
+	}
+	got, err := f.headManifest(ctx, ref, allManifestMediaTypes)
+	if err != nil {
+		var terr *transport.Error
+		if errors.As(err, &terr) {
+			if terr.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+		}
+
+		return false, err
+	}
+
+	if digest != got.Digest {
+		// Mark that we saw this digest in the registry so we don't have to check it again.
+		rw.work.Do(got.Digest, nop)
+
+		return false, nil
+	}
+
+	if tag, ok := ref.(name.Tag); ok {
+		logs.Progress.Printf("existing manifest: %s@%s", tag.Identifier(), got.Digest)
+	} else {
+		logs.Progress.Print("existing manifest: ", got.Digest)
+	}
+
+	return true, nil
+}
+
+func (rw *repoWriter) commitManifest(ctx context.Context, ref name.Reference, m manifest) error {
+	if rw.o.progress != nil {
+		size, err := m.Size()
+		if err != nil {
+			return err
+		}
+		rw.o.progress.total(size)
+	}
+
+	return rw.w.commitManifest(ctx, m, ref)
+}
+
+func (rw *repoWriter) writeLayers(pctx context.Context, img v1.Image) error {
+	ls, err := img.Layers()
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(pctx)
+	g.SetLimit(rw.o.jobs)
+
+	for _, l := range ls {
+		l := l
+
+		g.Go(func() error {
+			return rw.writeLayer(ctx, l)
+		})
+	}
+
+	mt, err := img.MediaType()
+	if err != nil {
+		return err
+	}
+
+	if mt.IsSchema1() {
+		return g.Wait()
+	}
+
+	cl, err := partial.ConfigLayer(img)
+	if errors.Is(err, stream.ErrNotComputed) {
+		if err := g.Wait(); err != nil {
+			return err
+		}
+
+		cl, err := partial.ConfigLayer(img)
+		if err != nil {
+			return err
+		}
+
+		return rw.writeLayer(pctx, cl)
+	} else if err != nil {
+		return err
+	}
+
+	g.Go(func() error {
+		return rw.writeLayer(ctx, cl)
+	})
+
+	return g.Wait()
+}
+
+func (rw *repoWriter) writeLayer(ctx context.Context, l v1.Layer) error {
+	// Skip any non-distributable things.
+	mt, err := l.MediaType()
+	if err != nil {
+		return err
+	}
+	if !mt.IsDistributable() && !rw.o.allowNondistributableArtifacts {
+		return nil
+	}
+
+	digest, err := l.Digest()
+	if err != nil {
+		if errors.Is(err, stream.ErrNotComputed) {
+			return rw.lazyWriteLayer(ctx, l)
+		}
+		return err
+	}
+
+	return rw.work.Do(digest, func() error {
+		if rw.o.progress != nil {
+			size, err := l.Size()
+			if err != nil {
+				return err
+			}
+			rw.o.progress.total(size)
+		}
+		return rw.w.uploadOne(ctx, l)
+	})
+}
+
+func (rw *repoWriter) lazyWriteLayer(ctx context.Context, l v1.Layer) error {
+	return rw.work.Stream(l, func() error {
+		if err := rw.w.uploadOne(ctx, l); err != nil {
+			return err
+		}
+
+		// Mark this upload completed.
+		digest, err := l.Digest()
+		if err != nil {
+			return err
+		}
+
+		rw.work.Do(digest, nop)
+
+		if rw.o.progress != nil {
+			size, err := l.Size()
+			if err != nil {
+				return err
+			}
+			rw.o.progress.total(size)
+		}
+
+		return nil
+	})
+}

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -25,9 +25,11 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/google/go-containerregistry/internal/redact"
 	"github.com/google/go-containerregistry/internal/retry"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -51,11 +53,11 @@ func Write(ref name.Reference, img v1.Image, options ...Option) (rerr error) {
 	}
 
 	if o.progress != nil {
+		defer func() { o.progress.Close(rerr) }()
 		o.progress.lastUpdate.Total, err = countImage(img, o.allowNondistributableArtifacts)
 		if err != nil {
 			return err
 		}
-		defer func() { o.progress.Close(rerr) }()
 	}
 	return writeImage(o.context, ref, img, o)
 }
@@ -159,12 +161,19 @@ func writeImage(ctx context.Context, ref name.Reference, img v1.Image, o *option
 
 // writer writes the elements of an image to a remote image reference.
 type writer struct {
-	repo   name.Repository
-	client *http.Client
+	repo      name.Repository
+	auth      authn.Authenticator
+	transport http.RoundTripper
+	client    *http.Client
 
 	progress  *progress
 	backoff   Backoff
 	predicate retry.Predicate
+
+	scopeLock sync.Mutex
+	// Keep track of scopes that we have already requested.
+	scopeSet map[string]struct{}
+	scopes   []string
 }
 
 func makeWriter(ctx context.Context, repo name.Repository, ls []v1.Layer, o *options) (*writer, error) {
@@ -181,12 +190,21 @@ func makeWriter(ctx context.Context, repo name.Repository, ls []v1.Layer, o *opt
 	if err != nil {
 		return nil, err
 	}
+
+	scopeSet := map[string]struct{}{}
+	for _, scope := range scopes {
+		scopeSet[scope] = struct{}{}
+	}
 	return &writer{
 		repo:      repo,
 		client:    &http.Client{Transport: tr},
+		auth:      auth,
+		transport: o.transport,
 		progress:  o.progress,
 		backoff:   o.retryBackoff,
 		predicate: o.retryPredicate,
+		scopes:    scopes,
+		scopeSet:  scopeSet,
 	}, nil
 }
 
@@ -197,6 +215,34 @@ func (w *writer) url(path string) url.URL {
 		Host:   w.repo.RegistryStr(),
 		Path:   path,
 	}
+}
+
+func (w *writer) maybeUpdateScopes(ctx context.Context, ml *MountableLayer) error {
+	if ml.Reference.Context().String() == w.repo.String() {
+		return nil
+	}
+	if ml.Reference.Context().Registry.String() != w.repo.Registry.String() {
+		return nil
+	}
+
+	scope := ml.Reference.Scope(transport.PullScope)
+
+	w.scopeLock.Lock()
+	defer w.scopeLock.Unlock()
+
+	if _, ok := w.scopeSet[scope]; !ok {
+		w.scopeSet[scope] = struct{}{}
+		w.scopes = append(w.scopes, scope)
+
+		logs.Debug.Printf("Refreshing token to add scope %q", scope)
+		wt, err := transport.NewWithContext(ctx, w.repo.Registry, w.auth, w.transport, w.scopes)
+		if err != nil {
+			return err
+		}
+		w.client = &http.Client{Transport: wt}
+	}
+
+	return nil
 }
 
 // nextLocation extracts the fully-qualified URL to which we should send the next request in an upload sequence.
@@ -433,6 +479,9 @@ func (w *writer) uploadOne(ctx context.Context, l v1.Layer) error {
 			mount = h.String()
 		}
 		if ml, ok := l.(*MountableLayer); ok {
+			if err := w.maybeUpdateScopes(ctx, ml); err != nil {
+				return err
+			}
 			from = ml.Reference.Context().RepositoryStr()
 			origin = ml.Reference.Context().RegistryStr()
 		}


### PR DESCRIPTION
The Pusher handles multiplexing across multiple repositories and deduplicating in-flight uploads. This removes the need to do an awkward dance around re-using auth handshakes by passing custom transports.

This also fixes limitations in remote.MultiWrite around streaming layers and multiple repositories.