### PR TITLE
feat: Add zstd compression to crane append and mutate

### DIFF
--- a/cmd/crane/cmd/append.go
+++ b/cmd/crane/cmd/append.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/compression"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -33,6 +34,7 @@ func NewCmdAppend(options *[]crane.Option) *cobra.Command {
 	var baseRef, newTag, outFile string
 	var newLayers []string
 	var annotate, ociEmptyBase bool
+	var comp = compression.GZip
 
 	appendCmd := &cobra.Command{
 		Use:   "append",
@@ -63,7 +65,7 @@ container image.`,
 				}
 			}
 
-			img, err := crane.Append(base, newLayers...)
+			img, err := crane.AppendWithCompression(base, comp, newLayers...)
 			if err != nil {
 				return fmt.Errorf("appending %v: %w", newLayers, err)
 			}
@@ -111,6 +113,7 @@ container image.`,
 	appendCmd.Flags().StringVarP(&baseRef, "base", "b", "", "Name of base image to append to")
 	appendCmd.Flags().StringVarP(&newTag, "new_tag", "t", "", "Tag to apply to resulting image")
 	appendCmd.Flags().StringSliceVarP(&newLayers, "new_layer", "f", []string{}, "Path to tarball to append to image")
+	appendCmd.Flags().VarP(&comp, "compression", "c", "Compression to use for new layers")
 	appendCmd.Flags().StringVarP(&outFile, "output", "o", "", "Path to new tarball of resulting image")
 	appendCmd.Flags().BoolVar(&annotate, "set-base-image-annotations", false, "If true, annotate the resulting image as being based on the base image")
 	appendCmd.Flags().BoolVar(&ociEmptyBase, "oci-empty-base", false, "If true, empty base image will have OCI media types instead of Docker")

--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/compression"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -30,6 +31,7 @@ import (
 func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	var labels map[string]string
 	var annotations map[string]string
+	var comp = compression.GZip
 	var envVars keyToValue
 	var entrypoint, cmd []string
 	var newLayers []string
@@ -67,7 +69,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				return fmt.Errorf("pulling %s: %w", ref, err)
 			}
 			if len(newLayers) != 0 {
-				img, err = crane.Append(img, newLayers...)
+				img, err = crane.AppendWithCompression(img, comp, newLayers...)
 				if err != nil {
 					return fmt.Errorf("appending %v: %w", newLayers, err)
 				}
@@ -174,6 +176,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 	mutateCmd.Flags().StringToStringVarP(&annotations, "annotation", "a", nil, "New annotations to add")
 	mutateCmd.Flags().StringToStringVarP(&labels, "label", "l", nil, "New labels to add")
 	mutateCmd.Flags().VarP(&envVars, "env", "e", "New envvar to add")
+	mutateCmd.Flags().VarP(&comp, "compression", "c", "Compression to use for new layers")
 	mutateCmd.Flags().StringSliceVar(&entrypoint, "entrypoint", nil, "New entrypoint to set")
 	mutateCmd.Flags().StringSliceVar(&cmd, "cmd", nil, "New cmd to set")
 	mutateCmd.Flags().StringVar(&newRepo, "repo", "", "Repository to push the mutated image to. If provided, push by digest to this repository.")

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -20,6 +20,7 @@ crane append [flags]
 
 ```
   -b, --base string                  Name of base image to append to
+  -c  --compression                  Compression to use for new image layers. Gzip is the default, Zstd is also supported but only works for OCI base images.
   -h, --help                         help for append
   -f, --new_layer strings            Path to tarball to append to image
   -t, --new_tag string               Tag to apply to resulting image

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -11,6 +11,7 @@ crane mutate [flags]
 ```
   -a, --annotation stringToString   New annotations to add (default [])
       --append strings              Path to tarball to append to image
+  -c  --compression                 Compression to use for new image layers. Gzip is the default, Zstd is also supported but only works for OCI base images.
       --cmd strings                 New cmd to set
       --entrypoint strings          New entrypoint to set
   -e, --env keyToValue              New envvar to add

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -15,6 +15,8 @@
 // Package compression abstracts over gzip and zstd.
 package compression
 
+import "errors"
+
 // Compression is an enumeration of the supported compression algorithms
 type Compression string
 
@@ -24,3 +26,25 @@ const (
 	GZip Compression = "gzip"
 	ZStd Compression = "zstd"
 )
+
+// Used by fmt.Print and Cobra in help text
+func (e *Compression) String() string {
+	return string(*e)
+}
+
+func (e *Compression) Set(v string) error {
+	switch v {
+	case "none", "gzip", "zstd":
+		*e = Compression(v)
+		return nil
+	default:
+		return errors.New(`must be one of "none", "gzip, or "zstd"`)
+	}
+}
+
+// Used in Cobra help text
+func (e *Compression) Type() string {
+	return "Compression"
+}
+
+var ErrZStdNonOci = errors.New("ZSTD compression can only be used with an OCI base image")

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/go-containerregistry/internal/compare"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/compression"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -439,7 +440,7 @@ func TestCraneFilesystem(t *testing.T) {
 	tw.Flush()
 	tw.Close()
 
-	img, err = crane.Append(img, tmp.Name())
+	img, err = crane.AppendWithCompression(img, compression.GZip, tmp.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +501,7 @@ func TestStreamingAppend(t *testing.T) {
 
 	os.Stdin = tmp
 
-	img, err := crane.Append(empty.Image, "-")
+	img, err := crane.AppendWithCompression(empty.Image, compression.GZip, "-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Support for zstd-compression was added in #1487. Add handling for this to crane append and mutate which should allow other projects that use Crane to begin creating zstd images (notably [rules_oci](https://github.com/bazel-contrib/rules_oci/issues/333) which is used by distroless amongst other projects).