### PR TITLE
crane: Add timestamp to flatten layer

### DIFF
--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -221,6 +222,7 @@ func flattenImage(old v1.Image, repo name.Repository, use string, o crane.Option
 	// Clear layer-specific config file information.
 	cf.RootFS.DiffIDs = []v1.Hash{}
 	cf.History = []v1.History{}
+	cf.Created = v1.Time{Time: time.Now().UTC()}
 
 	img, err := mutate.ConfigFile(empty.Image, cf)
 	if err != nil {
@@ -236,6 +238,7 @@ func flattenImage(old v1.Image, repo name.Repository, use string, o crane.Option
 	img, err = mutate.Append(img, mutate.Addendum{
 		Layer: layer,
 		History: v1.History{
+			Created:   cf.Created,
 			CreatedBy: fmt.Sprintf("%s flatten %s", use, digest),
 			Comment:   string(oldHistory),
 		},


### PR DESCRIPTION
Fixes #2115, which was reopened from #1974.

> When flattening an image the blob's created field is the same as the original image's, while the flattened layer's created field is a zero timestamp. This makes it impossible to figure out when was the flattened image actually created and distinguish it from the original.

After using crane flatten, the new layer does not have created time set. This will set the created time to the current time.

### Tested:
```
./hack/presubmit.sh 
```
<img width="755" height="82" alt="image" src="https://github.com/user-attachments/assets/d6a3ef6e-19ed-4ecb-9dc0-bbf2227608dc" />
