### PR TITLE
Ensure that tag name is not empty if name contains colon

### DIFF
--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -80,6 +80,9 @@ func NewTag(name string, opts ...Option) (Tag, error) {
 	if len(parts) > 1 && !strings.Contains(parts[len(parts)-1], regRepoDelimiter) {
 		base = strings.Join(parts[:len(parts)-1], tagDelim)
 		tag = parts[len(parts)-1]
+		if tag == "" {
+			return Tag{}, newErrBadName("%s must specify a tag name after the colon", name)
+		}
 	}
 
 	// We don't require a tag, but if we get one check it's valid,

--- a/pkg/name/tag_test.go
+++ b/pkg/name/tag_test.go
@@ -40,6 +40,7 @@ var badTagNames = []string{
 	"gcr.io/project-id/bad_chars:c@n'tuse",
 	"gcr.io/project-id/wrong-length:white space",
 	"gcr.io/project-id/too-many-chars:thisisthetagthatneverendsitgoesonandonmyfriendsomepeoplestartedtaggingitnotknowingwhatitwasandtheyllcontinuetaggingitforeverjustbecausethisisthetagthatneverends",
+	"library/ubuntu:",
 }
 
 func TestNewTagStrictValidation(t *testing.T) {


### PR DESCRIPTION
The following fails as I expected:

```sh
$ docker pull "library/ubuntu:"
invalid reference format
```

But gcr `name.ParseReference("library/ubuntu:")` succeeds. It returns a tag and uses latest.

This PR fixes the logic when parsing a tag that in case there is a colon, when it takes the last part as tag that this one is not an empty string.