### PR TITLE
chore: raw manifest indentation

### DIFF
--- a/pkg/crane/example_test.go
+++ b/pkg/crane/example_test.go
@@ -27,5 +27,5 @@ func Example() {
 	i, _ := crane.Image(c)
 	d, _ := i.Digest()
 	fmt.Println(d)
-	// Output: sha256:09fb0c6289cefaad8c74c7e5fd6758ad6906ab8f57f1350d9f4eb5a7df45ff8b
+	// Output: sha256:5c151b89fd9f3b93d910d05fb9f5efdf0fab8e645f65bbc268f926d64b15fc96
 }

--- a/pkg/crane/filemap_test.go
+++ b/pkg/crane/filemap_test.go
@@ -131,20 +131,20 @@ func TestImage(t *testing.T) {
 		Digest  string
 	}{{
 		Name:   "Empty contents",
-		Digest: "sha256:98132f58b523c391a5788997327cac95e114e3a6609d01163189774510705399",
+		Digest: "sha256:5b19422c75ffd2fe40e5cf332959491f16efd4948e5a647dfa18ef0893f60879",
 	}, {
 		Name: "One file",
 		FileMap: map[string][]byte{
 			"/test": []byte("testy"),
 		},
-		Digest: "sha256:d905c03ac635172a96c12b8af6c90cfd028e3edaa3114b31a9e196ab38c16963",
+		Digest: "sha256:0a5a9b92cb817d5362b14d92173e9c2fb813a17f261a6ad55e6a952edf86f21a",
 	}, {
 		Name: "Two files",
 		FileMap: map[string][]byte{
 			"/test": []byte("testy"),
 			"/bar":  []byte("not useful"),
 		},
-		Digest: "sha256:20e7e4800e5eb167f170970936c08d9e1bcbe91372420eeb6ab8d1a07752c3a3",
+		Digest: "sha256:d2c82c35a82be1186df962cd85b0eb1ac71f34ff2b9dab125b976cccbf11016c",
 	}, {
 		Name: "Many files",
 		FileMap: map[string][]byte{
@@ -158,7 +158,7 @@ func TestImage(t *testing.T) {
 			"/8": []byte("8"),
 			"/9": []byte("9"),
 		},
-		Digest: "sha256:dfca2803510c8e3b83a3151f7c035c60cfa2a8a52465b802e18b85014de361f1",
+		Digest: "sha256:9fd84648d36fe2792dfa1b1fadb6ddb31ae0ade5154536013fd912e2ab424616",
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/pkg/v1/empty/index.go
+++ b/pkg/v1/empty/index.go
@@ -45,7 +45,7 @@ func (i emptyIndex) IndexManifest() (*v1.IndexManifest, error) {
 }
 
 func (i emptyIndex) RawManifest() ([]byte, error) {
-	return json.Marshal(base())
+	return json.MarshalIndent(base(), "", "  ")
 }
 
 func (i emptyIndex) Image(v1.Hash) (v1.Image, error) {

--- a/pkg/v1/mutate/image.go
+++ b/pkg/v1/mutate/image.go
@@ -257,7 +257,7 @@ func (i *image) RawManifest() ([]byte, error) {
 	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return json.Marshal(i.manifest)
+	return json.MarshalIndent(i.manifest, "", "  ")
 }
 
 // LayerByDigest returns a Layer for interacting with a particular layer of

--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -208,7 +208,7 @@ func (i *index) RawManifest() ([]byte, error) {
 	if err := i.compute(); err != nil {
 		return nil, err
 	}
-	return json.Marshal(i.manifest)
+	return json.MarshalIndent(i.manifest, "", "  ")
 }
 
 func (i *index) Manifests() ([]partial.Describable, error) {

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -207,7 +207,7 @@ func (a arbitraryRawManifest) RawManifest() ([]byte, error) {
 	if a.subject != nil {
 		m["subject"] = a.subject
 	}
-	return json.Marshal(m)
+	return json.MarshalIndent(m, "", "  ")
 }
 
 // ConfigFile mutates the provided v1.Image to have the provided v1.ConfigFile

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -285,15 +285,39 @@ func TestAnnotations(t *testing.T) {
 	}{{
 		desc: "image",
 		in:   empty.Image,
-		want: `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":115,"digest":"sha256:5b943e2b943f6c81dbbd4e2eca5121f4fcc39139e3d1219d6d89bd925b77d9fe"},"layers":[],"annotations":{"foo":"bar"}}`,
+		want: `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 115,
+    "digest": "sha256:5b943e2b943f6c81dbbd4e2eca5121f4fcc39139e3d1219d6d89bd925b77d9fe"
+  },
+  "layers": [],
+  "annotations": {
+    "foo": "bar"
+  }
+}`,
 	}, {
 		desc: "index",
 		in:   empty.Index,
-		want: `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[],"annotations":{"foo":"bar"}}`,
+		want: `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [],
+  "annotations": {
+    "foo": "bar"
+  }
+}`,
 	}, {
 		desc: "arbitrary",
 		in:   arbitrary{},
-		want: `{"annotations":{"foo":"bar"},"hello":"world"}`,
+		want: `{
+  "annotations": {
+    "foo": "bar"
+  },
+  "hello": "world"
+}`,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got, err := mutate.Annotations(c.in, anns).RawManifest()
@@ -511,7 +535,7 @@ func TestAppendStreamableLayer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Digest: %v", err)
 	}
-	wantDigest := "sha256:14d140947afedc6901b490265a08bc8ebe7f9d9faed6fdf19a451f054a7dd746"
+	wantDigest := "sha256:77007fcd3426ae84eb97d4aeb30a645fd68d2ea1eb1ef6b6acf1e10732cbc863"
 	if h.String() != wantDigest {
 		t.Errorf("Image digest got %q, want %q", h, wantDigest)
 	}

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -178,7 +178,7 @@ func RawManifest(i WithManifest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(m)
+	return json.MarshalIndent(m, "", "  ")
 }
 
 // Size is a helper for implementing v1.Image

--- a/pkg/v1/random/index.go
+++ b/pkg/v1/random/index.go
@@ -94,7 +94,7 @@ func (i *randomIndex) RawManifest() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(m)
+	return json.MarshalIndent(m, "", "  ")
 }
 
 func (i *randomIndex) Image(h v1.Hash) (v1.Image, error) {


### PR DESCRIPTION
## Description

Add indentation to raw manifests to improve readability.

## Example

Following the example in the issue #2055, mutating the manifest after this patch will produce a new manifest with indentation:

2. Inspect the manifest with `crane manifest`:
```
crane manifest localhost:5000/simple-manifest:latest

{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 897,
    "digest": "sha256:701db07f8f291e50fbb06b4dd13310acad36c53120adbdf2568bd2009d48a2a3"
  },
  "layers": null
}
```
3. Mutate the manifest with `crane mutate`:
```
crane mutate localhost:5000/simple-manifest:latest

2025/02/08 13:04:41 existing blob: sha256:701db07f8f291e50fbb06b4dd13310acad36c53120adbdf2568bd2009d48a2a3
2025/02/08 13:04:41 localhost:5000/simple-manifest:latest: digest: sha256:e265ee69944da7c7dc2c32a18f11d2140333371a3fda5478a4900de543dacb45 size: 304
localhost:5000/simple-manifest@sha256:e265ee69944da7c7dc2c32a18f11d2140333371a3fda5478a4900de543dacb45
```
4. Inspect the manifest again with `crane manifest`:
```
crane manifest localhost:5000/simple-manifest:latest
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 897,
    "digest": "sha256:701db07f8f291e50fbb06b4dd13310acad36c53120adbdf2568bd2009d48a2a3"
  },
  "layers": null
}
```

Closes #2055 