### PR TITLE
Fix windows race condition when writing image with duplicate layers

### DIFF
--- a/pkg/v1/layout/write.go
+++ b/pkg/v1/layout/write.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 
 	"github.com/google/go-containerregistry/pkg/logs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -36,6 +38,8 @@ import (
 var layoutFile = `{
     "imageLayoutVersion": "1.0.0"
 }`
+
+var renameMutex sync.Mutex
 
 // AppendImage writes a v1.Image to the Path and updates
 // the index.json to reference it.
@@ -259,6 +263,11 @@ func (l Path) writeBlob(hash v1.Hash, size int64, rc io.ReadCloser, renamer func
 	}
 
 	renamePath := l.path("blobs", finalHash.Algorithm, finalHash.Hex)
+
+	if runtime.GOOS == "windows" {
+		renameMutex.Lock()
+		defer renameMutex.Unlock()
+	}
 	return os.Rename(w.Name(), renamePath)
 }
 


### PR DESCRIPTION
This PR addresses #1794 by introducing a mutex around the os.Rename. A simple reproduction of the race condition can be found at https://go.dev/play/p/NmHg-CTUlhN?v=, which replicates the following codepath. https://github.com/google/go-containerregistry/blob/61bd7f84d2bdc5507a5e1df435250020bf951cc3/pkg/v1/layout/write.go#L344-L350

Note that the Go playgroud runs in a linux environment, so to test it you'll need to run it locally on windows. If you comment out the mutex, you'll find that you will get an access denied error.

Testing: I have tested locally that the crane repro mentioned in the issue now works.

Any feedback greatly appreciated.