### PR TITLE
Add support for creating empty image config

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -217,9 +217,10 @@ func ConfigFile(base v1.Image, cfg *v1.ConfigFile) (v1.Image, error) {
 	}
 
 	image := &image{
-		base:       base,
-		manifest:   m.DeepCopy(),
-		configFile: cfg,
+		base:        base,
+		manifest:    m.DeepCopy(),
+		configFile:  cfg,
+		emptyConfig: false,
 	}
 
 	return image, nil
@@ -524,7 +525,6 @@ func Canonical(img v1.Image) (v1.Image, error) {
 	cfg.Container = ""
 	cfg.Config.Hostname = ""
 	cfg.DockerVersion = ""
-
 	return ConfigFile(img, cfg)
 }
 
@@ -551,5 +551,17 @@ func IndexMediaType(idx v1.ImageIndex, mt types.MediaType) v1.ImageIndex {
 	return &index{
 		base:      idx,
 		mediaType: &mt,
+	}
+}
+
+// EmptyConfig returns a new image with an empty config as per
+// https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage
+func EmptyConfig(img v1.Image) v1.Image {
+	mt := types.MediaType("application/vnd.oci.empty.v1+json")
+	return &image{
+		base:            img,
+		configMediaType: &mt,
+		configFile:      nil,
+		emptyConfig:     true,
 	}
 }


### PR DESCRIPTION
According to the [current OCI spec](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage):

> Content other than OCI container images MAY be packaged using the image manifest. When this is done, the config.mediaType value MUST be set to a value specific to the artifact type or the [empty value](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidance-for-an-empty-descriptor).

It's currently possible to set the config MediaType:

```golang
img = mutate.ConfigMediaType(img, "application/vnd.oci.empty.v1+json")
```

But it's not currently possible (as far as I can tell), to create the rest of the descriptor:

```json
{
  "mediaType": "application/vnd.oci.empty.v1+json",
  "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
  "size": 2,
  "data": "e30="
}
```

This PR adds a new `mutate` function to achieve this:

```golang
img = mutate.EmptyConfig(img)
```

An alternative, and maybe more general approach, would be to expose a `mutate` function to set the value of `Manifest.Config.Data` directly, and calculate the size/digest during `compute`. 
