### PR TITLE
Set annotations on descriptors created by referrers API 

### DIFF
--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -426,6 +426,7 @@ func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request)
 			Config struct {
 				MediaType string `json:"mediaType"`
 			} `json:"config"`
+			Annotations map[string]string `json:"annotations,omitempty"`
 		}
 		json.Unmarshal(manifest.blob, &imageAsArtifact)
 		im.Manifests = append(im.Manifests, v1.Descriptor{
@@ -433,6 +434,7 @@ func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request)
 			Size:         int64(len(manifest.blob)),
 			Digest:       h,
 			ArtifactType: imageAsArtifact.Config.MediaType,
+			Annotations:  imageAsArtifact.Annotations,
 		})
 	}
 	msg, _ := json.Marshal(&im)

--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -69,11 +69,16 @@ func TestReferrers(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			mf, err := img.Manifest()
+			if err != nil {
+				t.Fatal(err)
+			}
 			return v1.Descriptor{
 				Digest:       d,
 				Size:         sz,
 				MediaType:    mt,
 				ArtifactType: "application/testing123",
+				Annotations:  mf.Annotations,
 			}
 		}
 
@@ -118,6 +123,7 @@ func TestReferrers(t *testing.T) {
 			t.Fatal(err)
 		}
 		leafImg = mutate.ConfigMediaType(leafImg, types.MediaType("application/testing123"))
+		leafImg = mutate.Annotations(leafImg, map[string]string{"annotation-key": "annotation-value"}).(v1.Image)
 		leafImg = mutate.Subject(leafImg, rootDesc).(v1.Image)
 		if err := remote.Write(leafRef, leafImg); err != nil {
 			t.Fatal(err)
@@ -187,7 +193,7 @@ func TestReferrers(t *testing.T) {
 			t.Fatalf("referrers diff after second push (-want,+got): %s", d)
 		}
 
-		// Try applying filters and verify number of manifests and and annotations
+		// Try applying filters and verify number of manifests and annotations
 		index, err = remote.Referrers(rootRefDigest,
 			remote.WithFilter("artifactType", "application/testing123"))
 		if err != nil {

--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -145,6 +145,11 @@ func TestReferrers(t *testing.T) {
 			t.Fatalf("referrers diff (-want,+got): %s", d)
 		}
 
+		// Verify the annotations are present in the descriptor
+		if got := m2.Manifests[0].Annotations["annotation-key"]; got != "annotation-value" {
+			t.Errorf("expected annotation 'annotation-key' to be 'annotation-value', got %q", got)
+		}
+
 		if leg.tryFallback {
 			// Get the referrers by querying the root image's fallback tag directly.
 			tag, err := name.ParseReference(fmt.Sprintf("%s/repo:sha256-%s", u.Host, rootDesc.Digest.Hex))

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -560,6 +560,7 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		Config    struct {
 			MediaType types.MediaType `json:"mediaType"`
 		} `json:"config"`
+		Annotations map[string]string `json:"annotations,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &mf); err != nil {
 		return err
@@ -603,6 +604,7 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 				MediaType:    mf.MediaType,
 				Digest:       h,
 				Size:         size,
+				Annotations:  mf.Annotations,
 			}
 			if err := w.commitSubjectReferrers(ctx,
 				ref.Context().Digest(mf.Subject.Digest.String()),


### PR DESCRIPTION
Follow up of #1998
This PR just verifies that we see those values in the descriptor as mentioned [here](https://github.com/google/go-containerregistry/pull/1998#discussion_r1842980363)

