### PR TITLE
Fix fetching referrers error handling

### DIFF
--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -94,6 +94,16 @@ func TestReferrers(t *testing.T) {
 		rootDesc := descriptor(rootImg)
 		t.Logf("root image is %s", rootDesc.Digest)
 
+		// Before pushing referrers, try to get the referrers of the root image.
+		rootRefDigest := rootRef.Context().Digest(rootDesc.Digest.String())
+		index, err := remote.Referrers(rootRefDigest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if numManifests := len(index.Manifests); numManifests != 0 {
+			t.Fatalf("expected index to contain 0 manifests, but had %d", numManifests)
+		}
+
 		// Push an image that refers to the root image as its subject.
 		leafRef, err := name.ParseReference(fmt.Sprintf("%s/repo:leaf", u.Host))
 		if err != nil {
@@ -112,8 +122,7 @@ func TestReferrers(t *testing.T) {
 		t.Logf("leaf image is %s", leafDesc.Digest)
 
 		// Get the referrers of the root image, by digest.
-		rootRefDigest := rootRef.Context().Digest(rootDesc.Digest.String())
-		index, err := remote.Referrers(rootRefDigest)
+		index, err = remote.Referrers(rootRefDigest)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
fixes https://github.com/google/go-containerregistry/issues/1647

I've fixed the error handling when fetching referrers in an OCI registry that does not support for referrers API.

The err returned before properly handling the exception when receiving a 404 error. I have fixed the code to ensure that the exception is handled correctly before returning.

When only the test part was modified, the test failed with the following error. Also, after modifying the code, the test passed successfully.

```
2023/04/14 12:43:50 GET /v2/
2023/04/14 12:43:50 GET /v2/repo/referrers/sha256:790f56f28e146a86b21b3ea65618fdf240ffc5d51e0b9948e31c284b41b2ed27 404 METHOD_UNKNOWN We don’t understand your method + url
2023/04/14 12:43:50 GET /v2/repo/manifests/sha256-790f56f28e146a86b21b3ea65618fdf240ffc5d51e0b9948e31c284b41b2ed27 404 MANIFEST_UNKNOWN Unknown manifest
--- FAIL: TestReferrers (0.01s)
    referrers_test.go:95: root image is sha256:790f56f28e146a86b21b3ea65618fdf240ffc5d51e0b9948e31c284b41b2ed27
    referrers_test.go:101: GET http://127.0.0.1:56527/v2/repo/manifests/sha256-790f56f28e146a86b21b3ea65618fdf240ffc5d51e0b9948e31c284b41b2ed27: MANIFEST_UNKNOWN: Unknown manifest
FAIL
FAIL    github.com/google/go-containerregistry/pkg/v1/remote    1.431s
```