### PR TITLE
Adjust vendor setting in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,8 @@ updates:
       patterns:
       - "*"
 - package-ecosystem: gomod
+  directory: /
   vendor: true
-  directories:
-  - /
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
vendor is supported with "directory" but not "directories".