### PR TITLE
crane: Respect cmd.OutOrStdout

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -45,7 +45,7 @@ If the base image is a Windows base image (i.e., its config.OS is "windows"),
 the contents of the tarballs will be modified to be suitable for a Windows
 container image.`,
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var base v1.Image
 			var err error
 
@@ -103,7 +103,7 @@ container image.`,
 				if err != nil {
 					return fmt.Errorf("digest: %w", err)
 				}
-				fmt.Println(ref.Context().Digest(d.String()))
+				fmt.Fprintln(cmd.OutOrStdout(), ref.Context().Digest(d.String()))
 			}
 			return nil
 		},

--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -97,7 +97,7 @@ $ curl -H "$(crane auth token -H ubuntu)" https://index.docker.io/v2/library/ubu
 			}
 
 			if header {
-				fmt.Printf("Authorization: Bearer %s", tr.Token)
+				fmt.Fprintf(cmd.OutOrStdout(), "Authorization: Bearer %s", tr.Token)
 				return nil
 			}
 

--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"path"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -35,7 +36,7 @@ func NewCmdCatalog(options *[]crane.Option, _ ...string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := crane.GetOptions(*options...)
 
-			return catalog(cmd.Context(), args[0], fullRef, o)
+			return catalog(cmd.Context(), cmd.OutOrStdout(), args[0], fullRef, o)
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
@@ -43,7 +44,7 @@ func NewCmdCatalog(options *[]crane.Option, _ ...string) *cobra.Command {
 	return cmd
 }
 
-func catalog(ctx context.Context, src string, fullRef bool, o crane.Options) error {
+func catalog(ctx context.Context, w io.Writer, src string, fullRef bool, o crane.Options) error {
 	reg, err := name.NewRegistry(src, o.Name...)
 	if err != nil {
 		return fmt.Errorf("parsing reg %q: %w", src, err)
@@ -66,9 +67,9 @@ func catalog(ctx context.Context, src string, fullRef bool, o crane.Options) err
 		}
 		for _, repo := range repos.Repos {
 			if fullRef {
-				fmt.Println(path.Join(src, repo))
+				fmt.Fprintln(w, path.Join(src, repo))
 			} else {
-				fmt.Println(repo)
+				fmt.Fprintln(w, repo)
 			}
 		}
 	}

--- a/cmd/crane/cmd/config.go
+++ b/cmd/crane/cmd/config.go
@@ -27,12 +27,12 @@ func NewCmdConfig(options *[]crane.Option) *cobra.Command {
 		Use:   "config IMAGE",
 		Short: "Get the config of an image",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := crane.Config(args[0], *options...)
 			if err != nil {
 				return fmt.Errorf("fetching config: %w", err)
 			}
-			fmt.Print(string(cfg))
+			fmt.Fprint(cmd.OutOrStdout(), string(cfg))
 			return nil
 		},
 	}

--- a/cmd/crane/cmd/digest.go
+++ b/cmd/crane/cmd/digest.go
@@ -51,9 +51,9 @@ func NewCmdDigest(options *[]crane.Option) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Println(ref.Context().Digest(digest))
+				fmt.Fprintln(cmd.OutOrStdout(), ref.Context().Digest(digest))
 			} else {
-				fmt.Println(digest)
+				fmt.Fprintln(cmd.OutOrStdout(), digest)
 			}
 			return nil
 		},

--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -83,7 +83,7 @@ func NewCmdFlatten(options *[]crane.Option) *cobra.Command {
 			if err := push(flat, newRef, o); err != nil {
 				log.Fatalf("pushing %s: %v", newRef, err)
 			}
-			fmt.Println(repo.Digest(digest.String()))
+			fmt.Fprintln(cmd.OutOrStdout(), repo.Digest(digest.String()))
 		},
 	}
 	flattenCmd.Flags().StringVarP(&dst, "tag", "t", "", "New tag to apply to flattened image. If not provided, push by digest to the original image repository.")

--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -62,7 +62,7 @@ func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
   # Same as above, but in-place
   crane index filter example.com/hello-world:some-tag --platform linux`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			o := crane.GetOptions(*options...)
 			baseRef := args[0]
 
@@ -103,7 +103,7 @@ func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
 			if err := remote.WriteIndex(ref, idx, o.Remote...); err != nil {
 				return fmt.Errorf("pushing image %s: %w", newTag, err)
 			}
-			fmt.Println(ref.Context().Digest(digest.String()))
+			fmt.Fprintln(cmd.OutOrStdout(), ref.Context().Digest(digest.String()))
 			return nil
 		},
 	}
@@ -133,7 +133,7 @@ The platform for appended manifests is inferred from the config file or omitted 
   # Create an index from scratch for etcd.
   crane index append -m registry.k8s.io/etcd-amd64:3.4.9 -m registry.k8s.io/etcd-arm64:3.4.9 -t example.com/etcd`,
 		Args: cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				baseRef = args[0]
 			}
@@ -267,7 +267,7 @@ The platform for appended manifests is inferred from the config file or omitted 
 			if err := remote.WriteIndex(ref, idx, o.Remote...); err != nil {
 				return fmt.Errorf("pushing image %s: %w", newTag, err)
 			}
-			fmt.Println(ref.Context().Digest(digest.String()))
+			fmt.Fprintln(cmd.OutOrStdout(), ref.Context().Digest(digest.String()))
 			return nil
 		},
 	}

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -35,7 +36,7 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := crane.GetOptions(*options...)
 
