### PR TITLE
feat: gcrane - Increase GCRBackoff Steps to 5 and decrease Factor to 5.0

### DIFF
--- a/internal/retry/wait/kubernetes_apimachinery_wait.go
+++ b/internal/retry/wait/kubernetes_apimachinery_wait.go
@@ -89,7 +89,7 @@ func (b *Backoff) Step() time.Duration {
 		b.Duration = time.Duration(float64(b.Duration) * b.Factor)
 		if b.Cap > 0 && b.Duration > b.Cap {
 			b.Duration = b.Cap
-			b.Steps = 0
+			b.Steps = 1
 		}
 	}
 

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -57,7 +57,7 @@ func GCRBackoff() retry.Backoff {
 		Duration: 6 * time.Second,
 		Factor:   5.0,
 		Jitter:   0.1,
-		Steps:    6,
+		Steps:    5,
 		Cap:      1 * time.Hour,
 	}
 }

--- a/pkg/gcrane/copy.go
+++ b/pkg/gcrane/copy.go
@@ -46,16 +46,18 @@ var Keychain = authn.NewMultiKeychain(google.Keychain, authn.DefaultKeychain)
 //
 // On error, we will wait for:
 // - 6 seconds (in case of very short term 429s from GCS), then
-// - 1 minute (in case of temporary network issues), then
-// - 10 minutes (to get around GCR 10 minute quotas), then fail.
+// - 30 seconds  (in case of very short term 429s from GCS), then
+// - 2.5 minutes (in case of temporary network issues), then
+// - 12.5 minutes (to get around GCR 10 minute quotas), then
+// - 1 hour (in case of longer term network issues), then fail.
 //
 // TODO: In theory, we could keep retrying until the next day to get around the 1M limit.
 func GCRBackoff() retry.Backoff {
 	return retry.Backoff{
 		Duration: 6 * time.Second,
-		Factor:   10.0,
+		Factor:   5.0,
 		Jitter:   0.1,
-		Steps:    3,
+		Steps:    6,
 		Cap:      1 * time.Hour,
 	}
 }

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -345,9 +345,6 @@ func TestBackoff(t *testing.T) {
 	if d := backoff.Step(); d > 4000*time.Second {
 		t.Errorf("Duration too long: %v", d)
 	}
-	if d := backoff.Step(); d > 4000*time.Second {
-		t.Errorf("Duration too long: %v", d)
-	}
 	if s := backoff.Steps; s != 0 {
 		t.Errorf("backoff.Steps should be 0, got %d", s)
 	}

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -336,7 +336,16 @@ func TestBackoff(t *testing.T) {
 	if d := backoff.Step(); d > 100*time.Second {
 		t.Errorf("Duration too long: %v", d)
 	}
+	if d := backoff.Step(); d > 200*time.Second {
+		t.Errorf("Duration too long: %v", d)
+	}
 	if d := backoff.Step(); d > 1000*time.Second {
+		t.Errorf("Duration too long: %v", d)
+	}
+	if d := backoff.Step(); d > 4000*time.Second {
+		t.Errorf("Duration too long: %v", d)
+	}
+	if d := backoff.Step(); d > 4000*time.Second {
 		t.Errorf("Duration too long: %v", d)
 	}
 	if s := backoff.Steps; s != 0 {


### PR DESCRIPTION
[ExponentialBackoff](https://github.com/google/go-containerregistry/blob/main/internal/retry/wait/kubernetes_apimachinery_wait.go#L117-L119) breaks the loop when `backoff.Steps == 1`. This might cause the `gcrane cp` command to fail with 429 errors when we have only 2 steps to `GCRBackoff` because the wait period is only ~1 minute.

For some reason I saw 429 errors from GCR even after a wait of 15 minutes. Do a couple of improvements to remediate this issue:
- Increase `Steps` to 5 to get more retries and a longer wait time on the last step.
- Decrease `Factor` to 5.0 to get more retries in a more tight schedule. Last wait time will be the `Cap` which is 1 hour.
- Set `b.Steps = 1` when `b.Duration > b.Cap`.

Fix the same issue as [this PR](https://github.com/google/go-containerregistry/pull/512).

Fixes #424 