### PR TITLE
Cleanup: Switch the debug image to `cgr.dev/chainguard/busybox`

### DIFF
--- a/.ko/debug/.ko.yaml
+++ b/.ko/debug/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: gcr.io/distroless/base:debug
+defaultBaseImage: cgr.dev/chainguard/busybox


### PR DESCRIPTION
:broom: This doesn't have `glibc` (like `base`) and just has the `busybox` necessities.

/kind cleanup