### PR TITLE
fixed a goroutine leak

### DIFF
--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -196,6 +196,7 @@ func (l Path) WriteBlob(hash v1.Hash, r io.ReadCloser) error {
 }
 
 func (l Path) writeBlob(hash v1.Hash, size int64, rc io.ReadCloser, renamer func() (v1.Hash, error)) error {
+	defer rc.Close()
 	if hash.Hex == "" && renamer == nil {
 		panic("writeBlob called an invalid hash and no renamer")
 	}


### PR DESCRIPTION
If the rc is not closed (which happens when the files with the same digest already exists, due to the same image being added to the OCI layout directory twice) then 
```go
if s, err := os.Stat(file); err == nil && !s.IsDir() && (s.Size() == size || size == -1) {
	return nil
}
```
will not close the io.ReadCloser leaking a goroutine [here](https://github.com/ktarplee/go-containerregistry/blob/009eea0d1c371a8bc3ba6898a2e88d6fab35eecf/internal/gzip/zip.go#L53)