### PR TITLE
feat: export healthcheck start-interval from config

### DIFF
--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -95,9 +95,10 @@ type HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	Interval      time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout       time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod   time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	StartInterval time.Duration `json:",omitempty"` // The interval to attempt healthchecks at during the start period
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -329,11 +329,12 @@ func (i *image) computeImageConfig(config *container.Config) v1.Config {
 
 	if config.Healthcheck != nil {
 		c.Healthcheck = &v1.HealthConfig{
-			Test:        config.Healthcheck.Test,
-			Interval:    config.Healthcheck.Interval,
-			Timeout:     config.Healthcheck.Timeout,
-			StartPeriod: config.Healthcheck.StartPeriod,
-			Retries:     config.Healthcheck.Retries,
+			Test:          config.Healthcheck.Test,
+			Interval:      config.Healthcheck.Interval,
+			Timeout:       config.Healthcheck.Timeout,
+			StartPeriod:   config.Healthcheck.StartPeriod,
+			StartInterval: config.Healthcheck.StartInterval,
+			Retries:       config.Healthcheck.Retries,
 		}
 	}
 


### PR DESCRIPTION
This PR adds an export of the `start-interval` argument of the `healthcheck` instruction from the image configuration.

Fixes: https://github.com/google/go-containerregistry/issues/1930