### PR TITLE
Update goreleaser permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['*']
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Example failure: https://github.com/google/go-containerregistry/actions/runs/15148456191/job/42589682769