### PR TITLE
Add remote.Puller

### DIFF
--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -15,40 +15,62 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"strings"
+	"path"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
 )
 
-// NewCmdCatalog creates a new cobra.Command for the repos subcommand.
+// NewCmdCatalog creates a new cobra.Command for the catalog subcommand.
 func NewCmdCatalog(options *[]crane.Option, argv ...string) *cobra.Command {
-	if len(argv) == 0 {
-		argv = []string{os.Args[0]}
-	}
+	var fullRef bool
+	cmd := &cobra.Command{
+		Use:   "catalog REGISTRY",
+		Short: "List the repos in a registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := crane.GetOptions(*options...)
 
-	baseCmd := strings.Join(argv, " ")
-	eg := fmt.Sprintf(`  # list the repos for reg.example.com
-  $ %s catalog reg.example.com`, baseCmd)
-
-	return &cobra.Command{
-		Use:     "catalog [REGISTRY]",
-		Short:   "List the repos in a registry",
-		Example: eg,
-		Args:    cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			reg := args[0]
-			repos, err := crane.Catalog(reg, *options...)
-			if err != nil {
-				return fmt.Errorf("reading repos for %s: %w", reg, err)
-			}
-
-			for _, repo := range repos {
-				fmt.Println(repo)
-			}
-			return nil
+			return catalog(cmd.Context(), args[0], fullRef, o)
 		},
 	}
+	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
+
+	return cmd
+}
+
+func catalog(ctx context.Context, src string, fullRef bool, o crane.Options) error {
+	reg, err := name.NewRegistry(src, o.Name...)
+	if err != nil {
+		return fmt.Errorf("parsing reg %q: %w", src, err)
+	}
+
+	puller, err := remote.NewPuller(o.Remote...)
+	if err != nil {
+		return err
+	}
+
+	catalogger, err := puller.Catalogger(ctx, reg)
+	if err != nil {
+		return fmt.Errorf("reading tags for %s: %w", reg, err)
+	}
+
+	for catalogger.HasNext() {
+		repos, err := catalogger.Next(ctx)
+		if err != nil {
+			return err
+		}
+		for _, repo := range repos.Repos {
+			if fullRef {
+				fmt.Println(path.Join(src, repo))
+			} else {
+				fmt.Println(repo)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -15,11 +15,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -30,33 +32,49 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 		Use:   "ls REPO",
 		Short: "List the tags in a repo",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			repo := args[0]
-			tags, err := crane.ListTags(repo, *options...)
-			if err != nil {
-				return fmt.Errorf("reading tags for %s: %w", repo, err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := crane.GetOptions(*options...)
 
-			r, err := name.NewRepository(repo)
-			if err != nil {
-				return err
-			}
-
-			for _, tag := range tags {
-				if omitDigestTags && strings.HasPrefix(tag, "sha256-") {
-					continue
-				}
-
-				if fullRef {
-					fmt.Println(r.Tag(tag))
-				} else {
-					fmt.Println(tag)
-				}
-			}
-			return nil
+			return list(cmd.Context(), args[0], fullRef, omitDigestTags, o)
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
 	cmd.Flags().BoolVar(&omitDigestTags, "omit-digest-tags", false, "(Optional), if true, omit digest tags (e.g., ':sha256-...')")
 	return cmd
+}
+
+func list(ctx context.Context, src string, fullRef, omitDigestTags bool, o crane.Options) error {
+	repo, err := name.NewRepository(src, o.Name...)
+	if err != nil {
+		return fmt.Errorf("parsing repo %q: %w", src, err)
+	}
+
+	puller, err := remote.NewPuller(o.Remote...)
+	if err != nil {
+		return err
+	}
+
+	lister, err := puller.Lister(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("reading tags for %s: %w", repo, err)
+	}
+
+	for lister.HasNext() {
+		tags, err := lister.Next(ctx)
+		if err != nil {
+			return err
+		}
+		for _, tag := range tags.Tags {
+			if omitDigestTags && strings.HasPrefix(tag, "sha256-") {
+				continue
+			}
+
+			if fullRef {
+				fmt.Println(repo.Tag(tag))
+			} else {
+				fmt.Println(tag)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -3,20 +3,14 @@
 List the repos in a registry
 
 ```
-crane catalog [REGISTRY] [flags]
-```
-
-### Examples
-
-```
-  # list the repos for reg.example.com
-  $ crane catalog reg.example.com
+crane catalog REGISTRY [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for catalog
+      --full-ref   (Optional) if true, print the full image reference
+  -h, --help       help for catalog
 ```
 
 ### Options inherited from parent commands

--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -25,8 +25,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-type catalog struct {
+type Catalogs struct {
 	Repos []string `json:"repositories"`
+	Next  string   `json:"next,omitempty"`
 }
 
 // CatalogPage calls /_catalog, returning the list of repositories on the registry.
@@ -61,7 +62,7 @@ func CatalogPage(target name.Registry, last string, n int, options ...Option) ([
 		return nil, err
 	}
 
-	var parsed catalog
+	var parsed Catalogs
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, err
 	}
@@ -75,70 +76,82 @@ func Catalog(ctx context.Context, target name.Registry, options ...Option) ([]st
 	if err != nil {
 		return nil, err
 	}
-	f, err := makeFetcher(o.context, target, o)
-	if err != nil {
-		return nil, err
-	}
-
-	uri := &url.URL{
-		Scheme: target.Scheme(),
-		Host:   target.RegistryStr(),
-		Path:   "/v2/_catalog",
-	}
-	if o.pageSize > 0 {
-		uri.RawQuery = fmt.Sprintf("n=%d", o.pageSize)
-	}
 
 	// WithContext overrides the ctx passed directly.
 	if o.context != context.Background() {
 		ctx = o.context
 	}
 
-	var (
-		parsed   catalog
-		repoList []string
-	)
+	return newPuller(o).Catalog(ctx, target)
+}
 
-	// get responses until there is no next page
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
+func (f *fetcher) catalogPage(ctx context.Context, reg name.Registry, next string) (*Catalogs, error) {
+	if next == "" {
+		uri := &url.URL{
+			Scheme: reg.Scheme(),
+			Host:   reg.RegistryStr(),
+			Path:   "/v2/_catalog",
 		}
-
-		req, err := http.NewRequest("GET", uri.String(), nil)
-		if err != nil {
-			return nil, err
+		if f.pageSize > 0 {
+			uri.RawQuery = fmt.Sprintf("n=%d", f.pageSize)
 		}
-		req = req.WithContext(ctx)
-
-		resp, err := f.client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := transport.CheckError(resp, http.StatusOK); err != nil {
-			return nil, err
-		}
-
-		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-			return nil, err
-		}
-		if err := resp.Body.Close(); err != nil {
-			return nil, err
-		}
-
-		repoList = append(repoList, parsed.Repos...)
-
-		uri, err = getNextPageURL(resp)
-		if err != nil {
-			return nil, err
-		}
-		// no next page
-		if uri == nil {
-			break
-		}
+		next = uri.String()
 	}
-	return repoList, nil
+
+	req, err := http.NewRequestWithContext(ctx, "GET", next, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	parsed := Catalogs{}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	uri, err := getNextPageURL(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if uri != nil {
+		parsed.Next = uri.String()
+	}
+
+	return &parsed, nil
+}
+
+type Catalogger struct {
+	f   *fetcher
+	reg name.Registry
+
+	page *Catalogs
+	err  error
+
+	needMore bool
+}
+
+func (l *Catalogger) Next(ctx context.Context) (*Catalogs, error) {
+	if l.needMore {
+		l.page, l.err = l.f.catalogPage(ctx, l.reg, l.page.Next)
+	} else {
+		l.needMore = true
+	}
+	return l.page, l.err
+}
+
+func (l *Catalogger) HasNext() bool {
+	return l.page != nil && (!l.needMore || l.page.Next != "")
 }

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -249,6 +249,7 @@ type fetcher struct {
 	client   *http.Client
 	context  context.Context
 	platform v1.Platform
+	pageSize int
 }
 
 func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, error) {
@@ -279,6 +280,7 @@ func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, er
 		client:   &http.Client{Transport: tr},
 		context:  ctx,
 		platform: o.platform,
+		pageSize: o.pageSize,
 	}, nil
 }
 

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -26,11 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-type tags struct {
-	Name string   `json:"name"`
-	Tags []string `json:"tags"`
-}
-
 // ListWithContext calls List with the given context.
 //
 // Deprecated: Use List and WithContext. This will be removed in a future release.
@@ -45,67 +40,61 @@ func List(repo name.Repository, options ...Option) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := makeFetcher(o.context, repo, o)
+	return newPuller(o).List(o.context, repo)
+}
+
+type Tags struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+	Next string   `json:"next,omitempty"`
+}
+
+func (f *fetcher) listPage(ctx context.Context, repo name.Repository, next string) (*Tags, error) {
+	if next == "" {
+		uri := &url.URL{
+			Scheme: repo.Scheme(),
+			Host:   repo.RegistryStr(),
+			Path:   fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
+		}
+		if f.pageSize > 0 {
+			uri.RawQuery = fmt.Sprintf("n=%d", f.pageSize)
+		}
+		next = uri.String()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", next, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	uri := &url.URL{
-		Scheme: repo.Registry.Scheme(),
-		Host:   repo.Registry.RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
 	}
 
-	if o.pageSize > 0 {
-		uri.RawQuery = fmt.Sprintf("n=%d", o.pageSize)
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, err
 	}
 
-	tagList := []string{}
-	parsed := tags{}
-
-	// get responses until there is no next page
-	for {
-		select {
-		case <-o.context.Done():
-			return nil, o.context.Err()
-		default:
-		}
-
-		req, err := http.NewRequestWithContext(o.context, "GET", uri.String(), nil)
-		if err != nil {
-			return nil, err
-		}
-
-		resp, err := f.client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := transport.CheckError(resp, http.StatusOK); err != nil {
-			return nil, err
-		}
-
-		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-			return nil, err
-		}
-
-		if err := resp.Body.Close(); err != nil {
-			return nil, err
-		}
-
-		tagList = append(tagList, parsed.Tags...)
-
-		uri, err = getNextPageURL(resp)
-		if err != nil {
-			return nil, err
-		}
-		// no next page
-		if uri == nil {
-			break
-		}
+	parsed := Tags{}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
 	}
 
-	return tagList, nil
+	if err := resp.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	uri, err := getNextPageURL(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if uri != nil {
+		parsed.Next = uri.String()
+	}
+
+	return &parsed, nil
 }
 
 // getNextPageURL checks if there is a Link header in a http.Response which
@@ -136,4 +125,27 @@ func getNextPageURL(resp *http.Response) (*url.URL, error) {
 	}
 	linkURL = resp.Request.URL.ResolveReference(linkURL)
 	return linkURL, nil
+}
+
+type Lister struct {
+	f    *fetcher
+	repo name.Repository
+
+	page *Tags
+	err  error
+
+	needMore bool
+}
+
+func (l *Lister) Next(ctx context.Context) (*Tags, error) {
+	if l.needMore {
+		l.page, l.err = l.f.listPage(ctx, l.repo, l.page.Next)
+	} else {
+		l.needMore = true
+	}
+	return l.page, l.err
+}
+
+func (l *Lister) HasNext() bool {
+	return l.page != nil && (!l.needMore || l.page.Next != "")
 }

--- a/pkg/v1/remote/puller.go
+++ b/pkg/v1/remote/puller.go
@@ -1,0 +1,162 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type Puller struct {
+	o *options
+
+	// map[resource]*reader
+	readers sync.Map
+}
+
+func NewPuller(options ...Option) (*Puller, error) {
+	o, err := makeOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return newPuller(o), nil
+}
+
+func newPuller(o *options) *Puller {
+	return &Puller{
+		o: o,
+	}
+}
+
+type reader struct {
+	target resource
+	o      *options
+	once   sync.Once
+
+	f   *fetcher
+	err error
+}
+
+// this will run once per reader instance
+func (r *reader) init(ctx context.Context) error {
+	r.once.Do(func() {
+		r.f, r.err = makeFetcher(ctx, r.target, r.o)
+	})
+	return r.err
+}
+
+func (p *Puller) reader(ctx context.Context, target resource, o *options) (*reader, error) {
+	v, _ := p.readers.LoadOrStore(target, &reader{
+		target: target,
+		o:      o,
+	})
+	rr := v.(*reader)
+	return rr, rr.init(ctx)
+}
+
+// Head is like remote.Head, but avoids re-authenticating when possible.
+func (p *Puller) Head(ctx context.Context, ref name.Reference) (*v1.Descriptor, error) {
+	r, err := p.reader(ctx, ref.Context(), p.o)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.f.headManifest(ctx, ref, allManifestMediaTypes)
+}
+
+// Get is like remote.Get, but avoids re-authenticating when possible.
+func (p *Puller) Get(ctx context.Context, ref name.Reference) (*Descriptor, error) {
+	r, err := p.reader(ctx, ref.Context(), p.o)
+	if err != nil {
+		return nil, err
+	}
+	return r.f.get(ctx, ref, allManifestMediaTypes)
+}
+
+// List lists tags in a repo and handles pagination, returning the full list of tags.
+func (p *Puller) List(ctx context.Context, repo name.Repository) ([]string, error) {
+	lister, err := p.Lister(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	tagList := []string{}
+	for lister.HasNext() {
+		tags, err := lister.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		tagList = append(tagList, tags.Tags...)
+	}
+
+	return tagList, nil
+}
+
+// Lister lists tags in a repo and returns a Lister for paginating through the results.
+func (p *Puller) Lister(ctx context.Context, repo name.Repository) (*Lister, error) {
+	r, err := p.reader(ctx, repo, p.o)
+	if err != nil {
+		return nil, err
+	}
+	page, err := r.f.listPage(ctx, repo, "")
+	if err != nil {
+		return nil, err
+	}
+	return &Lister{
+		f:    r.f,
+		repo: repo,
+		page: page,
+		err:  err,
+	}, nil
+}
+
+// Catalog lists repos in a registry and handles pagination, returning the full list of repos.
+func (p *Puller) Catalog(ctx context.Context, reg name.Registry) ([]string, error) {
+	catalogger, err := p.Catalogger(ctx, reg)
+	if err != nil {
+		return nil, err
+	}
+	repoList := []string{}
+	for catalogger.HasNext() {
+		repos, err := catalogger.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		repoList = append(repoList, repos.Repos...)
+	}
+	return repoList, nil
+}
+
+// Catalogger lists repos in a registry and returns a Catalogger for paginating through the results.
+func (p *Puller) Catalogger(ctx context.Context, reg name.Registry) (*Catalogger, error) {
+	r, err := p.reader(ctx, reg, p.o)
+	if err != nil {
+		return nil, err
+	}
+	page, err := r.f.catalogPage(ctx, reg, "")
+	if err != nil {
+		return nil, err
+	}
+	return &Catalogger{
+		f:    r.f,
+		reg:  reg,
+		page: page,
+		err:  err,
+	}, nil
+}


### PR DESCRIPTION
This PR adds a Puller implementation and uses it in `crane ls` and `crane catalog` to stream results for each page.