### PR TITLE
Fix ArgsEscaped lint directive

### DIFF
--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -20,15 +20,6 @@ set -o pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# We can't install in the current directory without changing the current module.
-TMP_DIR="$(mktemp -d)"
-export PATH="${PATH}:${TMP_DIR}/bin"
-export GOPATH="${TMP_DIR}"
-pushd ${TMP_DIR}
-trap popd EXIT
-go install honnef.co/go/tools/cmd/staticcheck@latest
-popd
-
 pushd ${PROJECT_ROOT}
 trap popd EXIT
 

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -32,8 +32,6 @@ popd
 pushd ${PROJECT_ROOT}
 trap popd EXIT
 
-staticcheck ./pkg/...
-
 # Verify that all source files are correctly formatted.
 find . -name "*.go" | grep -v vendor/ | xargs gofmt -d -e -l
 

--- a/pkg/v1/daemon/image.go
+++ b/pkg/v1/daemon/image.go
@@ -312,7 +312,7 @@ func (i *image) computeImageConfig(config *specs.DockerOCIImageConfig) v1.Config
 		User:       config.User,
 		Volumes:    config.Volumes,
 		WorkingDir: config.WorkingDir,
-		//lint:ignore SA1019 this is erroneously deprecated, as windows uses it
+		//nolint:staticcheck // SA1019 this is erroneously deprecated, as windows uses it
 		ArgsEscaped: config.ArgsEscaped,
 		StopSignal:  config.StopSignal,
 		Shell:       config.Shell,


### PR DESCRIPTION
I am removing `staticcheck` from presubmit.sh because it it out of sync with out fixed version of staticcheck used in  the Style action: https://github.com/google/go-containerregistry/blob/main/.github/workflows/style.yaml#L28