### PR TITLE
Expose image 'DeleteTag' method in the 'daemon'

### DIFF
--- a/pkg/v1/daemon/image_test.go
+++ b/pkg/v1/daemon/image_test.go
@@ -82,6 +82,8 @@ type MockClient struct {
 	inspectBody []byte
 
 	tagErr error
+
+	imageRemoveErr error
 }
 
 func (m *MockClient) NegotiateAPIVersion(_ context.Context) {

--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -102,4 +102,5 @@ type Client interface {
 	ImageTag(context.Context, string, string) error
 	ImageInspectWithRaw(context.Context, string) (types.ImageInspect, []byte, error)
 	ImageHistory(context.Context, string) ([]api.HistoryResponseItem, error)
+	ImageRemove(context.Context, string, types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
 }

--- a/pkg/v1/daemon/write.go
+++ b/pkg/v1/daemon/write.go
@@ -16,11 +16,11 @@ package daemon
 
 import (
 	"fmt"
-	"io"
-
+	"github.com/docker/docker/api/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"io"
 )
 
 // Tag adds a tag to an already existent image.
@@ -75,4 +75,19 @@ func Write(tag name.Tag, img v1.Image, options ...Option) (string, error) {
 		return response, fmt.Errorf("error reading load response body: %w", err)
 	}
 	return response, nil
+}
+
+// DeleteTag - Deletes given tag:
+//   - force - delete the image even if it is being used by stopped containers or has other tags
+//   - pruneChildren - deletes untagged parent images
+func DeleteTag(tag name.Tag, pruneChildren bool, force bool, options ...Option) error {
+	o, err := makeOptions(options...)
+	if err != nil {
+		return err
+	}
+	_, err = o.client.ImageRemove(o.ctx, tag.Name(), types.ImageRemoveOptions{PruneChildren: pruneChildren, Force: force})
+	if err != nil {
+		return fmt.Errorf("error deleting image %s: %w", tag.Name(), err)
+	}
+	return nil
 }

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -61,6 +61,10 @@ func (m *MockClient) ImageTag(ctx context.Context, _, _ string) error {
 	return m.tagErr
 }
 
+func (m *MockClient) ImageRemove(context.Context, string, types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
+	return nil, m.imageRemoveErr
+}
+
 func TestWriteImage(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
@@ -163,6 +167,9 @@ func TestWriteDefaultClient(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := Write(tag, empty.Image, WithContext(ctx)); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteTag(tag, false, false, WithContext(ctx)); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The method is needed to enable image cleanup in the container-structure-tests.

The problem I'm trying to solve is that container-structure-tests are writing an image to docker
https://github.com/GoogleContainerTools/container-structure-test/blob/c35e48dcd5dd[…]ec6d50d688235d4a36/cmd/container-structure-test/app/cmd/test.go
but they are not deleting it at all. This leads to leaked registry.structure_test.oci.local/image that accumulate in CICD.
