### PR TITLE
Revert "Cleanup: Switch the debug image to `cgr.dev/chainguard/busybo…

### DIFF
--- a/.ko/debug/.ko.yaml
+++ b/.ko/debug/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: cgr.dev/chainguard/busybox
+defaultBaseImage: gcr.io/distroless/base:debug


### PR DESCRIPTION
…x` (#1638)"

This reverts commit 2ccd41c448369ef98d1cd785f75ebfa51bc8ac94.