### PR TITLE
pkg/registry: Export errNotFound

### DIFF
--- a/pkg/registry/blobs.go
+++ b/pkg/registry/blobs.go
@@ -51,14 +51,14 @@ func isBlob(req *http.Request) bool {
 // BlobHandler represents a minimal blob storage backend, capable of serving
 // blob contents.
 type BlobHandler interface {
-	// Get gets the blob contents, or errNotFound if the blob wasn't found.
+	// Get gets the blob contents, or ErrNotFound if the blob wasn't found.
 	Get(ctx context.Context, repo string, h v1.Hash) (io.ReadCloser, error)
 }
 
 // BlobStatHandler is an extension interface representing a blob storage
 // backend that can serve metadata about blobs.
 type BlobStatHandler interface {
-	// Stat returns the size of the blob, or errNotFound if the blob wasn't
+	// Stat returns the size of the blob, or ErrNotFound if the blob wasn't
 	// found, or redirectError if the blob can be found elsewhere.
 	Stat(ctx context.Context, repo string, h v1.Hash) (int64, error)
 }
@@ -103,8 +103,8 @@ func (r *bytesCloser) Close() error {
 
 func (e redirectError) Error() string { return fmt.Sprintf("redirecting (%d): %s", e.Code, e.Location) }
 
-// errNotFound represents an error locating the blob.
-var errNotFound = errors.New("not found")
+// ErrNotFound represents an error locating the blob.
+var ErrNotFound = errors.New("not found")
 
 type memHandler struct {
 	m    map[string][]byte
@@ -119,7 +119,7 @@ func (m *memHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error)
 
 	b, found := m.m[h.String()]
 	if !found {
-		return 0, errNotFound
+		return 0, ErrNotFound
 	}
 	return int64(len(b)), nil
 }
@@ -130,7 +130,7 @@ func (m *memHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser,
 
 	b, found := m.m[h.String()]
 	if !found {
-		return nil, errNotFound
+		return nil, ErrNotFound
 	}
 	return &bytesCloser{bytes.NewReader(b)}, nil
 }
@@ -153,7 +153,7 @@ func (m *memHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
 	defer m.lock.Unlock()
 
 	if _, found := m.m[h.String()]; !found {
-		return errNotFound
+		return ErrNotFound
 	}
 
 	delete(m.m, h.String())
@@ -206,7 +206,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 		var size int64
 		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
 			size, err = bsh.Stat(req.Context(), repo, h)
-			if errors.Is(err, errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				return regErrBlobUnknown
 			} else if err != nil {
 				var rerr redirectError
@@ -218,7 +218,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 			}
 		} else {
 			rc, err := b.blobHandler.Get(req.Context(), repo, h)
-			if errors.Is(err, errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				return regErrBlobUnknown
 			} else if err != nil {
 				var rerr redirectError
@@ -254,7 +254,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 		var r io.Reader
 		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
 			size, err = bsh.Stat(req.Context(), repo, h)
-			if errors.Is(err, errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				return regErrBlobUnknown
 			} else if err != nil {
 				var rerr redirectError
@@ -266,7 +266,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 			}
 
 			rc, err := b.blobHandler.Get(req.Context(), repo, h)
-			if errors.Is(err, errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				return regErrBlobUnknown
 			} else if err != nil {
 				var rerr redirectError
@@ -283,7 +283,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 
 		} else {
 			tmp, err := b.blobHandler.Get(req.Context(), repo, h)
-			if errors.Is(err, errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				return regErrBlobUnknown
 			} else if err != nil {
 				var rerr redirectError

--- a/pkg/registry/blobs_disk.go
+++ b/pkg/registry/blobs_disk.go
@@ -37,7 +37,7 @@ func (m *diskHandler) blobHashPath(h v1.Hash) string {
 func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
 	fi, err := os.Stat(m.blobHashPath(h))
 	if errors.Is(err, os.ErrNotExist) {
-		return 0, errNotFound
+		return 0, ErrNotFound
 	} else if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The registry logic checks for the unexported error `errNotFound` during blob handling.  
When implementing a custom `BlobHandler` outside of this package the developer is unable to use the unexported `errNotFound` variable, therefore the custom `BlobHandler` cannot signal the correct error to the registry package which results in a wrong execution flow.

This PR exposes the `ErrNotFound` error so it can be used from outside the registry package, this aligns with other packages in this module that use the same approach e.g. [cache](https://github.com/google/go-containerregistry/blob/main/pkg/v1/cache/cache.go#L49)
