### PR TITLE
Add ppc64le to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
     - arm64
     - 386
     - s390x
+    - ppc64le
   goos:
     - linux
     - darwin


### PR DESCRIPTION
Hi All 

love this code, I am using it on multiple architectures, and would like to add the PowerPC (ppc64le) architecture was not included (in the container image it is). 

This is to make the release consistent and ensure the ppc64le is available.

Thanks

Paul