### PR TITLE
Set Content-Length for blob uploads

### DIFF
--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -280,6 +280,11 @@ func (w *writer) streamBlob(ctx context.Context, layer v1.Layer, streamLocation 
 	if _, ok := layer.(*stream.Layer); !ok {
 		// We can't retry streaming layers.
 		req.GetBody = getBody
+
+		// If we know the size, set it.
+		if size, err := layer.Size(); err == nil {
+			req.ContentLength = size
+		}
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 


### PR DESCRIPTION
Sometimes we know it, sometimes we don't. When we do, set it.