### PR TITLE
Restore blind-write to remote.Put

### DIFF
--- a/cmd/crane/rebase.md
+++ b/cmd/crane/rebase.md
@@ -118,7 +118,7 @@ some compiler expected by the uppermost app layers, the resulting rebased image
 might be invalid.
 
 In general, it's a good practice to tag rebased images to some other tag than
-the `original` tag, perform some sanity checks, then tag the image to the
+the `original` tag, perform some confidence checks, then tag the image to the
 `original` tag once it's determined the image is valid.
 
 There is ongoing work to standardize and advertise base image contract

--- a/pkg/v1/remote/pusher.go
+++ b/pkg/v1/remote/pusher.go
@@ -125,6 +125,20 @@ func (p *Pusher) writer(ctx context.Context, repo name.Repository, o *options) (
 	return rw, rw.init(ctx)
 }
 
+func (p *Pusher) Put(ctx context.Context, ref name.Reference, t Taggable) error {
+	w, err := p.writer(ctx, ref.Context(), p.o)
+	if err != nil {
+		return err
+	}
+
+	m, err := taggableToManifest(t)
+	if err != nil {
+		return err
+	}
+
+	return w.commitManifest(ctx, ref, m)
+}
+
 func (p *Pusher) Push(ctx context.Context, ref name.Reference, t Taggable) error {
 	w, err := p.writer(ctx, ref.Context(), p.o)
 	if err != nil {

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -709,5 +709,5 @@ func Put(ref name.Reference, t Taggable, options ...Option) error {
 	if err != nil {
 		return err
 	}
-	return newPusher(o).Push(o.context, ref, t)
+	return newPusher(o).Put(o.context, ref, t)
 }

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -1101,7 +1101,7 @@ func TestScopesForUploadingImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("img.Layers() = %v", err)
 	}
-	dummyLayer := layers[0]
+	wokeLayer := layers[0]
 
 	testCases := []struct {
 		name      string
@@ -1122,7 +1122,7 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: sameReference,
 				},
 			},
@@ -1135,7 +1135,7 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 			},
@@ -1149,11 +1149,11 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 			},
@@ -1167,11 +1167,11 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo2,
 				},
 			},
@@ -1186,19 +1186,19 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo2,
 				},
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo1,
 				},
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: anotherRepo2,
 				},
 			},
@@ -1213,7 +1213,7 @@ func TestScopesForUploadingImage(t *testing.T) {
 			reference: referenceToUpload,
 			layers: []v1.Layer{
 				&MountableLayer{
-					Layer:     dummyLayer,
+					Layer:     wokeLayer,
 					Reference: repoOnOtherRegistry,
 				},
 			},


### PR DESCRIPTION
This used to do a blind write, but I "simplified" that when introducing remote.Pusher, which actually broke some things downstream of ggcr, so this restores that behavior.