### PR TITLE
*layout.layoutIndex implements Layer(Hash) for compatibility with remote.WriteIndex

### DIFF
--- a/pkg/v1/layout/index.go
+++ b/pkg/v1/layout/index.go
@@ -126,6 +126,19 @@ func (i *layoutIndex) Blob(h v1.Hash) (io.ReadCloser, error) {
 	return i.path.Blob(h)
 }
 
+// Workaround for #819.
+func (i *layoutIndex) Layer(h v1.Hash) (v1.Layer, error) {
+	desc, err := i.findDescriptor(h)
+	if err != nil {
+		return nil, err
+	}
+	layer := &compressedBlob{
+		path: i.path,
+		desc: *desc,
+	}
+	return partial.CompressedToLayer(layer)
+}
+
 func (i *layoutIndex) findDescriptor(h v1.Hash) (*v1.Descriptor, error) {
 	im, err := i.IndexManifest()
 	if err != nil {


### PR DESCRIPTION
remote.Pusher [detects](https://github.com/google/go-containerregistry/blob/v0.18.0/pkg/v1/remote/pusher.go#L348) an ImageIndex's children using partial.ComputeManifests, which gets and uploads a v1.Layer element [if the index implements withLayer](https://github.com/google/go-containerregistry/blob/v0.18.0/pkg/v1/partial/index.go#L152).

This change satisfies that condition, allowing for uploading an index containing non-image entries in a layout.

Thanks in advance!