### PR TITLE
Fix "crane layout gc" failing on Windows wit "Error: cannot parse hash: "sha256\\0401ae60059.." (#1942)

### DIFF
--- a/pkg/v1/layout/gc.go
+++ b/pkg/v1/layout/gc.go
@@ -18,6 +18,7 @@ package layout
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +55,7 @@ func (l Path) GarbageCollect() ([]v1.Hash, error) {
 		if err != nil {
 			return err
 		}
-		hashString := strings.Replace(rel, "/", ":", 1)
+		hashString := strings.Replace(rel, string(os.PathSeparator), ":", 1)
 		if present := blobsToKeep[hashString]; !present {
 			h, err := v1.NewHash(hashString)
 			if err != nil {


### PR DESCRIPTION
This pull request updates "layout gc" to use os-specific path separator instead of "/".