### PR TITLE
Surface better error messages in crane index

### DIFF
--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -70,9 +70,16 @@ func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			base, err := remote.Index(ref, o.Remote...)
+			desc, err := remote.Get(ref, o.Remote...)
 			if err != nil {
 				return fmt.Errorf("pulling %s: %w", baseRef, err)
+			}
+			if !desc.MediaType.IsIndex() {
+				return fmt.Errorf("expected %s to be an index, got %q", baseRef, desc.MediaType)
+			}
+			base, err := desc.ImageIndex()
+			if err != nil {
+				return nil
 			}
 
 			idx := filterIndex(base, platforms.platforms)
@@ -153,9 +160,16 @@ The platform for appended manifests is inferred from the config file or omitted 
 				if err != nil {
 					return err
 				}
-				base, err = remote.Index(ref, o.Remote...)
+				desc, err := remote.Get(ref, o.Remote...)
 				if err != nil {
 					return fmt.Errorf("pulling %s: %w", baseRef, err)
+				}
+				if !desc.MediaType.IsIndex() {
+					return fmt.Errorf("expected %s to be an index, got %q", baseRef, desc.MediaType)
+				}
+				base, err = desc.ImageIndex()
+				if err != nil {
+					return err
 				}
 			}
 


### PR DESCRIPTION
If we're trying to do things to a non-index, we should fail earlier.

Fixes: https://github.com/google/go-containerregistry/issues/1720

Before:

```
$ crane index filter docker.io/neuvector/scanner:latest --platform linux/amd64
Error: pulling docker.io/neuvector/scanner:latest: unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377
```

After:

```
$ crane index filter docker.io/neuvector/scanner:latest --platform linux/amd64
Error: expected docker.io/neuvector/scanner:latest to be index, got "application/vnd.docker.distribution.manifest.v2+json"
```