### PR TITLE
gcrane: Use page size of 10,000 for googley things

### DIFF
--- a/pkg/v1/google/keychain.go
+++ b/pkg/v1/google/keychain.go
@@ -53,11 +53,7 @@ type googleKeychain struct {
 // gcloud configuration in the scope of this one process.
 func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
 	// Only authenticate GCR and AR so it works with authn.NewMultiKeychain to fallback.
-	host := target.RegistryStr()
-	if host != "gcr.io" &&
-		!strings.HasSuffix(host, ".gcr.io") &&
-		!strings.HasSuffix(host, ".pkg.dev") &&
-		!strings.HasSuffix(host, ".google.com") {
+	if !isGoogle(target.RegistryStr()) {
 		return authn.Anonymous, nil
 	}
 
@@ -89,4 +85,11 @@ func resolve() authn.Authenticator {
 		logs.Debug.Printf("gcloud error: %v", gErr)
 	}
 	return authn.Anonymous
+}
+
+func isGoogle(host string) bool {
+	return host == "gcr.io" ||
+		strings.HasSuffix(host, ".gcr.io") ||
+		strings.HasSuffix(host, ".pkg.dev") ||
+		strings.HasSuffix(host, ".google.com")
 }

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -89,12 +89,16 @@ func newLister(repo name.Repository, options ...Option) (*lister, error) {
 
 func (l *lister) list(repo name.Repository) (*Tags, error) {
 	uri := &url.URL{
-		Scheme: repo.Registry.Scheme(),
-		Host:   repo.Registry.RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
-		// ECR returns an error if n > 1000:
-		// https://github.com/google/go-containerregistry/issues/681
-		RawQuery: "n=1000",
+		Scheme:   repo.Registry.Scheme(),
+		Host:     repo.Registry.RegistryStr(),
+		Path:     fmt.Sprintf("/v2/%s/tags/list", repo.RepositoryStr()),
+		RawQuery: "n=10000",
+	}
+
+	// ECR returns an error if n > 1000:
+	// https://github.com/google/go-containerregistry/issues/681
+	if !isGoogle(repo.RegistryStr()) {
+		uri.RawQuery = "n=1000"
 	}
 
 	tags := Tags{}


### PR DESCRIPTION
We dropped down to 1000 for the sake of ECR, but that doesn't make much sense, really.

Per https://cloud.google.com/artifact-registry/quotas#limits this will return up to 10k items.

Fixes https://github.com/google/go-containerregistry/issues/1643