### PR TITLE
fix: remove current time from random.Image history

### DIFF
--- a/pkg/v1/random/image.go
+++ b/pkg/v1/random/image.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -69,7 +68,6 @@ func Image(byteSize, layers int64, options ...Option) (v1.Image, error) {
 				Author:    "random.Image",
 				Comment:   fmt.Sprintf("this is a random history %d of %d", i, layers),
 				CreatedBy: "random",
-				Created:   v1.Time{Time: time.Now()},
 			},
 		})
 	}

--- a/pkg/v1/random/image_test.go
+++ b/pkg/v1/random/image_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
@@ -167,5 +168,39 @@ func TestRandomLayerSource(t *testing.T) {
 
 	if bytes.Equal(dataA, dataB) {
 		t.Error("Expected the layer data to be different with different random seeds")
+	}
+}
+
+func TestRandomImageSource(t *testing.T) {
+	imageDigest := func(o ...Option) v1.Hash {
+		img, err := Image(1024, 2, o...)
+		if err != nil {
+			t.Fatalf("Image: %v", err)
+		}
+
+		h, err := img.Digest()
+		if err != nil {
+			t.Fatalf("Digest(): %v", err)
+		}
+		return h
+	}
+
+	digest0a := imageDigest(WithSource(rand.NewSource(0)))
+	digest0b := imageDigest(WithSource(rand.NewSource(0)))
+	digest1 := imageDigest(WithSource(rand.NewSource(1)))
+
+	if digest0a != digest0b {
+		t.Error("Expected the image digest to be the same with the same seed")
+	}
+
+	if digest0a == digest1 {
+		t.Error("Expected the image digest to be different with different seeds")
+	}
+
+	digestA := imageDigest()
+	digestB := imageDigest()
+
+	if digestA == digestB {
+		t.Error("Expected the image digest to be different with different random seeds")
 	}
 }

--- a/pkg/v1/random/index_test.go
+++ b/pkg/v1/random/index_test.go
@@ -15,8 +15,10 @@
 package random
 
 import (
+	"math/rand"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 )
@@ -60,5 +62,39 @@ func TestRandomIndex(t *testing.T) {
 
 	if got, want := man.MediaType, types.OCIImageIndex; got != want {
 		t.Errorf("MediaType: got: %v, want: %v", got, want)
+	}
+}
+
+func TestRandomIndexSource(t *testing.T) {
+	indexDigest := func(o ...Option) v1.Hash {
+		img, err := Index(1024, 2, 2, o...)
+		if err != nil {
+			t.Fatalf("Image: %v", err)
+		}
+
+		h, err := img.Digest()
+		if err != nil {
+			t.Fatalf("Digest(): %v", err)
+		}
+		return h
+	}
+
+	digest0a := indexDigest(WithSource(rand.NewSource(0)))
+	digest0b := indexDigest(WithSource(rand.NewSource(0)))
+	digest1 := indexDigest(WithSource(rand.NewSource(1)))
+
+	if digest0a != digest0b {
+		t.Error("Expected the index digest to be the same with the same seed")
+	}
+
+	if digest0a == digest1 {
+		t.Error("Expected the index digest to be different with different seeds")
+	}
+
+	digestA := indexDigest()
+	digestB := indexDigest()
+
+	if digestA == digestB {
+		t.Error("Expected the index digest to be different with different random seeds")
 	}
 }


### PR DESCRIPTION
The history contained the `time.Now()` which I missed in my prior PR #1675 .  Using the current time makes the random images non-reproducible which defeats the purpose of setting the random source. I removed the CreatedBy time since it is optional according to the OCI spec.  We could instead use the random source to generate a random time but the time is not used for anything important so I do not see the value in doing that.

I added tests that revealed the issue then fixed the issue.

Related to #1674 