### PR TITLE
Referrer API must return correct Content-Type

### DIFF
--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -66,7 +66,7 @@ func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, 
 	}
 
 	var b []byte
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode == http.StatusOK && resp.Header.Get("Content-Type") == string(types.OCIImageIndex) {
 		b, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
As per the spec, [https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) Content-Type header MUST be set to application/vnd.oci.image.index.v1+json.

This is important as GAR today (OCI 1.0) redirect "referrers" API call to the google console authentication page, and doing so the call return 200 OK  + content-type: text/html.

As the test use the registry package it is quite difficult to set a test explicitly on this part.