### PR TITLE
Improve markdown for crane code snippets

### DIFF
--- a/cmd/crane/README.md
+++ b/cmd/crane/README.md
@@ -14,21 +14,21 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 1. Get the [latest release](https://github.com/google/go-containerregistry/releases/latest) version.
 
    ```sh
-   $ VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
+   VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
    ```
 
    or set a specific version:
 
    ```sh
-   $ VERSION=vX.Y.Z   # Version number with a leading v
+   VERSION=vX.Y.Z   # Version number with a leading v
    ```
 
 1. Download the release.
 
    ```sh
-   $ OS=Linux       # or Darwin, Windows
-   $ ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
-   $ curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+   OS=Linux       # or Darwin, Windows
+   ARCH=x86_64    # or arm64, x86_64, armv6, i386, s390x
+   curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
    ```
 
 1. Verify the signature. We generate [SLSA 3 provenance](https://slsa.dev) using
@@ -36,7 +36,7 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
    To verify our release, install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation)
    and verify as follows:
 
-   ```sh
+   ```console
    $ curl -sL https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl > provenance.intoto.jsonl
    $ # NOTE: You may be using a different architecture.
    $ slsa-verifier-linux-amd64 verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${VERSION}"
@@ -46,7 +46,7 @@ A collection of useful things you can do with `crane` is [here](recipes.md).
 1. Unpack it in the PATH.
 
    ```sh
-   $ tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
+   tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
    ```
 
 ### Install manually
@@ -62,7 +62,7 @@ go install github.com/google/go-containerregistry/cmd/crane@latest
 If you're macOS user and using [Homebrew](https://brew.sh/), you can install via brew command:
 
 ```sh
-$ brew install crane
+brew install crane
 ```
 
 ### Install on Arch Linux
@@ -70,7 +70,7 @@ $ brew install crane
 If you're an Arch Linux user you can install via pacman command:
 
 ```sh
-$ pacman -S crane
+pacman -S crane
 ```
 
 ### Setup on GitHub Actions
@@ -79,7 +79,7 @@ You can use the [`setup-crane`](https://github.com/imjasonh/setup-crane) action
 to install `crane` and setup auth to [GitHub Container
 Registry](https://github.com/features/packages) in a GitHub Action workflow:
 
-```
+```yaml
 steps:
 - uses: imjasonh/setup-crane@v0.1
 ```
@@ -88,7 +88,7 @@ steps:
 
 You can also use crane as docker image
 
-```sh
+```console
 $ docker run --rm gcr.io/go-containerregistry/crane ls ubuntu
 10.04
 12.04.5


### PR DESCRIPTION
Before this change, code snippets in the README were hard to copy since they contained a leading `$ ` and mixed shell commands with  console output. This change aims to improve the syntax so pure shell code snippets are easier to copy and so console output is marked as such (so GitHub can properly distinguish between command and output when rendering it). Also adds correct code fence for a YAML snippet.