### PR TITLE
fix: add bounds checking to addendum layer mutations to prevent panic

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -402,7 +402,9 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 			historyIdx++
 			break
 		}
-		addendums[addendumIdx].Layer = newLayer
+		if addendumIdx < len(addendums) {
+			addendums[addendumIdx].Layer = newLayer
+		}
 	}
 
 	// add all leftover History entries


### PR DESCRIPTION
fixes #1646 

Based on PR by @Gnoale here - https://github.com/GoogleContainerTools/kaniko/pull/2538.  From the PR there - "It seems that the addendums slice index is incremented twice in cases there is an empty layer in the history" <-- this seems to lead to a possibly unexpected case where addendumIdx > len(addendums) which makes addendums[addendumIdx] panic

Adding context from the above issue in the description below vvv:
Currently in kaniko v1.9.2+ (which uses go-containerregistry v0.14.0+) a panic occurs when attempting to call go-containerregistry related to the code here:
https://github.com/google/go-containerregistry/blob/main/pkg/v1/mutate/mutate.go#L405

No errors using the same dockerfile with kaniko v1.9.1 which uses go-containerregistry v0.8.1-0.20220507185902-82405e5dfa82

The likely cuplrit is commit https://github.com/google/go-containerregistry/commit/9db616f1dab14326675b8f0b8b360a3066fe3348, since the error happens in mutate.Time after trying to index the addendums slice.  The PR adds an additional bounds check on `addendums` before mutating. 