### PR TITLE
fix: require both username and password

### DIFF
--- a/cmd/crane/cmd/auth.go
+++ b/cmd/crane/cmd/auth.go
@@ -249,7 +249,7 @@ func login(opts loginOptions) error {
 		opts.password = strings.TrimSuffix(string(contents), "\n")
 		opts.password = strings.TrimSuffix(opts.password, "\r")
 	}
-	if opts.user == "" && opts.password == "" {
+	if opts.user == "" || opts.password == "" {
 		return errors.New("username and password required")
 	}
 	cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))


### PR DESCRIPTION
The `crane auth` command only checks if username or password are set. It should check for both. If only one is set then a invalid docker config will be created