### PR TITLE
fix: improve error message when ParseReference fails

### DIFF
--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -36,15 +36,22 @@ type Reference interface {
 	Scope(string) string
 }
 
-// ParseReference parses the string as a reference, either by tag or digest.
 func ParseReference(s string, opts ...Option) (Reference, error) {
-	if t, err := NewTag(s, opts...); err == nil {
+	var tagErr, digestErr error
+
+	if t, tagErr := NewTag(s, opts...); tagErr == nil {
 		return t, nil
 	}
-	if d, err := NewDigest(s, opts...); err == nil {
+
+	if d, digestErr := NewDigest(s, opts...); digestErr == nil {
 		return d, nil
 	}
-	return nil, newErrBadName("could not parse reference: " + s)
+
+	errMsg := fmt.Sprintf(
+		"could not parse reference '%s' as tag or digest: tag error: %v, digest error: %v",
+		s, tagErr, digestErr,
+	)
+	return nil, newErrBadName(errMsg)
 }
 
 type stringConst string

--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -38,12 +38,13 @@ type Reference interface {
 
 func ParseReference(s string, opts ...Option) (Reference, error) {
 	var tagErr, digestErr error
+	var t, d Reference
 
-	if t, tagErr := NewTag(s, opts...); tagErr == nil {
+	if t, tagErr = NewTag(s, opts...); tagErr == nil {
 		return t, nil
 	}
 
-	if d, digestErr := NewDigest(s, opts...); digestErr == nil {
+	if d, digestErr = NewDigest(s, opts...); digestErr == nil {
 		return d, nil
 	}
 


### PR DESCRIPTION
When given invalid reference name, `name.ParseReference` returns a generic error message:

```
package main

import (
	"fmt"

	"github.com/google/go-containerregistry/pkg/name"
)

var badTagNames = []string{
	"gcr.io/project-id/bad_chars:c@n'tuse",
	"gcr.io/project-id/wrong-length:white space",
	"gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends",
}

func main() {
	for _, n := range badTagNames {
		_, err := name.ParseReference(n)
		fmt.Printf("ParseReference(%q) returned err=%v\n", n, err)
	}
}

# ParseReference("gcr.io/project-id/bad_chars:c@n'tuse") returned err=could not parse reference: gcr.io/project-id/bad_chars:c@n'tuse
# ParseReference("gcr.io/project-id/wrong-length:white space") returned err=could not parse reference: gcr.io/project-id/wrong-length:white space
# ParseReference("gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends") returned err=could not parse reference: gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends

```
[playground](https://go.dev/play/p/9UXWRC78OBR)

The error message is succinct but unhelpful when the end user is trying to figure out why the given reference name is invalid.

We modify the code to include more descriptive error message on why the parsing failed as a tag or digest:

```
# could not parse reference 'gcr.io/project-id/bad_chars:c@n'tuse' as tag or digest: tag error: tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`: c@n'tuse, digest error: unsupported digest algorithm: n'tuse
# could not parse reference 'gcr.io/project-id/wrong-length:white space' as tag or digest: tag error: tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`: white space, digest error: a digest must contain exactly one '@' separator (e.g. registry/repository@digest) saw: gcr.io/project-id/wrong-length:white space
# could not parse reference 'gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends' as tag or digest: tag error: tag must be between 1 and 128 characters in length: thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends, digest error: a digest must contain exactly one '@' separator (e.g. registry/repository@digest) saw: gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends
```

The resulting error message is much more verbose, but clearly identifies the problem with the given resource name.