### PR TITLE
Add -O shorthand for --omit-digest-tags to crane.

### DIFF
--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -40,7 +40,7 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "(Optional) if true, print the full image reference")
-	cmd.Flags().BoolVar(&omitDigestTags, "omit-digest-tags", false, "(Optional), if true, omit digest tags (e.g., ':sha256-...')")
+	cmd.Flags().BoolVarP(&omitDigestTags, "omit-digest-tags", "O", false, "(Optional), if true, omit digest tags (e.g., ':sha256-...')")
 	return cmd
 }
 

--- a/cmd/crane/doc/crane_ls.md
+++ b/cmd/crane/doc/crane_ls.md
@@ -11,7 +11,7 @@ crane ls REPO [flags]
 ```
       --full-ref           (Optional) if true, print the full image reference
   -h, --help               help for ls
-      --omit-digest-tags   (Optional), if true, omit digest tags (e.g., ':sha256-...')
+  -O, --omit-digest-tags   (Optional), if true, omit digest tags (e.g., ':sha256-...')
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
--omit-digest-tags is hard to remember and easy to typo. Support -O as an alias.