### PR TITLE
feat: add option considerAsRepository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-containerregistry
+module github.com/hotkeyprince/go-containerregistry
 
 go 1.18
 

--- a/pkg/name/options.go
+++ b/pkg/name/options.go
@@ -26,10 +26,11 @@ const (
 )
 
 type options struct {
-	strict          bool // weak by default
-	insecure        bool // secure by default
-	defaultRegistry string
-	defaultTag      string
+	strict               bool // weak by default
+	insecure             bool // secure by default
+	considerAsRepository bool
+	defaultRegistry      string
+	defaultTag           string
 }
 
 func makeOptions(opts ...Option) options {
@@ -62,6 +63,11 @@ func WeakValidation(opts *options) {
 // Insecure is an Option that allows image references to be fetched without TLS.
 func Insecure(opts *options) {
 	opts.insecure = true
+}
+
+// ConsiderAsRepository is an Option that talks about using a repository with a dot as a repository, not a registry
+func ConsiderAsRepository(opts *options) {
+	opts.considerAsRepository = true
 }
 
 // OptionFn is a function that returns an option.

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -79,11 +79,13 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 	repo := name
 	parts := strings.SplitN(name, regRepoDelimiter, 2)
 	if len(parts) == 2 && (strings.ContainsRune(parts[0], '.') || strings.ContainsRune(parts[0], ':')) {
-		// The first part of the repository is treated as the registry domain
-		// iff it contains a '.' or ':' character, otherwise it is all repository
-		// and the domain defaults to Docker Hub.
-		registry = parts[0]
-		repo = parts[1]
+		if !opt.considerAsRepository {
+			// The first part of the repository is treated as the registry domain
+			// iff it contains a '.' or ':' character, otherwise it is all repository
+			// and the domain defaults to Docker Hub.
+			registry = parts[0]
+			repo = parts[1]
+		}
 	}
 
 	if err := checkRepository(repo); err != nil {

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -29,6 +29,8 @@ var goodStrictValidationRepositoryNames = []string{
 	"index.docker.io/library/ubuntu",
 }
 
+var goodConsiderAsRepositoryName = "registry-1.docker.io-shared/library/ubuntu"
+
 var goodWeakValidationRepositoryNames = []string{
 	"namespace/pathcomponent/image",
 	"library/ubuntu",
@@ -57,6 +59,18 @@ func TestNewRepositoryStrictValidation(t *testing.T) {
 			t.Errorf("`%s` should be an invalid repository name, got Repository: %#v", name, repo)
 		}
 	}
+}
+
+func TestNewRepositoryConsiderAsRepository(t *testing.T) {
+	t.Parallel()
+
+	repository, err := NewRepository(goodConsiderAsRepositoryName, ConsiderAsRepository)
+	if err != nil {
+		t.Errorf("`%s` should be a valid Repository name, got error: %v", goodConsiderAsRepositoryName, err)
+	} else if repository.repository != goodConsiderAsRepositoryName {
+		t.Errorf("`%v` repository name should reproduce the original name. Wanted: %s Got: %s", repository, goodConsiderAsRepositoryName, repository.repository)
+	}
+
 }
 
 func TestNewRepository(t *testing.T) {


### PR DESCRIPTION
in case of using a private cache proxy container registry, for example: `nexus.company-example/registry-1.docker.io-shared/library/ubuntu`, allows the repository name to be used with dots, without defining it as a registry