### PR TITLE
Do not reuse pushers for pullers

### DIFF
--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -32,13 +32,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-func fetcherFromWriter(w *writer) *fetcher {
-	return &fetcher{
-		target: w.repo,
-		client: w.client,
-	}
-}
-
 // fetcher implements methods for reading from a registry.
 type fetcher struct {
 	target resource

--- a/pkg/v1/remote/puller.go
+++ b/pkg/v1/remote/puller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -72,21 +71,6 @@ func (r *reader) init(ctx context.Context) error {
 }
 
 func (p *Puller) fetcher(ctx context.Context, target resource) (*fetcher, error) {
-	// If we are Reuse()ing a Pusher, we want to use that for token handshakes and scopes,
-	// but we want to do read requests via a fetcher{}.
-	//
-	// TODO(jonjohnsonjr): Unify fetcher, writer, and repoWriter.
-	if p.o.pusher != nil {
-		if repo, ok := target.(name.Repository); ok {
-			w, err := p.o.pusher.writer(ctx, repo, p.o)
-			if err == nil {
-				return fetcherFromWriter(w.w), nil
-			}
-			logs.Debug.Printf("reusing Pusher failed: %v", err)
-		}
-	}
-
-	// Normal path for NewPuller.
 	v, _ := p.readers.LoadOrStore(target, &reader{
 		target: target,
 		o:      p.o,


### PR DESCRIPTION
This causes issues with broken registry implementations that 403 if you have requested push scopes even for pull operations.

See https://github.com/sigstore/cosign/issues/2973