### PR TITLE
add keychain support for docker desktop on mac

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -137,6 +137,16 @@ func (dk *defaultKeychain) ResolveContext(ctx context.Context, target Resource) 
 		if err != nil {
 			return nil, err
 		}
+	} else if fileExists(filepath.Join(os.Getenv("HOME"), ".config/containers/auth.json")) {
+		f, err := os.Open(filepath.Join(os.Getenv("HOME"), ".config/containers/auth.json"))
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		cf, err = config.LoadFromReader(f)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		return Anonymous, nil
 	}


### PR DESCRIPTION
I was using the tool [incert](git@github.com:nmcostello/go-containerregistry.git) on my mac where I have Podman Desktop running. Incert uses `authn` to handle their credentials. I had to do override some environment variables to get the tool to read my credentials correctly. 

The podman-login doc for the auth file says:
> Default is ${XDG_RUNTIME_DIR}/containers/auth.json on Linux, and $HOME/.config/containers/auth.json on Windows/macOS

I figured a default should be supported without having to override things. 

I updated and ran `keychain_test.go` and I also ran `./hack/presubmit.sh` and validated that no new test were failing.