### PR TITLE
Check for 406 status code when handling referrers API endpoint response

### DIFF
--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -61,7 +61,7 @@ func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, 
 	}
 	defer resp.Body.Close()
 
-	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound, http.StatusBadRequest); err != nil {
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound, http.StatusBadRequest, http.StatusNotAcceptable); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
While using the [remote.Referrers](https://github.com/google/go-containerregistry/blob/main/pkg/v1/remote/referrers.go#L36) function with the Artifactory registry, I found the function was unexpectedly failing. Digging into the error, I found the registry was returning a 406 instead of a 404 when the `remote.Referrers` function attempted to make a request to the referrers endpoint. Adding http.StatusNotAcceptable to the list of handled status codes in `transport.CheckError` fixed the problem for me.

This PR adds `http.StatusNotAcceptable` to the list of status codes handled by transport.CheckError. Since it is a 4XX error, `remote.Referrers` is able to fallback and try the manifests API endpoint.

I had filed https://github.com/google/go-containerregistry/issues/1962 asking about this change but realized the change is small enough a pull request might be easier.