### PR TITLE
Don't wrap DefaultKeychain with refreshes

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -53,7 +53,7 @@ type defaultKeychain struct {
 
 var (
 	// DefaultKeychain implements Keychain by interpreting the docker config file.
-	DefaultKeychain = RefreshingKeychain(&defaultKeychain{}, 5*time.Minute)
+	DefaultKeychain = &defaultKeychain{}
 )
 
 const (


### PR DESCRIPTION
The heuristic only works well if the upstream keychain doesn't do any caching. This is usually the case, but I've run into a couple situations where the hardcoded 5 minutes does not overlap well with certain cred helper implementations.

Undoing that wrap allows callers to set a time that makes sense for them. With the wrap, there's not any direct reference to DefaultKeychain, which feels... bad.