### PR TITLE
fix: pin to goreleaser v1.18 to unblock release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4.2.0
         id: run-goreleaser
         with:
-          version: latest
+          version: v1.18.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v0.16.0 release failed with 

```
  line 94: field replacements not found in type config.Archive
```

https://github.com/google/go-containerregistry/actions/runs/5743578802/job/15568191187

That line hasn't changed in 3 years (https://github.com/google/go-containerregistry/commit/96cf69f03a3cf2d9c8850ce9d8e1f33da354826a) and the file hasn't changed since v0.15.2 where this wasn't a problem.

My only thinking is that the version of goreleaser changed from 1.18 to 1.19 since the v0.15.2 release (https://github.com/google/go-containerregistry/actions/runs/4996651209/job/13531871710)

So let's pin to 1.18 and see if it helps.