### PR TITLE
feat: crane mutate platform

### DIFF
--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -19,6 +19,7 @@ crane mutate [flags]
   -l, --label stringToString        New labels to add (default [])
   -o, --output string               Path to new tarball of resulting image
       --repo string                 Repository to push the mutated image to. If provided, push by digest to this repository.
+      --set-platform string         New platform to set in the form os/arch[/variant][:osversion] (e.g. linux/amd64)
   -t, --tag string                  New tag reference to apply to mutated image. If not provided, push by digest to the original image repository.
   -u, --user string                 New user to set
   -w, --workdir string              New working dir to set


### PR DESCRIPTION
This is a potential solution to #1918, and allows an image config's os/arch/variant/osversion to be set via `crane mutate myimage --set-platform linux/arm64`.

I chose `--set-platform`, since `--platform` is already in use as a persistent flag and a selector for the image to mutate.