### PR TITLE
Introduce GGCR_CREDS_CACHE

### DIFF
--- a/cmd/krane/go.mod
+++ b/cmd/krane/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/renameio v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect

--- a/cmd/krane/go.sum
+++ b/cmd/krane/go.sum
@@ -101,6 +101,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
+github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v23.0.4+incompatible
 	github.com/google/go-cmp v0.5.9
+	github.com/google/renameio v1.0.1
 	github.com/klauspost/compress v1.16.5
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
+github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -237,6 +237,7 @@ func (d *Descriptor) remoteIndex() *remoteIndex {
 }
 
 type resource interface {
+	Name() string
 	Scheme() string
 	RegistryStr() string
 	Scope(string) string
@@ -262,16 +263,7 @@ func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, er
 		auth = kauth
 	}
 
-	reg, ok := target.(name.Registry)
-	if !ok {
-		repo, ok := target.(name.Repository)
-		if !ok {
-			return nil, fmt.Errorf("unexpected resource: %T", target)
-		}
-		reg = repo.Registry
-	}
-
-	tr, err := transport.NewWithContext(ctx, reg, auth, o.transport, []string{target.Scope(transport.PullScope)})
+	tr, err := transport.NewTransport(ctx, target, auth, o.transport, []string{target.Scope(transport.PullScope)})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/transport/cache.go
+++ b/pkg/v1/remote/transport/cache.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package transport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/renameio"
+)
+
+func getCache() (cache, error) {
+	cachedir := os.Getenv("GGCR_CREDS_CACHE")
+	if cachedir == "" {
+		return nil, nil
+	}
+	for _, d := range []string{"ping", "token"} {
+		dir := filepath.Join(cachedir, d)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return nil, fmt.Errorf("MkdirAll(%q): %w", dir, err)
+		}
+	}
+
+	return &fileCache{cachedir}, nil
+}
+
+type fileCache struct {
+	dir string
+}
+
+func (c *fileCache) Get(key string) ([]byte, error) {
+	fname := filepath.Join(c.dir, key)
+	stat, err := os.Stat(fname)
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.ModTime().Before(time.Now().Add(-10 * time.Minute)) {
+		logs.Debug.Printf("cache found %q but it was expired", key)
+		return nil, nil
+	}
+	return os.ReadFile(fname)
+}
+
+func (c *fileCache) Put(key string, b []byte) error {
+	fname := filepath.Join(c.dir, key)
+
+	// This library does not exist for windows.
+	return renameio.WriteFile(fname, b, 0666)
+}

--- a/pkg/v1/remote/transport/cache_windows.go
+++ b/pkg/v1/remote/transport/cache_windows.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package transport
+
+func getCache() (cache, error) {
+	return nil, nil
+}

--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -16,16 +16,17 @@ package transport
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	authchallenge "github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/google/go-containerregistry/pkg/logs"
-	"github.com/google/go-containerregistry/pkg/name"
 )
 
 type challenge string
