### PR TITLE
`WithProgress` option for crane push/pull

### DIFF
--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -109,6 +109,17 @@ func WithPlatform(platform *v1.Platform) Option {
 	}
 }
 
+// WithProgress is an option which takes a channel that will receive
+// progress updates as bytes are written.
+//
+// Sending updates to an unbuffered channel will block writes, so callers
+// should provide a buffered channel to avoid potential deadlocks.
+func WithProgress(updates chan<- v1.Update) Option {
+	return func(o *Options) {
+		o.Remote = append(o.Remote, remote.WithProgress(updates))
+	}
+}
+
 // WithAuthFromKeychain is a functional option for overriding the default
 // authenticator for remote operations, using an authn.Keychain to find
 // credentials.

--- a/pkg/crane/options_test.go
+++ b/pkg/crane/options_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -54,5 +55,15 @@ func TestInsecureTransport(t *testing.T) {
 
 	if got := transport.TLSClientConfig.InsecureSkipVerify; got != want {
 		t.Errorf("got: %t\nwant: %t", got, want)
+	}
+}
+
+func TestWithProgress(t *testing.T) {
+	c := make(chan v1.Update, 100)
+
+	opts := GetOptions(WithProgress(c))
+
+	if len(opts.Remote) != 2 {
+		t.Errorf("expected 1 remote option, got %d", len(opts.Remote))
 	}
 }


### PR DESCRIPTION
Adds a top-level `crane.Option` which adds the underlying `WithProgress` option to the remote options. This improves the discoverability of configuring progress watching when using crane as a library.