### PR TITLE
reformat installation shell snippets

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -14,21 +14,21 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 1. Get the [latest release](https://github.com/google/go-containerregistry/releases/latest) version.
 
    ```sh
-   $ VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
+   VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
    ```
 
    or set a specific version:
 
    ```sh
-   $ VERSION=vX.Y.Z   # Version number with a leading v
+   VERSION=vX.Y.Z   # Version number with a leading v
    ```
 
 1. Download the release.
 
    ```sh
-   $ OS=Linux       # or Darwin, Windows
-   $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-   $ curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+   OS=Linux       # or Darwin, Windows
+   ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
+   curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
    ```
 
 1. Verify the signature. We generate [SLSA 3 provenance](https://slsa.dev) using
@@ -37,16 +37,16 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
    and verify as follows:
 
    ```sh
-   $ curl -sL https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
-   $ # NOTE: You may be using a different architecture.
-   $ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
-     PASSED: Verified SLSA provenance
+   curl -sL https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
+   # NOTE: You may be using a different architecture.
+   slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
+   # NOTE: Output of the above command should equal:  PASSED: Verified SLSA provenance
    ```
 
 1. Unpack it in the PATH.
 
    ```sh
-   $ tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
+   tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
    ```
 
 ### Install manually
@@ -62,7 +62,7 @@ go install github.com/google/go-containerregistry/cmd/crane@latest
 If you're macOS user and using [Homebrew](https://brew.sh/), you can install via brew command:
 
 ```sh
-$ brew install crane
+brew install crane
 ```
 
 ### Install on Arch Linux
@@ -70,7 +70,7 @@ $ brew install crane
 If you're an Arch Linux user you can install via pacman command:
 
 ```sh
-$ pacman -S crane
+pacman -S crane
 ```
 
 ### Setup on GitHub Actions


### PR DESCRIPTION
This PR does minor reformatting of the shell snippets which illustrate how to install `crane`.

It removes the leading dollar sign in the examples. Without those leading `$` you can now use the copy button which appears in the GitHub UI if you hover over such a code sample.

This makes installing crane a little bit easier. 

