### PR TITLE
feat: Add v1.Manifest 'artifactType' field from OCI spec

### DIFF
--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -25,6 +25,7 @@ import (
 type Manifest struct {
 	SchemaVersion int64             `json:"schemaVersion"`
 	MediaType     types.MediaType   `json:"mediaType,omitempty"`
+	ArtifactType  string            `json:"artifactType,omitempty"`
 	Config        Descriptor        `json:"config"`
 	Layers        []Descriptor      `json:"layers"`
 	Annotations   map[string]string `json:"annotations,omitempty"`

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -117,6 +117,10 @@ func (i *image) compute() error {
 			desc.MediaType = add.MediaType
 		}
 
+		if add.ArtifactType != "" {
+			desc.ArtifactType = add.ArtifactType
+		}
+
 		manifestLayers = append(manifestLayers, *desc)
 		digestMap[desc.Digest] = add.Layer
 	}

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -35,6 +35,7 @@ type image struct {
 	manifest        *v1.Manifest
 	annotations     map[string]string
 	mediaType       *types.MediaType
+	artifactType    *string
 	configMediaType *types.MediaType
 	diffIDMap       map[v1.Hash]v1.Layer
 	digestMap       map[v1.Hash]v1.Layer
@@ -50,6 +51,13 @@ func (i *image) MediaType() (types.MediaType, error) {
 		return *i.mediaType, nil
 	}
 	return i.base.MediaType()
+}
+
+func (i *image) ArtifactType() (string, error) {
+	if i.artifactType != nil {
+		return *i.artifactType, nil
+	}
+	return partial.ArtifactType(i.base)
 }
 
 func (i *image) compute() error {
@@ -153,6 +161,10 @@ func (i *image) compute() error {
 
 	if i.mediaType != nil {
 		manifest.MediaType = *i.mediaType
+	}
+
+	if i.artifactType != nil {
+		manifest.ArtifactType = *i.artifactType
 	}
 
 	if i.annotations != nil {

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -537,6 +537,14 @@ func MediaType(img v1.Image, mt types.MediaType) v1.Image {
 	}
 }
 
+// ArtifactType modifies the ArtifactType() of the given image.
+func ArtifactType(img v1.Image, at string) v1.Image {
+	return &image{
+		base:         img,
+		artifactType: &at,
+	}
+}
+
 // ConfigMediaType modifies the MediaType() of the given image's Config.
 //
 // If !mt.IsConfig(), this will be the image's artifactType in any indexes it's a part of.

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -39,11 +39,12 @@ const whiteoutPrefix = ".wh."
 // Addendum contains layers and history to be appended
 // to a base image
 type Addendum struct {
-	Layer       v1.Layer
-	History     v1.History
-	URLs        []string
-	Annotations map[string]string
-	MediaType   types.MediaType
+	Layer        v1.Layer
+	History      v1.History
+	URLs         []string
+	Annotations  map[string]string
+	MediaType    types.MediaType
+	ArtifactType string
 }
 
 // AppendLayers applies layers to a base image.

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -148,7 +148,8 @@ func TestAppendWithAddendum(t *testing.T) {
 		Annotations: map[string]string{
 			"foo": "bar",
 		},
-		MediaType: types.MediaType("foo"),
+		MediaType:    types.MediaType("foo"),
+		ArtifactType: "bar",
 	}
 
 	result, err := mutate.Append(source, addendum)
@@ -186,6 +187,9 @@ func TestAppendWithAddendum(t *testing.T) {
 	}
 	if diff := cmp.Diff(m.Layers[1].MediaType, addendum.MediaType); diff != "" {
 		t.Fatalf("the appended MediaType is not the same (-got, +want) %s", diff)
+	}
+	if diff := cmp.Diff(m.Layers[1].ArtifactType, addendum.ArtifactType); diff != "" {
+		t.Fatalf("the appended ArtifactType is not the same (-got, +want) %s", diff)
 	}
 }
 

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -337,8 +337,12 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 			mf, _ := Manifest(wrm)
 			// Failing to parse as a manifest should just be ignored.
 			// The manifest might not be valid, and that's okay.
-			if mf != nil && !mf.Config.MediaType.IsConfig() {
-				desc.ArtifactType = string(mf.Config.MediaType)
+			if mf != nil {
+				if mf.ArtifactType != "" {
+					desc.ArtifactType = mf.ArtifactType
+				} else if !mf.Config.MediaType.IsConfig() {
+					desc.ArtifactType = string(mf.Config.MediaType)
+				}
 			}
 		}
 	}
@@ -429,8 +433,13 @@ func ArtifactType(w WithManifest) (string, error) {
 	mf, _ := w.Manifest()
 	// Failing to parse as a manifest should just be ignored.
 	// The manifest might not be valid, and that's okay.
-	if mf != nil && !mf.Config.MediaType.IsConfig() {
-		return string(mf.Config.MediaType), nil
+	if mf != nil {
+		if mf.ArtifactType != "" {
+			return mf.ArtifactType, nil
+		}
+		if !mf.Config.MediaType.IsConfig() {
+			return string(mf.Config.MediaType), nil
+		}
 	}
 	return "", nil
 }

--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -49,6 +49,10 @@ func fallbackTag(d name.Digest) name.Tag {
 func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, d name.Digest) (v1.ImageIndex, error) {
 	// Check the Referrers API endpoint first.
 	u := f.url("referrers", d.DigestStr())
+	artifactType, ok := filter["artifactType"]
+	if ok {
+		u.Query().Add("artifactType", artifactType)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -562,9 +562,10 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		return err
 	}
 	var mf struct {
-		MediaType types.MediaType `json:"mediaType"`
-		Subject   *v1.Descriptor  `json:"subject,omitempty"`
-		Config    struct {
+		ArtifactType string          `json:"artifactType,omitempty"`
+		MediaType    types.MediaType `json:"mediaType"`
+		Subject      *v1.Descriptor  `json:"subject,omitempty"`
+		Config       struct {
 			MediaType types.MediaType `json:"mediaType"`
 		} `json:"config"`
 	}
@@ -605,8 +606,12 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 			if err != nil {
 				return err
 			}
+			artifactType := mf.ArtifactType
+			if artifactType == "" {
+				artifactType = string(mf.Config.MediaType)
+			}
 			desc := v1.Descriptor{
-				ArtifactType: string(mf.Config.MediaType),
+				ArtifactType: artifactType,
 				MediaType:    mf.MediaType,
 				Digest:       h,
 				Size:         size,


### PR DESCRIPTION
OCI has released v1.1.0 of the Image Spec which includes the artifactType field in the manifest json schema: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#image-manifest-property-descriptions

Relevant to #1832 closed as stale 