### PR TITLE
✨ Add mTLS support for crane

### DIFF
--- a/cmd/crane/doc/crane.md
+++ b/cmd/crane/doc/crane.md
@@ -12,6 +12,8 @@ crane [flags]
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
   -h, --help                               help for crane
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_append.md
+++ b/cmd/crane/doc/crane_append.md
@@ -33,6 +33,8 @@ crane append [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth.md
+++ b/cmd/crane/doc/crane_auth.md
@@ -17,6 +17,8 @@ crane auth [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_get.md
+++ b/cmd/crane/doc/crane_auth_get.md
@@ -28,6 +28,8 @@ crane auth get [REGISTRY_ADDR] [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_login.md
+++ b/cmd/crane/doc/crane_auth_login.md
@@ -27,6 +27,8 @@ crane auth login [OPTIONS] [SERVER] [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_logout.md
+++ b/cmd/crane/doc/crane_auth_logout.md
@@ -24,6 +24,8 @@ crane auth logout [SERVER] [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_auth_token.md
+++ b/cmd/crane/doc/crane_auth_token.md
@@ -31,6 +31,8 @@ $ curl -H "$(crane auth token -H ubuntu)" https://index.docker.io/v2/library/ubu
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_blob.md
+++ b/cmd/crane/doc/crane_blob.md
@@ -23,6 +23,8 @@ crane blob ubuntu@sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac3
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_catalog.md
+++ b/cmd/crane/doc/crane_catalog.md
@@ -18,6 +18,8 @@ crane catalog REGISTRY [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_config.md
+++ b/cmd/crane/doc/crane_config.md
@@ -17,6 +17,8 @@ crane config IMAGE [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -20,6 +20,8 @@ crane copy SRC DST [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_delete.md
+++ b/cmd/crane/doc/crane_delete.md
@@ -17,6 +17,8 @@ crane delete IMAGE [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_digest.md
+++ b/cmd/crane/doc/crane_digest.md
@@ -19,6 +19,8 @@ crane digest IMAGE [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_export.md
+++ b/cmd/crane/doc/crane_export.md
@@ -30,6 +30,8 @@ crane export IMAGE|- TARBALL|- [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_flatten.md
+++ b/cmd/crane/doc/crane_flatten.md
@@ -18,6 +18,8 @@ crane flatten [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_index.md
+++ b/cmd/crane/doc/crane_index.md
@@ -17,6 +17,8 @@ crane index [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_index_append.md
+++ b/cmd/crane/doc/crane_index_append.md
@@ -37,6 +37,8 @@ crane index append [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_index_filter.md
+++ b/cmd/crane/doc/crane_index_filter.md
@@ -32,6 +32,8 @@ crane index filter [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
   -v, --verbose                            Enable debug logs
 ```
 

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -19,6 +19,8 @@ crane ls REPO [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_manifest.md
+++ b/cmd/crane/doc/crane_manifest.md
@@ -17,6 +17,8 @@ crane manifest IMAGE [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -29,6 +29,8 @@ crane mutate [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_pull.md
+++ b/cmd/crane/doc/crane_pull.md
@@ -20,6 +20,8 @@ crane pull IMAGE TARBALL [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -23,6 +23,8 @@ crane push PATH IMAGE [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_rebase.md
+++ b/cmd/crane/doc/crane_rebase.md
@@ -22,6 +22,8 @@ crane rebase [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_registry.md
+++ b/cmd/crane/doc/crane_registry.md
@@ -13,6 +13,8 @@
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_registry_serve.md
+++ b/cmd/crane/doc/crane_registry_serve.md
@@ -25,6 +25,8 @@ crane registry serve [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_tag.md
+++ b/cmd/crane/doc/crane_tag.md
@@ -38,6 +38,8 @@ crane tag ubuntu v1
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_validate.md
+++ b/cmd/crane/doc/crane_validate.md
@@ -20,6 +20,8 @@ crane validate [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```

--- a/cmd/crane/doc/crane_version.md
+++ b/cmd/crane/doc/crane_version.md
@@ -24,6 +24,8 @@ crane version [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --mtls-certificate string            Certificate path for mTLS
+      --mtls-key string                    Certificate key path for mTLS
       --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```


### PR DESCRIPTION
* Add two flags to pass client.cert/client.key for mTLS
* Use the provided certificate in the http transport for all requests

Usage example:
```console
$ ./crane validate --fast --remote docker.corp/busybox:1.34.1 
Error: failed to read image docker.corp/busybox:1.34.1: GET https://docker.corp/v2/: unexpected status code 400 Bad Request: <html>
<head><title>400 No required SSL certificate was sent</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<center>No required SSL certificate was sent</center>
<hr><center>nginx/1.21.6</center>
</body>
</html>
$ ./crane validate --fast --remote docker.corp/busybox:1.34.1 --mtls-certificate ~/.docker/certs.d/docker.corp/client.cert --mtls-key ~/.docker/certs.d/docker.corp/client.key
PASS: docker.corp/busybox:1.34.1
```