### PR TITLE
Always print pushed digest in crane push

### DIFF
--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -71,7 +71,9 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 
 			digest := ref.Context().Digest(h.String())
 			if imageRefs != "" {
-				return os.WriteFile(imageRefs, []byte(digest.String()), 0600)
+				if err := os.WriteFile(imageRefs, []byte(digest.String()), 0600); err != nil {
+					return fmt.Errorf("failed to write image refs to %s: %w", imageRefs, err)
+				}
 			}
 
 			// Print the digest of the pushed image to stdout to facilitate command composition.


### PR DESCRIPTION
Currently if you use `--image-refs` with `crane push`, the result reference doesn't get pushed if the manifest already exists, e.g.: 

```
2024/01/03 21:50:41 existing manifest: sha256:eef3b150e5e8d2b5b9ff7ed861ba503e0093139f595f9a549f614b64b6d6e1b2
2024/01/03 21:50:45 existing manifest: dev@sha256:eef3b150e5e8d2b5b9ff7ed861ba503e0093139f595f9a549f614b64b6d6e1b2
```

This change ensures that `crane push` always prints the full reference that was pushed.