### PR TITLE
crane export: Support reading an image from a directory.

### DIFF
--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -127,3 +127,15 @@ func loadImage(path string, index bool) (partial.WithRawManifest, error) {
 
 	return nil, fmt.Errorf("layout contains non-image (mediaType: %q), consider --index", desc.MediaType)
 }
+
+func loadImageTarballOrDir(path string) (v1.Image, error) {
+	img, err := loadImage(path, false)
+	if err != nil {
+		return nil, err
+	}
+	if img, ok := img.(v1.Image); ok {
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("directory doesn't specify an image")
+}


### PR DESCRIPTION
Add --local-image flag to `crane export` to specify that the image argument is a path, not a remote image.

If the flag is passed, the image may be either a tarball or a directory that's loaded with ImageIndexFromPath.

Addresses https://github.com/google/go-containerregistry/issues/1992.