### PR TITLE
Drop localhost to support crane registry serve in a container

### DIFF
--- a/cmd/crane/cmd/serve.go
+++ b/cmd/crane/cmd/serve.go
@@ -54,7 +54,7 @@ Contents are only stored in memory, and when the process exits, pushed data is l
 			if port == "" {
 				port = "0"
 			}
-			listener, err := net.Listen("tcp", "localhost:"+port)
+			listener, err := net.Listen("tcp", ":"+port)
 			if err != nil {
 				log.Fatalln(err)
 			}


### PR DESCRIPTION
This allows you to run `docker run -e PORT=1234 --name foo.local cgr.dev/chainguard/crane registry serve` and then `--link foo.local` to push to `foo.local:1234`.

Right now it only listens on the loopback interface, so unless it's run in a K8s-style pod with something that exposes and proxies things (e.g. like Knative / Cloud Run), it is inaccessible.