### PR TITLE
retry HTTP 522 errors by default

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -96,7 +96,8 @@ var defaultRetryStatusCodes = []int{
 	http.StatusBadGateway,
 	http.StatusServiceUnavailable,
 	http.StatusGatewayTimeout,
-	499,
+	499, // nginx-specific, client closed request
+	522, // Cloudflare-specific, connection timeout
 }
 
 const (


### PR DESCRIPTION
Previously, on X-Men: https://github.com/google/go-containerregistry/pull/1612

https://http.dev/522 says:

> HTTP response status code 522 Connection timed out is an unofficial server error that is specific to Cloudflare. This HTTP status code occurs when Cloudflare is unable to connect to the [origin](https://http.dev/origins) server due to a timeout.