### PR TITLE
Allow remote config layers to be lazy fetched

### DIFF
--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -140,6 +140,21 @@ func (r *remoteImage) Descriptor() (*v1.Descriptor, error) {
 	return r.descriptor, err
 }
 
+func (r *remoteImage) ConfigLayer() (v1.Layer, error) {
+	if _, err := r.RawManifest(); err != nil {
+		return nil, err
+	}
+	m, err := partial.Manifest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return partial.CompressedToLayer(&remoteImageLayer{
+		ri:     r,
+		digest: m.Config.Digest,
+	})
+}
+
 // remoteImageLayer implements partial.CompressedLayer
 type remoteImageLayer struct {
 	ri     *remoteImage


### PR DESCRIPTION
The partial.ConfigLayer implementation needs to fetch the config blob, but we don't always need to do that (e.g. if we just need the digest).