@@ -39,22 +40,38 @@ const (
 // 300ms is the default fallback period for go's DNS dialer but we could make this configurable.
 var fallbackDelay = 300 * time.Millisecond
 
-type pingResp struct {
-	challenge challenge
+type PingResponse struct {
+	Challenge challenge
 
 	// Following the challenge there are often key/value pairs
 	// e.g. Bearer service="gcr.io",realm="https://auth.gcr.io/v36/tokenz"
-	parameters map[string]string
+	Parameters map[string]string
 
 	// The registry's scheme to use. Communicates whether we fell back to http.
-	scheme string
+	Scheme string
 }
 
 func (c challenge) Canonical() challenge {
 	return challenge(strings.ToLower(string(c)))
 }
 
-func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingResp, error) {
+func ping(ctx context.Context, reg resource, t http.RoundTripper) (*PingResponse, error) {
+	// Attempt to find the ping response in the credCache.
+	if credCache != nil {
+		key := fmt.Sprintf("ping/%s", url.QueryEscape(reg.RegistryStr()))
+		b, err := credCache.Get(key)
+		if err != nil || b == nil {
+			logs.Debug.Printf("Transport.credCache.Get(%q) = (%v)", key, err)
+		} else {
+			pr := PingResponse{}
+			if err := json.Unmarshal(b, &pr); err != nil {
+				logs.Debug.Printf("Unmarshaling cached PingResponse: %v", err)
+			} else {
+				return &pr, nil
+			}
+		}
+	}
+
 	// This first attempts to use "https" for every request, falling back to http
 	// if the registry matches our localhost heuristic or if it is intentionally
 	// set to insecure via name.NewInsecureRegistry.
@@ -68,9 +85,9 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 	return pingParallel(ctx, reg, t, schemes)
 }
 
-func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, scheme string) (*pingResp, error) {
+func pingSingle(ctx context.Context, reg resource, t http.RoundTripper, scheme string) (*PingResponse, error) {
 	client := http.Client{Transport: t}
-	url := fmt.Sprintf("%s://%s/v2/", scheme, reg.Name())
+	url := fmt.Sprintf("%s://%s/v2/", scheme, reg.RegistryStr())
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -89,24 +106,24 @@ func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, sch
 	switch resp.StatusCode {
 	case http.StatusOK:
 		// If we get a 200, then no authentication is needed.
-		return &pingResp{
-			challenge: anonymous,
-			scheme:    scheme,
+		return &PingResponse{
+			Challenge: anonymous,
+			Scheme:    scheme,
 		}, nil
 	case http.StatusUnauthorized:
 		if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
 			// If we hit more than one, let's try to find one that we know how to handle.
 			wac := pickFromMultipleChallenges(challenges)
-			return &pingResp{
-				challenge:  challenge(wac.Scheme).Canonical(),
-				parameters: wac.Parameters,
-				scheme:     scheme,
+			return &PingResponse{
+				Challenge:  challenge(wac.Scheme).Canonical(),
+				Parameters: wac.Parameters,
+				Scheme:     scheme,
 			}, nil
 		}
 		// Otherwise, just return the challenge without parameters.
-		return &pingResp{
-			challenge: challenge(resp.Header.Get("WWW-Authenticate")).Canonical(),
-			scheme:    scheme,
+		return &PingResponse{
+			Challenge: challenge(resp.Header.Get("WWW-Authenticate")).Canonical(),
+			Scheme:    scheme,
 		}, nil
 	default:
 		return nil, CheckError(resp, http.StatusOK, http.StatusUnauthorized)
@@ -114,12 +131,12 @@ func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, sch
 }
 
 // Based on the golang happy eyeballs dialParallel impl in net/dial.go.
-func pingParallel(ctx context.Context, reg name.Registry, t http.RoundTripper, schemes []string) (*pingResp, error) {
+func pingParallel(ctx context.Context, reg resource, t http.RoundTripper, schemes []string) (*PingResponse, error) {
 	returned := make(chan struct{})
 	defer close(returned)
 
 	type pingResult struct {
-		*pingResp
+		*PingResponse
 		error
 		primary bool
 		done    bool
@@ -130,7 +147,7 @@ func pingParallel(ctx context.Context, reg name.Registry, t http.RoundTripper, s
 	startRacer := func(ctx context.Context, scheme string) {
 		pr, err := pingSingle(ctx, reg, t, scheme)
 		select {
-		case results <- pingResult{pingResp: pr, error: err, primary: scheme == "https", done: true}:
+		case results <- pingResult{PingResponse: pr, error: err, primary: scheme == "https", done: true}:
 		case <-returned:
 			if pr != nil {
 				logs.Debug.Printf("%s lost race", scheme)
@@ -156,7 +173,7 @@ func pingParallel(ctx context.Context, reg name.Registry, t http.RoundTripper, s
 
 		case res := <-results:
 			if res.error == nil {
-				return res.pingResp, nil
+				return res.PingResponse, nil
 			}
 			if res.primary {
 				primary = res

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -47,11 +47,11 @@ func TestPingNoChallenge(t *testing.T) {
 	if err != nil {
 		t.Errorf("ping() = %v", err)
 	}
-	if pr.challenge != anonymous {
-		t.Errorf("ping(); got %v, want %v", pr.challenge, anonymous)
+	if pr.Challenge != anonymous {
+		t.Errorf("ping(); got %v, want %v", pr.Challenge, anonymous)
 	}
-	if pr.scheme != "http" {
-		t.Errorf("ping(); got %v, want %v", pr.scheme, "http")
+	if pr.Scheme != "http" {
+		t.Errorf("ping(); got %v, want %v", pr.Scheme, "http")
 	}
 }
 
@@ -72,10 +72,10 @@ func TestPingBasicChallengeNoParams(t *testing.T) {
 	if err != nil {
 		t.Errorf("ping() = %v", err)
 	}
-	if pr.challenge != basic {
-		t.Errorf("ping(); got %v, want %v", pr.challenge, basic)
+	if pr.Challenge != basic {
+		t.Errorf("ping(); got %v, want %v", pr.Challenge, basic)
 	}
-	if got, want := len(pr.parameters), 0; got != want {
+	if got, want := len(pr.Parameters), 0; got != want {
 		t.Errorf("ping(); got %v, want %v", got, want)
 	}
 }
@@ -97,10 +97,10 @@ func TestPingBearerChallengeWithParams(t *testing.T) {
 	if err != nil {
 		t.Errorf("ping() = %v", err)
 	}
-	if pr.challenge != bearer {
-		t.Errorf("ping(); got %v, want %v", pr.challenge, bearer)
+	if pr.Challenge != bearer {
+		t.Errorf("ping(); got %v, want %v", pr.Challenge, bearer)
 	}
-	if got, want := len(pr.parameters), 1; got != want {
+	if got, want := len(pr.Parameters), 1; got != want {
 		t.Errorf("ping(); got %v, want %v", got, want)
 	}
 }
@@ -123,10 +123,10 @@ func TestPingMultipleChallenges(t *testing.T) {
 	if err != nil {
 		t.Errorf("ping() = %v", err)
 	}
-	if pr.challenge != basic {
-		t.Errorf("ping(); got %v, want %v", pr.challenge, basic)
+	if pr.Challenge != basic {
+		t.Errorf("ping(); got %v, want %v", pr.Challenge, basic)
 	}
-	if got, want := len(pr.parameters), 1; got != want {
+	if got, want := len(pr.Parameters), 1; got != want {
 		t.Errorf("ping(); got %v, want %v", got, want)
 	}
 }
@@ -149,8 +149,8 @@ func TestPingMultipleNotSupportedChallenges(t *testing.T) {
 	if err != nil {
 		t.Errorf("ping() = %v", err)
 	}
-	if pr.challenge != "negotiate" {
-		t.Errorf("ping(); got %v, want %v", pr.challenge, "negotiate")
+	if pr.Challenge != "negotiate" {
+		t.Errorf("ping(); got %v, want %v", pr.Challenge, "negotiate")
 	}
 }
 

--- a/pkg/v1/remote/transport/schemer.go
+++ b/pkg/v1/remote/transport/schemer.go
@@ -16,8 +16,6 @@ package transport
 
 import (
 	"net/http"
-
-	"github.com/google/go-containerregistry/pkg/name"
 )
 
 type schemeTransport struct {
@@ -25,7 +23,7 @@ type schemeTransport struct {
 	scheme string
 
 	// Registry we're talking to.
-	registry name.Registry
+	registry resource
 
 	// Wrapped by schemeTransport.
 	inner http.RoundTripper
@@ -37,7 +35,7 @@ func (st *schemeTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	// based on which scheme was successful. That is only valid for the
 	// registry server and not e.g. a separate token server or blob storage,
 	// so we should only override the scheme if the host is the registry.
-	if matchesHost(st.registry, in, st.scheme) {
+	if matchesHost(st.registry.RegistryStr(), in, st.scheme) {
 		in.URL.Scheme = st.scheme
 	}
 	return st.inner.RoundTrip(in)

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -186,7 +186,8 @@ func makeWriter(ctx context.Context, repo name.Repository, ls []v1.Layer, o *opt
 		auth = kauth
 	}
 	scopes := scopesForUploadingImage(repo, ls)
-	tr, err := transport.NewWithContext(ctx, repo.Registry, auth, o.transport, scopes)
+
+	tr, err := transport.NewTransport(ctx, repo, auth, o.transport, scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/google/renameio/.golangci.yml
+++ b/vendor/github.com/google/renameio/.golangci.yml
@@ -1,0 +1,5 @@
+linters:
+  disable:
+  - errcheck
+  enable:
+  - gofmt

--- a/vendor/github.com/google/renameio/CONTRIBUTING.md
+++ b/vendor/github.com/google/renameio/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).

--- a/vendor/github.com/google/renameio/LICENSE
+++ b/vendor/github.com/google/renameio/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/renameio/README.md
+++ b/vendor/github.com/google/renameio/README.md
@@ -1,0 +1,61 @@
+[![Build Status](https://github.com/google/renameio/workflows/Test/badge.svg)](https://github.com/google/renameio/actions?query=workflow%3ATest)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/google/renameio)](https://pkg.go.dev/github.com/google/renameio)
+[![Go Report Card](https://goreportcard.com/badge/github.com/google/renameio)](https://goreportcard.com/report/github.com/google/renameio)
+
+The `renameio` Go package provides a way to atomically create or replace a file or
+symbolic link.
+
+## Atomicity vs durability
+
+`renameio` concerns itself *only* with atomicity, i.e. making sure applications
+never see unexpected file content (a half-written file, or a 0-byte file).
+
+As a practical example, consider https://manpages.debian.org/: if there is a
+power outage while the site is updating, we are okay with losing the manpages
+which were being rendered at the time of the power outage. They will be added in
+a later run of the software. We are not okay with having a manpage replaced by a
+0-byte file under any circumstances, though.
+
+## Advantages of this package
+
+There are other packages for atomically replacing files, and sometimes ad-hoc
+implementations can be found in programs.
+
+A naive approach to the problem is to create a temporary file followed by a call
+to `os.Rename()`. However, there are a number of subtleties which make the
+correct sequence of operations hard to identify:
+
+* The temporary file should be removed when an error occurs, but a remove must
+  not be attempted if the rename succeeded, as a new file might have been
+  created with the same name. This renders a throwaway `defer
+  os.Remove(t.Name())` insufficient; state must be kept.
+
+* The temporary file must be created on the same file system (same mount point)
+  for the rename to work, but the TMPDIR environment variable should still be
+  respected, e.g. to direct temporary files into a separate directory outside of
+  the webserver’s document root but on the same file system.
+
+* On POSIX operating systems, the
+  [`fsync`](https://manpages.debian.org/stretch/manpages-dev/fsync.2) system
+  call must be used to ensure that the `os.Rename()` call will not result in a
+  0-length file.
+
+This package attempts to get all of these details right, provides an intuitive,
+yet flexible API and caters to use-cases where high performance is required.
+
+## Windows support
+
+It is [not possible to reliably write files atomically on
+Windows](https://github.com/golang/go/issues/22397#issuecomment-498856679), and
+[`chmod` is not reliably supported by the Go standard library on
+Windows](https://github.com/google/renameio/issues/17).
+
+As it is not possible to provide a correct implementation, this package does not
+export any functions on Windows.
+
+## Disclaimer
+
+This is not an official Google product (experimental or otherwise), it
+is just code that happens to be owned by Google.
+
+This project is not affiliated with the Go project.

--- a/vendor/github.com/google/renameio/doc.go
+++ b/vendor/github.com/google/renameio/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package renameio provides a way to atomically create or replace a file or
+// symbolic link.
+//
+// Caveat: this package requires the file system rename(2) implementation to be
+// atomic. Notably, this is not the case when using NFS with multiple clients:
+// https://stackoverflow.com/a/41396801
+package renameio

--- a/vendor/github.com/google/renameio/tempfile.go
+++ b/vendor/github.com/google/renameio/tempfile.go
@@ -1,0 +1,187 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package renameio
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// TempDir checks whether os.TempDir() can be used as a temporary directory for
+// later atomically replacing files within dest. If no (os.TempDir() resides on
+// a different mount point), dest is returned.
+//
+// Note that the returned value ceases to be valid once either os.TempDir()
+// changes (e.g. on Linux, once the TMPDIR environment variable changes) or the
+// file system is unmounted.
+func TempDir(dest string) string {
+	return tempDir("", filepath.Join(dest, "renameio-TempDir"))
+}
+
+func tempDir(dir, dest string) string {
+	if dir != "" {
+		return dir // caller-specified directory always wins
+	}
+
+	// Chose the destination directory as temporary directory so that we
+	// definitely can rename the file, for which both temporary and destination
+	// file need to point to the same mount point.
+	fallback := filepath.Dir(dest)
+
+	// The user might have overridden the os.TempDir() return value by setting
+	// the TMPDIR environment variable.
+	tmpdir := os.TempDir()
+
+	testsrc, err := ioutil.TempFile(tmpdir, "."+filepath.Base(dest))
+	if err != nil {
+		return fallback
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.Remove(testsrc.Name())
+		}
+	}()
+	testsrc.Close()
+
+	testdest, err := ioutil.TempFile(filepath.Dir(dest), "."+filepath.Base(dest))
+	if err != nil {
+		return fallback
+	}
+	defer os.Remove(testdest.Name())
+	testdest.Close()
+
+	if err := os.Rename(testsrc.Name(), testdest.Name()); err != nil {
+		return fallback
+	}
+	cleanup = false // testsrc no longer exists
+	return tmpdir
+}
+
+// PendingFile is a pending temporary file, waiting to replace the destination
+// path in a call to CloseAtomicallyReplace.
+type PendingFile struct {
+	*os.File
+
+	path   string
+	done   bool
+	closed bool
+}
+
+// Cleanup is a no-op if CloseAtomicallyReplace succeeded, and otherwise closes
+// and removes the temporary file.
+//
+// This method is not safe for concurrent use by multiple goroutines.
+func (t *PendingFile) Cleanup() error {
+	if t.done {
+		return nil
+	}
+	// An error occurred. Close and remove the tempfile. Errors are returned for
+	// reporting, there is nothing the caller can recover here.
+	var closeErr error
+	if !t.closed {
+		closeErr = t.Close()
+	}
+	if err := os.Remove(t.Name()); err != nil {
+		return err
+	}
+	return closeErr
+}
+
+// CloseAtomicallyReplace closes the temporary file and atomically replaces
+// the destination file with it, i.e., a concurrent open(2) call will either
+// open the file previously located at the destination path (if any), or the
+// just written file, but the file will always be present.
+//
+// This method is not safe for concurrent use by multiple goroutines.
+func (t *PendingFile) CloseAtomicallyReplace() error {
+	// Even on an ordered file system (e.g. ext4 with data=ordered) or file
+	// systems with write barriers, we cannot skip the fsync(2) call as per
+	// Theodore Ts'o (ext2/3/4 lead developer):
+	//
+	// > data=ordered only guarantees the avoidance of stale data (e.g., the previous
+	// > contents of a data block showing up after a crash, where the previous data
+	// > could be someone's love letters, medical records, etc.). Without the fsync(2)
+	// > a zero-length file is a valid and possible outcome after the rename.
+	if err := t.Sync(); err != nil {
+		return err
+	}
+	t.closed = true
+	if err := t.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(t.Name(), t.path); err != nil {
+		return err
+	}
+	t.done = true
+	return nil
+}
+
+// TempFile wraps ioutil.TempFile for the use case of atomically creating or
+// replacing the destination file at path.
+//
+// If dir is the empty string, TempDir(filepath.Base(path)) is used. If you are
+// going to write a large number of files to the same file system, store the
+// result of TempDir(filepath.Base(path)) and pass it instead of the empty
+// string.
+//
+// The file's permissions will be 0600 by default. You can change these by
+// explicitly calling Chmod on the returned PendingFile.
+func TempFile(dir, path string) (*PendingFile, error) {
+	f, err := ioutil.TempFile(tempDir(dir, path), "."+filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+
+	return &PendingFile{File: f, path: path}, nil
+}
+
+// Symlink wraps os.Symlink, replacing an existing symlink with the same name
+// atomically (os.Symlink fails when newname already exists, at least on Linux).
+func Symlink(oldname, newname string) error {
+	// Fast path: if newname does not exist yet, we can skip the whole dance
+	// below.
+	if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
+		return err
+	}
+
+	// We need to use ioutil.TempDir, as we cannot overwrite a ioutil.TempFile,
+	// and removing+symlinking creates a TOCTOU race.
+	d, err := ioutil.TempDir(filepath.Dir(newname), "."+filepath.Base(newname))
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.RemoveAll(d)
+		}
+	}()
+
+	symlink := filepath.Join(d, "tmp.symlink")
+	if err := os.Symlink(oldname, symlink); err != nil {
+		return err
+	}
+
+	if err := os.Rename(symlink, newname); err != nil {
+		return err
+	}
+
+	cleanup = false
+	return os.RemoveAll(d)
+}

--- a/vendor/github.com/google/renameio/writefile.go
+++ b/vendor/github.com/google/renameio/writefile.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package renameio
+
+import "os"
+
+// WriteFile mirrors ioutil.WriteFile, replacing an existing file with the same
+// name atomically.
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	t, err := TempFile("", filename)
+	if err != nil {
+		return err
+	}
+	defer t.Cleanup()
+
+	// Set permissions before writing data, in case the data is sensitive.
+	if err := t.Chmod(perm); err != nil {
+		return err
+	}
+
+	if _, err := t.Write(data); err != nil {
+		return err
+	}
+
+	return t.CloseAtomicallyReplace()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,6 +76,9 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
+# github.com/google/renameio v1.0.1
+## explicit; go 1.13
+github.com/google/renameio
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap


### PR DESCRIPTION
If set, ggcr will store and load ping responses and token responses to
avoid re-authenticating on every invocation. Currently, this writes out
files that it will ignore after 10 minutes (based on file modtime) to
avoid using an expired token.

We can do more clever things in the future like respecting ExpiresIn
from the token response.

On windows this won't work because renameio doesn't work on windows.