### PR TITLE
feat(mutate): adding empty-oci-base functionality

### DIFF
--- a/cmd/crane/doc/crane_mutate.md
+++ b/cmd/crane/doc/crane_mutate.md
@@ -17,6 +17,7 @@ crane mutate [flags]
       --exposed-ports strings       New ports to expose
   -h, --help                        help for mutate
   -l, --label stringToString        New labels to add (default [])
+      --oci-empty-base              If true, use an empty OCI image when the base image is not found
   -o, --output string               Path to new tarball of resulting image
       --repo string                 Repository to push the mutated image to. If provided, push by digest to this repository.
       --set-platform string         New platform to set in the form os/arch[/variant][:osversion] (e.g. linux/amd64)


### PR DESCRIPTION
This is my first contribution, so please let me know if there’s anything I can improve. I referenced append.go for these changes.

As mentioned in issue #2050, I believe it would be useful to add the ability to modify an empty oci-base to reduce the number of commands required to create an oci artifact, similar to the functionality of crane append. I’m happy to discuss any alternative solutions or concerns you may have about implementing these changes. 