### PR TITLE
Adjust referrers fallback behavior to be optional

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -595,7 +596,7 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 
 		// If the manifest referred to a subject, we may need to update the fallback tag manifest.
 		// TODO: If this fails, we'll retry the whole upload. We should retry just this part.
-		if mf.Subject != nil {
+		if mf.Subject != nil && os.Getenv("GGCR_REF_FALLBACK") != "" {
 			h, size, err := v1.SHA256(bytes.NewReader(raw))
 			if err != nil {
 				return err


### PR DESCRIPTION
I was talking with @jonjohnsonjr about using `crane cp` in a use case where I never want it to accidentally surprise me with the fallback tags, so this implements a very basic means of making that behavior optional.

I figured having a PR would give us a stronger straw-man to discuss the finer details around, especially since I don't feel like I know this library/codebase well enough to make actual informed recommendations for how I'd like to see this implemented. :sweat_smile:

(As always, happy to rebase, amend, adjust, rewrite, reword, close, let someone else take over, etc as desired!)