### PR TITLE
crane: Add "did you mean" to ls and catalog

### DIFF
--- a/cmd/crane/cmd/catalog.go
+++ b/cmd/crane/cmd/catalog.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
@@ -47,6 +49,9 @@ func NewCmdCatalog(options *[]crane.Option, _ ...string) *cobra.Command {
 func catalog(ctx context.Context, w io.Writer, src string, fullRef bool, o crane.Options) error {
 	reg, err := name.NewRegistry(src, o.Name...)
 	if err != nil {
+		if repo, err := name.NewRepository(src, o.Name...); err == nil {
+			logs.Warn.Printf("did you mean '%s catalog %s'?", os.Args[0], repo.RegistryStr())
+		}
 		return fmt.Errorf("parsing reg %q: %w", src, err)
 	}
 

--- a/cmd/crane/cmd/list.go
+++ b/cmd/crane/cmd/list.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
@@ -47,6 +49,9 @@ func NewCmdList(options *[]crane.Option) *cobra.Command {
 func list(ctx context.Context, w io.Writer, src string, fullRef, omitDigestTags bool, o crane.Options) error {
 	repo, err := name.NewRepository(src, o.Name...)
 	if err != nil {
+		if _, err := name.NewRegistry(src, o.Name...); err == nil {
+			logs.Warn.Printf("did you mean '%s catalog %s'?", os.Args[0], src)
+		}
 		return fmt.Errorf("parsing repo %q: %w", src, err)
 	}
 
@@ -57,6 +62,9 @@ func list(ctx context.Context, w io.Writer, src string, fullRef, omitDigestTags 
 
 	lister, err := puller.Lister(ctx, repo)
 	if err != nil {
+		if _, err := name.NewRegistry(src, o.Name...); err == nil {
+			logs.Warn.Printf("did you mean '%s catalog %s'?", os.Args[0], src)
+		}
 		return fmt.Errorf("reading tags for %s: %w", repo, err)
 	}
 


### PR DESCRIPTION
People often try to run `crane ls` on a registry and `crane catalog` on a repo, neither of which will work. Attempt to nudge them in the right direction if we hit an error.

`crane catalog example.com/foo` -> `crane catalog example.com` (fails to parse)
`crane ls example.com` -> `crane catalog example.com` (dockerhub rejects)
`crane ls localhost:5000` -> `crane catalog localhost:5000` (fails to parse)