### PR TITLE
Use OCI manifest format for images from scratch

### DIFF
--- a/pkg/v1/empty/image.go
+++ b/pkg/v1/empty/image.go
@@ -29,7 +29,7 @@ type emptyImage struct{}
 
 // MediaType implements partial.UncompressedImageCore.
 func (i emptyImage) MediaType() (types.MediaType, error) {
-	return types.DockerManifestSchema2, nil
+	return types.OCIManifestSchema1, nil
 }
 
 // RawConfigFile implements partial.UncompressedImageCore.


### PR DESCRIPTION
Images built from scratch where still using the outdated Docker v2 image format (recognizable in the mediaType `application/vnd.docker.distribution.manifest.v2+json`). This patch replaces that outdate format with the current one based in the OCI standard (marked by the mediaType `application/vnd.oci.image.manifest.v1+json`).