### PR TITLE
fix: use OCI and not Docker manifest schema

### DIFF
--- a/pkg/v1/empty/image.go
+++ b/pkg/v1/empty/image.go
@@ -29,7 +29,7 @@ type emptyImage struct{}
 
 // MediaType implements partial.UncompressedImageCore.
 func (i emptyImage) MediaType() (types.MediaType, error) {
-	return types.DockerManifestSchema2, nil
+	return types.OCIManifestSchema1, nil
 }
 
 // RawConfigFile implements partial.UncompressedImageCore.


### PR DESCRIPTION
Empty package has empty image and empty index,
so both should have the same media type - either
OCI or Docker schema to keep the consistency.

Issue: #1904