### PR TITLE
Add --all-tags flag to crane cp

### DIFF
--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -15,20 +15,36 @@
 package cmd
 
 import (
+	"runtime"
+
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
 )
 
 // NewCmdCopy creates a new cobra.Command for the copy subcommand.
 func NewCmdCopy(options *[]crane.Option) *cobra.Command {
-	return &cobra.Command{
+	allTags := false
+	noclobber := false
+	jobs := runtime.GOMAXPROCS(0)
+	cmd := &cobra.Command{
 		Use:     "copy SRC DST",
 		Aliases: []string{"cp"},
 		Short:   "Efficiently copy a remote image from src to dst while retaining the digest value",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
+			opts := append(*options, crane.WithJobs(jobs), crane.WithNoClobber(noclobber))
 			src, dst := args[0], args[1]
-			return crane.Copy(src, dst, *options...)
+			if allTags {
+				return crane.CopyRepository(src, dst, opts...)
+			}
+
+			return crane.Copy(src, dst, opts...)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&allTags, "all-tags", "a", false, "(Optional) if true, copy all tags from SRC to DST")
+	cmd.Flags().BoolVarP(&noclobber, "no-clobber", "n", false, "(Optional) if true, avoid overwriting existing tags in DST")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "(Optional) The maximum number of concurrent copies, defaults to GOMAXPROCS")
+
+	return cmd
 }

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -9,7 +9,10 @@ crane copy SRC DST [flags]
 ### Options
 
 ```
-  -h, --help   help for copy
+  -a, --all-tags     (Optional) if true, copy all tags from SRC to DST
+  -h, --help         help for copy
+  -j, --jobs int     (Optional) The maximum number of concurrent copies, defaults to GOMAXPROCS
+  -n, --no-clobber   (Optional) if true, avoid overwriting existing tags in DST
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This will copy every tag in the src repo to dst.

This adds a --no-clobber flag that crane cp will respect that avoids overwriting an existing tag (at the time of command invocation).

Fixes https://github.com/google/go-containerregistry/issues/1355