### PR TITLE
Fix inconsistent tar generation on windows (#1961)

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -296,6 +296,11 @@ func extract(img v1.Image, w io.Writer) error {
 			// name, we may have duplicate entries, which angers tar-split.
 			header.Name = filepath.Clean(header.Name)
 			header.Name = filepath.ToSlash(header.Name)
+
+			if header.Name == "." {
+				continue
+			}
+
 			// force PAX format to remove Name/Linkname length limit of 100 characters
 			// required by USTAR and to not depend on internal tar package guess which
 			// prefers USTAR over PAX

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -295,6 +295,7 @@ func extract(img v1.Image, w io.Writer) error {
 			// Some tools prepend everything with "./", so if we don't Clean the
 			// name, we may have duplicate entries, which angers tar-split.
 			header.Name = filepath.Clean(header.Name)
+			header.Name = filepath.ToSlash(header.Name)
 			// force PAX format to remove Name/Linkname length limit of 100 characters
 			// required by USTAR and to not depend on internal tar package guess which
 			// prefers USTAR over PAX


### PR DESCRIPTION
Fix #1961.

Also, there are no longer empty "." folder in the generated tar.
