### PR TITLE
fix: `mutate.Extract` path manipulation on Windows

### DIFF
--- a/pkg/v1/mutate/whiteout_test.go
+++ b/pkg/v1/mutate/whiteout_test.go
@@ -35,7 +35,7 @@ func TestWhiteoutDir(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		whiteout := inWhiteoutDir(fsMap, tt.path)
+		whiteout := inWhiteoutDir(fsMap, tt.path, filepathImageFS{})
 		if whiteout != tt.whiteout {
 			t.Errorf("Whiteout %s: expected %v, but got %v", tt.path, tt.whiteout, whiteout)
 		}


### PR DESCRIPTION
`mutate.Extract` replaces `/` with `\` on Windows (even for non-Windows images) due to the use of `filepath.Clean()`, and other functions (e.g., `filepath.Dir`) that ultimately call `filepath.Clean` on the result.
This is typically not desired, since:
 - the flattened image would not be valid on Linux
 - Windows can handle `/` as a path separator, if the result is meant to be extracted on Windows
 - the conversion may be non-reversible in the edge case where the image contains a file name with `\`

Add an `imageFS` interface to abstract away path manipulation operations (e.g., `Dir`, `Base`, `Clean`, `Join`), with the default case being `filepath.*`, but allows using `path.*` if extracting a non-Windows image on Windows.

Note: extracting a Windows image on Linux is left as is, since neither `path` nor `filepath` will be able to appropriately handle the paths if the separator is `\`.