### PR TITLE
fix: mimic oci-layout in diskblobhandler

### DIFF
--- a/pkg/registry/blobs_disk_test.go
+++ b/pkg/registry/blobs_disk_test.go
@@ -15,6 +15,7 @@
 package registry_test
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func TestDiskPush(t *testing.T) {
 	if h, err := img.ConfigName(); err != nil {
 		t.Fatal(err)
 	} else {
-		want[h.String()] = true
+		want[fmt.Sprintf("%s/%s", h.Algorithm, h.Hex)] = true
 	}
 	ls, err := img.Layers()
 	if err != nil {
@@ -69,7 +70,7 @@ func TestDiskPush(t *testing.T) {
 		if h, err := l.Digest(); err != nil {
 			t.Fatal(err)
 		} else {
-			want[h.String()] = true
+			want[fmt.Sprintf("%s/%s", h.Algorithm, h.Hex)] = true
 		}
 	}
 


### PR DESCRIPTION
this change makes blob disk implementation mimic oci-layout for storing blobs.  This will speed up the pushing of 
oci-layout images on disk to the registry by providing the oci-layout image as the storage directory. 

Cross-ref: https://github.com/bazel-contrib/rules_oci/issues/365