### PR TITLE
Support copying multiple platforms.

### DIFF
--- a/cmd/crane/cmd/copy.go
+++ b/cmd/crane/cmd/copy.go
@@ -23,6 +23,7 @@ import (
 
 // NewCmdCopy creates a new cobra.Command for the copy subcommand.
 func NewCmdCopy(options *[]crane.Option) *cobra.Command {
+	platforms := &platformsValue{}
 	allTags := false
 	noclobber := false
 	jobs := runtime.GOMAXPROCS(0)
@@ -32,7 +33,7 @@ func NewCmdCopy(options *[]crane.Option) *cobra.Command {
 		Short:   "Efficiently copy a remote image from src to dst while retaining the digest value",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			opts := append(*options, crane.WithJobs(jobs), crane.WithNoClobber(noclobber))
+			opts := append(*options, crane.WithJobs(jobs), crane.WithNoClobber(noclobber), crane.WithPlatforms(platforms.platforms))
 			src, dst := args[0], args[1]
 			if allTags {
 				return crane.CopyRepository(src, dst, opts...)
@@ -42,6 +43,7 @@ func NewCmdCopy(options *[]crane.Option) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().Var(platforms, "platform", "Specifies the platform(s) to keep from base in the form os/arch[/variant][:osversion][,<platform>] (e.g. linux/amd64).")
 	cmd.Flags().BoolVarP(&allTags, "all-tags", "a", false, "(Optional) if true, copy all tags from SRC to DST")
 	cmd.Flags().BoolVarP(&noclobber, "no-clobber", "n", false, "(Optional) if true, avoid overwriting existing tags in DST")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "(Optional) The maximum number of concurrent copies, defaults to GOMAXPROCS")

--- a/cmd/crane/cmd/index.go
+++ b/cmd/crane/cmd/index.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -82,7 +81,7 @@ func NewCmdIndexFilter(options *[]crane.Option) *cobra.Command {
 				return nil
 			}
 
-			idx := filterIndex(base, platforms.platforms)
+			idx := crane.FilterIndex(base, platforms.platforms)
 
 			digest, err := idx.Digest()
 			if err != nil {
@@ -277,29 +276,4 @@ The platform for appended manifests is inferred from the config file or omitted 
 	cmd.Flags().BoolVar(&flatten, "flatten", true, "If true, appending an index will append each of its children rather than the index itself")
 
 	return cmd
-}
-
-func filterIndex(idx v1.ImageIndex, platforms []v1.Platform) v1.ImageIndex {
-	matcher := not(satisfiesPlatforms(platforms))
-	return mutate.RemoveManifests(idx, matcher)
-}
-
-func satisfiesPlatforms(platforms []v1.Platform) match.Matcher {
-	return func(desc v1.Descriptor) bool {
-		if desc.Platform == nil {
-			return false
-		}
-		for _, p := range platforms {
-			if desc.Platform.Satisfies(p) {
-				return true
-			}
-		}
-		return false
-	}
-}
-
-func not(in match.Matcher) match.Matcher {
-	return func(desc v1.Descriptor) bool {
-		return !in(desc)
-	}
 }

--- a/cmd/crane/doc/crane_copy.md
+++ b/cmd/crane/doc/crane_copy.md
@@ -9,10 +9,11 @@ crane copy SRC DST [flags]
 ### Options
 
 ```
-  -a, --all-tags     (Optional) if true, copy all tags from SRC to DST
-  -h, --help         help for copy
-  -j, --jobs int     (Optional) The maximum number of concurrent copies, defaults to GOMAXPROCS
-  -n, --no-clobber   (Optional) if true, avoid overwriting existing tags in DST
+  -a, --all-tags               (Optional) if true, copy all tags from SRC to DST
+  -h, --help                   help for copy
+  -j, --jobs int               (Optional) The maximum number of concurrent copies, defaults to GOMAXPROCS
+  -n, --no-clobber             (Optional) if true, avoid overwriting existing tags in DST
+      --platform platform(s)   Specifies the platform(s) to keep from base in the form os/arch[/variant][:osversion][,<platform>] (e.g. linux/amd64).
 ```
 
 ### Options inherited from parent commands
@@ -20,7 +21,6 @@ crane copy SRC DST [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
-      --platform platform                  Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default all)
   -v, --verbose                            Enable debug logs
 ```
 

--- a/pkg/crane/options.go
+++ b/pkg/crane/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	Name      []name.Option
 	Remote    []remote.Option
 	Platform  *v1.Platform
+	Platforms []v1.Platform
 	Keychain  authn.Keychain
 	Transport http.RoundTripper
 
@@ -106,6 +107,13 @@ func WithPlatform(platform *v1.Platform) Option {
 			o.Remote = append(o.Remote, remote.WithPlatform(*platform))
 		}
 		o.Platform = platform
+	}
+}
+
+// WithPlatforms is an Option to specify the platforms.
+func WithPlatforms(platforms []v1.Platform) Option {
+	return func(o *Options) {
+		o.Platforms = platforms
 	}
 }
 

--- a/pkg/v1/remote/descriptor.go
+++ b/pkg/v1/remote/descriptor.go
@@ -47,12 +47,9 @@ type Descriptor struct {
 	fetcher fetcher
 	v1.Descriptor
 
-	ref      name.Reference
-	Manifest []byte
-	ctx      context.Context
-
-	// So we can share this implementation with Image.
-	platform v1.Platform
+	Reference name.Reference
+	Manifest  []byte
+	ctx       context.Context
 }
 
 func (d *Descriptor) toDesc() v1.Descriptor {
@@ -113,7 +110,7 @@ func (d *Descriptor) Image() (v1.Image, error) {
 		return nil, newErrSchema1(d.MediaType)
 	case types.OCIImageIndex, types.DockerManifestList:
 		// We want an image but the registry has an index, resolve it to an image.
-		return d.remoteIndex().imageByPlatform(d.platform)
+		return d.remoteIndex().imageByPlatform(*d.Descriptor.Platform)
 	case types.OCIManifestSchema1, types.DockerManifestSchema2:
 		// These are expected. Enumerated here to allow a default case.
 	default:
@@ -130,7 +127,7 @@ func (d *Descriptor) Image() (v1.Image, error) {
 	}
 	return &mountableImage{
 		Image:     imgCore,
-		Reference: d.ref,
+		Reference: d.Reference,
 	}, nil
 }
 
@@ -141,7 +138,7 @@ func (d *Descriptor) Image() (v1.Image, error) {
 // This is separate from Image() to avoid a backward incompatible change for callers expecting ErrSchema1.
 func (d *Descriptor) Schema1() (v1.Image, error) {
 	i := &schema1{
-		ref:        d.ref,
+		ref:        d.Reference,
 		fetcher:    d.fetcher,
 		ctx:        d.ctx,
 		manifest:   d.Manifest,
@@ -151,7 +148,7 @@ func (d *Descriptor) Schema1() (v1.Image, error) {
 
 	return &mountableImage{
 		Image:     i,
-		Reference: d.ref,
+		Reference: d.Reference,
 	}, nil
 }
 
@@ -177,7 +174,7 @@ func (d *Descriptor) ImageIndex() (v1.ImageIndex, error) {
 
 func (d *Descriptor) remoteImage() *remoteImage {
 	return &remoteImage{
-		ref:        d.ref,
+		ref:        d.Reference,
 		ctx:        d.ctx,
 		fetcher:    d.fetcher,
 		manifest:   d.Manifest,
@@ -188,7 +185,7 @@ func (d *Descriptor) remoteImage() *remoteImage {
 
 func (d *Descriptor) remoteIndex() *remoteIndex {
 	return &remoteIndex{
-		ref:        d.ref,
+		ref:        d.Reference,
 		ctx:        d.ctx,
 		fetcher:    d.fetcher,
 		manifest:   d.Manifest,

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -104,13 +104,13 @@ func (f *fetcher) get(ctx context.Context, ref name.Reference, acceptable []type
 	if err != nil {
 		return nil, err
 	}
+	desc.Platform = &platform
 	return &Descriptor{
-		ref:        ref,
+		Reference:  ref,
 		ctx:        ctx,
 		fetcher:    *f,
 		Manifest:   b,
 		Descriptor: *desc,
-		platform:   platform,
 	}, nil
 }
 

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -230,13 +230,13 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 		}
 	}
 
+	child.Platform = &platform
 	return &Descriptor{
-		ref:        ref,
+		Reference:  ref,
 		ctx:        r.ctx,
 		fetcher:    r.fetcher,
 		Manifest:   manifest,
 		Descriptor: child,
-		platform:   platform,
 	}, nil
 }
 


### PR DESCRIPTION
`crane index filter` is a great way to copy multi-platform images without copying undesired platforms. Unfortunately, that command requires that the source image support multiple platforms (i.e., has a manifest list/index). In a scenario where you may be programmatically copying images, some source images may not host a manifest list/index, and additional checks must be performed to decide between `crane index filter` and `crane copy`.

This PR updates`crane copy` so that it behaves similar to `crane index filter`, but does not require a manifest list/index. In a single-platform scenario, it behaves much as it did before. In a multi-platform scenario, it filters the manifest list/index to the desired platforms, and copies only those layers.

Example command:
```
crane copy --platform linux/amd64 --platform linux/arm64 redis localhost:58273/redis
```