-			return list(cmd.Context(), args[0], fullRef, omitDigestTags, o)
+			return list(cmd.Context(), cmd.OutOrStdout(), args[0], fullRef, omitDigestTags, o)
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
@@ -43,7 +44,7 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 	return cmd
 }
 
-func list(ctx context.Context, src string, fullRef, omitDigestTags bool, o crane.Options) error {
+func list(ctx context.Context, w io.Writer, src string, fullRef, omitDigestTags bool, o crane.Options) error {
 	repo, err := name.NewRepository(src, o.Name...)
 	if err != nil {
 		return fmt.Errorf("parsing repo %q: %w", src, err)
@@ -70,9 +71,9 @@ func list(ctx context.Context, src string, fullRef, omitDigestTags bool, o crane
 			}
 
 			if fullRef {
-				fmt.Println(repo.Tag(tag))
+				fmt.Fprintln(w, repo.Tag(tag))
 			} else {
-				fmt.Println(tag)
+				fmt.Fprintln(w, tag)
 			}
 		}
 	}

--- a/cmd/crane/cmd/manifest.go
+++ b/cmd/crane/cmd/manifest.go
@@ -27,13 +27,13 @@ func NewCmdManifest(options *[]crane.Option) *cobra.Command {
 		Use:   "manifest IMAGE",
 		Short: "Get the manifest of an image",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			src := args[0]
 			manifest, err := crane.Manifest(src, *options...)
 			if err != nil {
 				return fmt.Errorf("fetching manifest %s: %w", src, err)
 			}
-			fmt.Print(string(manifest))
+			fmt.Fprint(cmd.OutOrStdout(), string(manifest))
 			return nil
 		},
 	}

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -44,7 +44,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 		Use:   "mutate",
 		Short: "Modify image labels and annotations. The container must be pushed to a registry, and the manifest is updated there.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(c *cobra.Command, args []string) error {
 			// Pull image and get config.
 			ref := args[0]
 
@@ -166,7 +166,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				if err := crane.Push(img, newRef, *options...); err != nil {
 					return fmt.Errorf("pushing %s: %w", newRef, err)
 				}
-				fmt.Println(r.Context().Digest(digest.String()))
+				fmt.Fprintln(c.OutOrStdout(), r.Context().Digest(digest.String()))
 			}
 			return nil
 		},

--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -36,7 +36,7 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 		Short: "Push local image contents to a remote registry",
 		Long:  `If the PATH is a directory, it will be read as an OCI image layout. Otherwise, PATH is assumed to be a docker-style tarball.`,
 		Args:  cobra.ExactArgs(2),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			path, tag := args[0], args[1]
 
 			img, err := loadImage(path, index)
@@ -75,7 +75,7 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 			}
 
 			// Print the digest of the pushed image to stdout to facilitate command composition.
-			fmt.Println(digest)
+			fmt.Fprintln(cmd.OutOrStdout(), digest)
 
 			return nil
 		},

--- a/cmd/crane/cmd/rebase.go
+++ b/cmd/crane/cmd/rebase.go
@@ -123,7 +123,7 @@ func NewCmdRebase(options *[]crane.Option) *cobra.Command {
 				log.Fatalf("pushing %s: %v", rebased, err)
 			}
 
-			fmt.Println(r.Context().Digest(rebasedDigest.String()))
+			fmt.Fprintln(cmd.OutOrStdout(), r.Context().Digest(rebasedDigest.String()))
 			return nil
 		},
 	}

--- a/cmd/crane/cmd/validate.go
+++ b/cmd/crane/cmd/validate.go
@@ -35,7 +35,7 @@ func NewCmdValidate(options *[]crane.Option) *cobra.Command {
 		Use:   "validate",
 		Short: "Validate that an image is well-formed",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			for flag, maker := range map[string]func(string, ...crane.Option) (v1.Image, error){
 				tarballPath: makeTarball,
 				remoteRef:   crane.Pull,
@@ -53,10 +53,10 @@ func NewCmdValidate(options *[]crane.Option) *cobra.Command {
 					opt = append(opt, validate.Fast)
 				}
 				if err := validate.Image(img, opt...); err != nil {
-					fmt.Printf("FAIL: %s: %v\n", flag, err)
+					fmt.Fprintf(cmd.OutOrStdout(), "FAIL: %s: %v\n", flag, err)
 					return err
 				}
-				fmt.Printf("PASS: %s\n", flag)
+				fmt.Fprintf(cmd.OutOrStdout(), "PASS: %s\n", flag)
 			}
 			return nil
 		},

--- a/cmd/crane/cmd/version.go
+++ b/cmd/crane/cmd/version.go
@@ -45,11 +45,11 @@ func NewCmdVersion() *cobra.Command {
 This could be an arbitrary string, if specified via -ldflags.
 This could also be the go module version, if built with go modules (often "(devel)").`,
 		Args: cobra.NoArgs,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			if Version == "" {
-				fmt.Println("could not determine build information")
+				fmt.Fprintln(cmd.OutOrStdout(), "could not determine build information")
 			} else {
-				fmt.Println(Version)
+				fmt.Fprintln(cmd.OutOrStdout(), Version)
 			}
 		},
 	}


### PR DESCRIPTION
When calling Crane programmatically, it's difficult to capture the output as it's written directly to stdout. This change uses Cobra's built-in support for changing stdout to an io.Writer.