### PR TITLE
Make ErrSchema1 checkable via errors.Is()

### DIFF
--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -16,6 +16,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -33,20 +34,11 @@ var allManifestMediaTypes = append(append([]types.MediaType{
 // ErrSchema1 indicates that we received a schema1 manifest from the registry.
 // This library doesn't have plans to support this legacy image format:
 // https://github.com/google/go-containerregistry/issues/377
-type ErrSchema1 struct {
-	schema string
-}
+var ErrSchema1 = errors.New("see https://github.com/google/go-containerregistry/issues/377")
 
 // newErrSchema1 returns an ErrSchema1 with the unexpected MediaType.
 func newErrSchema1(schema types.MediaType) error {
-	return &ErrSchema1{
-		schema: string(schema),
-	}
-}
-
-// Error implements error.
-func (e *ErrSchema1) Error() string {
-	return fmt.Sprintf("unsupported MediaType: %q, see https://github.com/google/go-containerregistry/issues/377", e.schema)
+	return fmt.Errorf("unsupported MediaType: %q, %w", schema, ErrSchema1)
 }
 
 // Descriptor provides access to metadata about remote artifact and accessors

--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -72,7 +72,7 @@ func TestGetSchema1(t *testing.T) {
 	want := `unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377`
 	// Should fail based on media type.
 	if _, err := desc.Image(); err != nil {
-		if errors.Is(err, &ErrSchema1{}) {
+		if !errors.Is(err, ErrSchema1) {
 			t.Errorf("Image() = %v, expected remote.ErrSchema1", err)
 		}
 		if diff := cmp.Diff(want, err.Error()); diff != "" {
@@ -84,8 +84,7 @@ func TestGetSchema1(t *testing.T) {
 
 	// Should fail based on media type.
 	if _, err := desc.ImageIndex(); err != nil {
-		var s1err ErrSchema1
-		if errors.Is(err, &s1err) {
+		if !errors.Is(err, ErrSchema1) {
 			t.Errorf("ImageImage() = %v, expected remote.ErrSchema1", err)
 		}
 	} else {


### PR DESCRIPTION
The `TestGetSchema1` said it should fail based on media type while gave the unsupported MediaType. But it not return the true.

This fixes that problem by implementing an `Is()` function on `ErrSchema1`
so that `errors.Is()` can properly identify the error as an ErrSchema1.
Usage can now be: `errors.Is(err, &ErrSchema1{schema : "foo"})`