### PR TITLE
implement TextMarshaler/JSONMarshaler more consistently

### DIFF
--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -17,6 +17,7 @@ package name
 import (
 	// nolint: depguard
 	_ "crypto/sha256" // Recommended by go-digest.
+	"encoding"
 	"encoding/json"
 	"strings"
 
@@ -32,8 +33,11 @@ type Digest struct {
 	original string
 }
 
-// Ensure Digest implements Reference
 var _ Reference = (*Digest)(nil)
+var _ encoding.TextMarshaler = (*Digest)(nil)
+var _ encoding.TextUnmarshaler = (*Digest)(nil)
+var _ json.Marshaler = (*Digest)(nil)
+var _ json.Unmarshaler = (*Digest)(nil)
 
 // Context implements Reference.
 func (d Digest) Context() Repository {

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -79,6 +79,21 @@ func (d *Digest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalText formats the digest into a string for text serialization.
+func (d Digest) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
+// UnmarshalText parses a text string into a Digest.
+func (d *Digest) UnmarshalText(data []byte) error {
+	n, err := NewDigest(string(data))
+	if err != nil {
+		return err
+	}
+	*d = n
+	return nil
+}
+
 // NewDigest returns a new Digest representing the given name.
 func NewDigest(name string, opts ...Option) (Digest, error) {
 	// Split on "@"

--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding/json"
 	"net"
 	"net/url"
 	"path"
@@ -139,4 +140,34 @@ func NewRegistry(name string, opts ...Option) (Registry, error) {
 func NewInsecureRegistry(name string, opts ...Option) (Registry, error) {
 	opts = append(opts, Insecure)
 	return NewRegistry(name, opts...)
+}
+
+// MarshalJSON formats the Registry into a string for JSON serialization.
+func (r Registry) MarshalJSON() ([]byte, error) { return json.Marshal(r.String()) }
+
+// UnmarshalJSON parses a JSON string into a Registry.
+func (r *Registry) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := NewRegistry(s)
+	if err != nil {
+		return err
+	}
+	*r = n
+	return nil
+}
+
+// MarshalText formats the registry into a string for text serialization.
+func (r Registry) MarshalText() ([]byte, error) { return []byte(r.String()), nil }
+
+// UnmarshalText parses a text string into a Registry.
+func (r *Registry) UnmarshalText(data []byte) error {
+	n, err := NewRegistry(string(data))
+	if err != nil {
+		return err
+	}
+	*r = n
+	return nil
 }

--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding"
 	"encoding/json"
 	"net"
 	"net/url"
@@ -37,6 +38,11 @@ type Registry struct {
 	insecure bool
 	registry string
 }
+
+var _ encoding.TextMarshaler = (*Registry)(nil)
+var _ encoding.TextUnmarshaler = (*Registry)(nil)
+var _ json.Marshaler = (*Registry)(nil)
+var _ json.Unmarshaler = (*Registry)(nil)
 
 // RegistryStr returns the registry component of the Registry.
 func (r Registry) RegistryStr() string {

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -118,4 +119,34 @@ func (r Repository) Digest(identifier string) Digest {
 	}
 	d.original = d.Name()
 	return d
+}
+
+// MarshalJSON formats the Repository into a string for JSON serialization.
+func (r Repository) MarshalJSON() ([]byte, error) { return json.Marshal(r.String()) }
+
+// UnmarshalJSON parses a JSON string into a Repository.
+func (r *Repository) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := NewRepository(s)
+	if err != nil {
+		return err
+	}
+	*r = n
+	return nil
+}
+
+// MarshalText formats the repository name into a string for text serialization.
+func (r Repository) MarshalText() ([]byte, error) { return []byte(r.String()), nil }
+
+// UnmarshalText parses a text string into a Repository.
+func (r *Repository) UnmarshalText(data []byte) error {
+	n, err := NewRepository(string(data))
+	if err != nil {
+		return err
+	}
+	*r = n
+	return nil
 }

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -31,6 +32,11 @@ type Repository struct {
 	Registry
 	repository string
 }
+
+var _ encoding.TextMarshaler = (*Repository)(nil)
+var _ encoding.TextUnmarshaler = (*Repository)(nil)
+var _ json.Marshaler = (*Repository)(nil)
+var _ json.Unmarshaler = (*Repository)(nil)
 
 // See https://docs.docker.com/docker-hub/official_repos
 func hasImplicitNamespace(repo string, reg Registry) bool {

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding"
 	"encoding/json"
 	"strings"
 )
@@ -32,8 +33,11 @@ type Tag struct {
 	original string
 }
 
-// Ensure Tag implements Reference
 var _ Reference = (*Tag)(nil)
+var _ encoding.TextMarshaler = (*Tag)(nil)
+var _ encoding.TextUnmarshaler = (*Tag)(nil)
+var _ json.Marshaler = (*Tag)(nil)
+var _ json.Unmarshaler = (*Tag)(nil)
 
 // Context implements Reference.
 func (t Tag) Context() Repository {

--- a/pkg/name/tag.go
+++ b/pkg/name/tag.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"encoding/json"
 	"strings"
 )
 
@@ -105,4 +106,34 @@ func NewTag(name string, opts ...Option) (Tag, error) {
 		tag:        tag,
 		original:   name,
 	}, nil
+}
+
+// MarshalJSON formats the Tag into a string for JSON serialization.
+func (t Tag) MarshalJSON() ([]byte, error) { return json.Marshal(t.String()) }
+
+// UnmarshalJSON parses a JSON string into a Tag.
+func (t *Tag) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := NewTag(s)
+	if err != nil {
+		return err
+	}
+	*t = n
+	return nil
+}
+
+// MarshalText formats the tag into a string for text serialization.
+func (t Tag) MarshalText() ([]byte, error) { return []byte(t.String()), nil }
+
+// UnmarshalText parses a text string into a Tag.
+func (t *Tag) UnmarshalText(data []byte) error {
+	n, err := NewTag(string(data))
+	if err != nil {
+		return err
+	}
+	*t = n
+	return nil
 }

--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"crypto"
+	"encoding"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -32,6 +33,11 @@ type Hash struct {
 	// Hex holds the hex portion of the content hash.
 	Hex string
 }
+
+var _ encoding.TextMarshaler = (*Hash)(nil)
+var _ encoding.TextUnmarshaler = (*Hash)(nil)
+var _ json.Marshaler = (*Hash)(nil)
+var _ json.Unmarshaler = (*Hash)(nil)
 
 // String reverses NewHash returning the string-form of the hash.
 func (h Hash) String() string {

--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"strconv"
 	"strings"
 )
 
@@ -49,14 +48,12 @@ func NewHash(s string) (Hash, error) {
 }
 
 // MarshalJSON implements json.Marshaler
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return json.Marshal(h.String())
-}
+func (h Hash) MarshalJSON() ([]byte, error) { return json.Marshal(h.String()) }
 
 // UnmarshalJSON implements json.Unmarshaler
 func (h *Hash) UnmarshalJSON(data []byte) error {
-	s, err := strconv.Unquote(string(data))
-	if err != nil {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
 	return h.parse(s)
@@ -64,15 +61,11 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 
 // MarshalText implements encoding.TextMarshaler. This is required to use
 // v1.Hash as a key in a map when marshalling JSON.
-func (h Hash) MarshalText() (text []byte, err error) {
-	return []byte(h.String()), nil
-}
+func (h Hash) MarshalText() ([]byte, error) { return []byte(h.String()), nil }
 
 // UnmarshalText implements encoding.TextUnmarshaler. This is required to use
 // v1.Hash as a key in a map when unmarshalling JSON.
-func (h *Hash) UnmarshalText(text []byte) error {
-	return h.parse(string(text))
-}
+func (h *Hash) UnmarshalText(text []byte) error { return h.parse(string(text)) }
 
 // Hasher returns a hash.Hash for the named algorithm (e.g. "sha256")
 func Hasher(name string) (hash.Hash, error) {


### PR DESCRIPTION
Various things in the Go ecosystem natively understand how to go from `string->Foo` if `Foo` implements `TextUnmarshaler`, and likewise from `Foo->string` if `Foo` implements `TextMarshaler`.

This adds TextMarshaler and JSONMarshaler support to `name.Registry`, `name.Repository`, `name.Tag`, and `name.Digest`, and makes `v1.Hash`'s implementation a bit more consistent with those (using `json.Unmarshal` instead of `strconv.Unquote`)

