### PR TITLE
Add ppc64le to all binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,7 @@ builds:
     - arm64
     - 386
     - s390x
+    - ppc64le
   goos:
     - linux
     - darwin
@@ -79,6 +80,7 @@ builds:
     - arm64
     - 386
     - s390x
+    - ppc64le
   goos:
     - linux
     - darwin


### PR DESCRIPTION
goreleaser failed with:

archive has different count of binaries for each platform, which may cause your users confusion.