### PR TITLE
feat(remote): retry on TooManyRequests

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -89,6 +89,7 @@ var retryableStatusCodes = []int{
 	http.StatusBadGateway,
 	http.StatusServiceUnavailable,
 	http.StatusGatewayTimeout,
+	http.StatusTooManyRequests,
 	499,
 }
 


### PR DESCRIPTION
Add HTTP 429 `TooManyRequests` to the list of retryable status codes.