### PR TITLE
Limit size of manifest

### DIFF
--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -32,6 +32,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+const (
+	kib           = 1024
+	mib           = 1024 * kib
+	manifestLimit = 100 * mib
+)
+
 // fetcher implements methods for reading from a registry.
 type fetcher struct {
 	target resource
@@ -130,7 +136,7 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 		return nil, nil, err
 	}
 
-	manifest, err := io.ReadAll(resp.Body)
+	manifest, err := io.ReadAll(io.LimitReader(resp.Body, manifestLimit))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This adds a limit to the size of manifest that can get pulled.

Since the manifest is untrusted, this imposes a security risk to go-containerregistry users; If the size of the manifest is excessive compared to the ressources available on the machine running go-containerregistry, then a large manifest could cause Denial of Service by exhausting the memory of the machine.