### PR TITLE
Remove "vendor" flag from dependabot and split dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,10 @@ updates:
       - "*"
 - package-ecosystem: gomod
   directory: /
-  vendor: true
   schedule:
     interval: weekly
   groups:
-    deps:
+    root-deps:
       patterns:
       - "*"
 - package-ecosystem: gomod
@@ -25,6 +24,6 @@ updates:
   schedule:
     interval: weekly
   groups:
-    deps:
+    auxiliary-deps:
       patterns:
       - "*"


### PR DESCRIPTION
According to documentation, `vendor` is invalid for gomod because the behavior is automatically managed.