### PR TITLE
fix: remote.Referrers: Set remoteIndex.ref to resolve panics in Index manifests

### DIFF
--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -89,6 +89,7 @@ func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, 
 	}
 	idx := &remoteIndex{
 		fetcher:   *f,
+		ref:       d.Context().Digest(h.String()),
 		ctx:       ctx,
 		manifest:  b,
 		mediaType: types.OCIImageIndex,


### PR DESCRIPTION
When `remote.Referrers()` returns a `v1.Index`, fetching derivative objects (like referenced manifests) requires keeping the Reference to the original repository.

Without setting the `ref` field, we get nil pointer dereference panics in (*remoteIndex).childDescriptor() https://github.com/google/go-containerregistry/blob/005bb7197dad1a6bffcda9405b91990331b1f406/pkg/v1/remote/index.go#L206-L207