### PR TITLE
fix: ignore empty fields when validating

### DIFF
--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 )
@@ -87,7 +88,7 @@ func validateConfig(img v1.Image) error {
 		errs = append(errs, fmt.Sprintf("mismatched config size: Manifest.Config.Size()=%d, len(RawConfigFile())=%d", want, got))
 	}
 
-	if diff := cmp.Diff(pcf, cf); diff != "" {
+	if diff := cmp.Diff(pcf, cf, cmpopts.EquateEmpty()); diff != "" {
 		errs = append(errs, fmt.Sprintf("mismatched config content: (-ParseConfigFile(RawConfigFile()) +ConfigFile()) %s", diff))
 	}
 
@@ -253,7 +254,7 @@ func validateManifest(img v1.Image) error {
 		errs = append(errs, fmt.Sprintf("mismatched manifest digest: Digest()=%s, SHA256(RawManifest())=%s", digest, hash))
 	}
 
-	if diff := cmp.Diff(pm, m); diff != "" {
+	if diff := cmp.Diff(pm, m, cmpopts.EquateEmpty()); diff != "" {
 		errs = append(errs, fmt.Sprintf("mismatched manifest content: (-ParseManifest(RawManifest()) +Manifest()) %s", diff))
 	}
 


### PR DESCRIPTION
Currently validation is performed by comparing using `cmp.Diff` both configs and manifests, but this could result in false positives depending on how the images are built/parsed, such as:
```
  &v1.Manifest{
  	SchemaVersion: 2,
  	MediaType:     "application/vnd.docker.distribution.manifest.v2+json",
  	Config:        {MediaType: "application/vnd.docker.container.image.v1+json", Size: 233, Digest: {Algorithm: "sha256", Hex: "d13f3aa025daec00a0398dda4a3c71613494f8f339140256658b553f14533605"}},
  	Layers: []v1.Descriptor{
  		{
  			... // 3 identical fields
  			Data:         nil,
  			URLs:         nil,
- 			Annotations:  nil,
+ 			Annotations:  map[string]string{},
  			Platform:     nil,
  			ArtifactType: "",
  		},
  	},
  	Annotations: nil,
  	Subject:     nil,
  }
```

Which I think this is not the desired behavior.