### PR TITLE
Support ~/.config podman path in default keychain

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -95,9 +95,13 @@ func (dk *defaultKeychain) ResolveContext(_ context.Context, target Resource) (A
 
 	// First, check $HOME/.docker/config.json
 	foundDockerConfig := false
+	configHome := os.Getenv("XDG_CONFIG_HOME")
 	home, err := homedir.Dir()
 	if err == nil {
 		foundDockerConfig = fileExists(filepath.Join(home, ".docker/config.json"))
+		if configHome == "" {
+			configHome = filepath.Join(home, ".config")
+		}
 	}
 	// If $HOME/.docker/config.json isn't found, check $DOCKER_CONFIG (if set)
 	if !foundDockerConfig && os.Getenv("DOCKER_CONFIG") != "" {
@@ -107,7 +111,8 @@ func (dk *defaultKeychain) ResolveContext(_ context.Context, target Resource) (A
 	// config.Load, which may fail if the config can't be parsed.
 	//
 	// If neither was found, look for Podman's auth at
-	// $REGISTRY_AUTH_FILE or $XDG_RUNTIME_DIR/containers/auth.json
+	// $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,
+	// $XDG_CONFIG_HOME/containers/auth.json, or ~/.config/containers/auth.json
 	// and attempt to load it as a Docker config.
 	//
 	// If neither are found, fallback to Anonymous.
@@ -129,6 +134,16 @@ func (dk *defaultKeychain) ResolveContext(_ context.Context, target Resource) (A
 		}
 	} else if fileExists(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json")) {
 		f, err := os.Open(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json"))
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		cf, err = config.LoadFromReader(f)
+		if err != nil {
+			return nil, err
+		}
+	} else if configHome != "" && fileExists(filepath.Join(configHome, "containers/auth.json")) {
+		f, err := os.Open(filepath.Join(configHome, "containers/auth.json"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
According to [podman's auth docs](https://docs.podman.io/en/v5.1.0/markdown/podman-login.1.html#authfile-path):

> Default is `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux, and `$HOME/.config/containers/auth.json` on Windows/macOS.

The current default keychain supports the `$XDG_RUNTIME_DIR` path but not the `$HOME/.config` path. This PR fixes that.

Note: podman's behavior is actually a little more subtle than what these docs would imply:
- The `$HOME/.config/containers` path is actually supported on all platforms, not just Windows/macOS. The `$HOME/.config` part of the path is computed as `$XDG_CONFIG_HOME` if defined, otherwise it defaults to `$HOME/.config`. The logic for that is [here](https://github.com/containers/podman/blob/c131c9d0382e8dedd460d8a9844a0cc2e65ecb71/vendor/github.com/containers/image/v5/pkg/docker/config/config.go#L157-L160).
- The `$XDG_RUNTIME_DIR` is indeed Linux-only, though, and takes precedence over the `~/.config` path. The logic for this precedence is [here](https://github.com/containers/podman/blob/c131c9d0382e8dedd460d8a9844a0cc2e65ecb71/vendor/github.com/containers/image/v5/pkg/docker/config/config.go#L147-L156), and the relevant code from `getPathToAuth` is [here](https://github.com/containers/podman/blob/c131c9d0382e8dedd460d8a9844a0cc2e65ecb71/vendor/github.com/containers/image/v5/pkg/docker/config/config.go#L573-L577).