### PR TITLE
feat(transport): add resumable transport for remote resources

### DIFF
--- a/cmd/crane/cmd/pull.go
+++ b/cmd/crane/cmd/pull.go
@@ -32,6 +32,7 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 	var (
 		cachePath, format string
 		annotateRef       bool
+		resumable         bool
 	)
 
 	cmd := &cobra.Command{
@@ -47,6 +48,10 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 				ref, err := name.ParseReference(src, o.Name...)
 				if err != nil {
 					return fmt.Errorf("parsing reference %q: %w", src, err)
+				}
+
+				if resumable {
+					o.Remote = append(o.Remote, remote.WithResumable())
 				}
 
 				rmt, err := remote.Get(ref, o.Remote...)
@@ -133,6 +138,7 @@ func NewCmdPull(options *[]crane.Option) *cobra.Command {
 	cmd.Flags().StringVarP(&cachePath, "cache_path", "c", "", "Path to cache image layers")
 	cmd.Flags().StringVar(&format, "format", "tarball", fmt.Sprintf("Format in which to save images (%q, %q, or %q)", "tarball", "legacy", "oci"))
 	cmd.Flags().BoolVar(&annotateRef, "annotate-ref", false, "Preserves image reference used to pull as an annotation when used with --format=oci")
+	cmd.Flags().BoolVar(&resumable, "resumable", false, "Enable resumable transport for pulling images")
 
 	return cmd
 }

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -46,6 +46,7 @@ type options struct {
 	retryPredicate                 retry.Predicate
 	retryStatusCodes               []int
 	resumable                      bool
+	resumableBackoff               Backoff
 
 	// Only these options can overwrite Reuse()d options.
 	platform v1.Platform
@@ -136,6 +137,7 @@ func makeOptions(opts ...Option) (*options, error) {
 		retryPredicate:   defaultRetryPredicate,
 		retryBackoff:     defaultRetryBackoff,
 		retryStatusCodes: defaultRetryStatusCodes,
+		resumableBackoff: defaultRetryBackoff,
 	}
 
 	for _, option := range opts {
@@ -173,7 +175,7 @@ func makeOptions(opts ...Option) (*options, error) {
 		o.transport = transport.NewRetry(o.transport, transport.WithRetryBackoff(o.retryBackoff), transport.WithRetryPredicate(predicate), transport.WithRetryStatusCodes(o.retryStatusCodes...))
 
 		if o.resumable {
-			o.transport = transport.NewResumable(o.transport)
+			o.transport = transport.NewResumable(o.transport, o.resumableBackoff)
 		}
 
 		// Wrap this last to prevent transport.New from double-wrapping.
@@ -198,9 +200,21 @@ func WithTransport(t http.RoundTripper) Option {
 	}
 }
 
+// WithResumable is a functional option for enabling resumable downloads. and it will wrap retry transport by default.
+// If configures retry and resumable backoff, should be aware of all backoff will be applied.
 func WithResumable() Option {
 	return func(o *options) error {
 		o.resumable = true
+		return nil
+	}
+}
+
+// WithResumableBackoff is a functional option for overriding the default resumable backoff for remote operations.
+// Resumable backoff will resume failed requests after a delay, unlike retry actions, resumable backoff will ignore
+// transport.RoundTripper.RoundTrip errors.
+func WithResumableBackoff(backoff Backoff) Option {
+	return func(o *options) error {
+		o.resumableBackoff = backoff
 		return nil
 	}
 }

--- a/pkg/v1/remote/transport/resumable.go
+++ b/pkg/v1/remote/transport/resumable.go
@@ -1,0 +1,242 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+)
+
+// NewResumable creates a http.RoundTripper that resumes http GET from error,
+// and the inner should be wrapped with retry transport, otherwise, the
+// transport will abort if resume() returns error.
+func NewResumable(inner http.RoundTripper) http.RoundTripper {
+	return &resumableTransport{inner: inner}
+}
+
+var (
+	contentRangeRe = regexp.MustCompile(`^bytes (\d+)-(\d+)/(\d+|\*)$`)
+)
+
+type resumableTransport struct {
+	inner http.RoundTripper
+}
+
+func (rt *resumableTransport) RoundTrip(in *http.Request) (*http.Response, error) {
+	if in.Method != http.MethodGet {
+		return rt.inner.RoundTrip(in)
+	}
+
+	req := in.Clone(in.Context())
+	req.Header.Set("Range", "bytes=0-")
+	resp, err := rt.inner.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+	case http.StatusRequestedRangeNotSatisfiable:
+		// fallback to previous behavior
+		resp.Body.Close()
+		return rt.inner.RoundTrip(in)
+	default:
+		return resp, nil
+	}
+
+	var contentLength int64
+	if _, _, contentLength, err = parseContentRange(resp.Header.Get("Content-Range")); err != nil || contentLength <= 0 {
+		// fallback to previous behavior
+		resp.Body.Close()
+		return rt.inner.RoundTrip(in)
+	}
+
+	// modify response status to 200, ensure caller error checking works
+	resp.StatusCode = http.StatusOK
+	resp.Status = "200 OK"
+	resp.ContentLength = contentLength
+	resp.Body = &resumableBody{
+		rc:          resp.Body,
+		inner:       rt.inner,
+		req:         req,
+		total:       contentLength,
+		transferred: 0,
+	}
+
+	return resp, nil
+}
+
+type resumableBody struct {
+	rc io.ReadCloser
+
+	inner http.RoundTripper
+	req   *http.Request
+
+	transferred int64
+	total       int64
+
+	closed uint32
+}
+
+func (rb *resumableBody) Read(p []byte) (n int, err error) {
+	if atomic.LoadUint32(&rb.closed) == 1 {
+		// response body already closed
+		return 0, http.ErrBodyReadAfterClose
+	} else if rb.total >= 0 && rb.transferred >= rb.total {
+		return 0, io.EOF
+	}
+
+resume:
+	if n, err = rb.rc.Read(p); n > 0 {
+		rb.transferred += int64(n)
+	}
+
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, io.EOF) && rb.total >= 0 && rb.transferred == rb.total {
+		return
+	}
+
+	if err = rb.resume(err); err == nil {
+		if n == 0 {
+			// zero bytes read, try reading again with new response.Body
+			goto resume
+		}
+
+		// already read some bytes from previous response.Body, returns and waits for next Read operation
+	}
+
+	return n, err
+}
+
+func (rb *resumableBody) Close() (err error) {
+	if !atomic.CompareAndSwapUint32(&rb.closed, 0, 1) {
+		return nil
+	}
+
+	return rb.rc.Close()
+}
+
+func (rb *resumableBody) resume(reason error) error {
+	if reason != nil {
+		logs.Debug.Printf("Resume http transporting from error: %v", reason)
+	}
+
+	ctx := rb.req.Context()
+	select {
+	case <-ctx.Done():
+		// context already done, stop resuming from error
+		return ctx.Err()
+	default:
+	}
+
+	req := rb.req.Clone(ctx)
+	req.Header.Set("Range", "bytes="+strconv.FormatInt(rb.transferred, 10)+"-")
+	resp, err := rb.inner.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+
+	if err = rb.validate(resp); err != nil {
+		resp.Body.Close()
+		return err
+	}
+
+	if atomic.LoadUint32(&rb.closed) == 1 {
+		resp.Body.Close()
+		return http.ErrBodyReadAfterClose
+	}
+
+	rb.rc.Close()
+	rb.rc = resp.Body
+
+	return nil
+}
+
+func (rb *resumableBody) validate(resp *http.Response) (err error) {
+	var start, total int64
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		if start, _, total, err = parseContentRange(resp.Header.Get("Content-Range")); err != nil {
+			return err
+		}
+
+		if total > rb.total {
+			rb.total = total
+		}
+
+		if start == rb.transferred {
+			break
+		} else if start < rb.transferred {
+			if _, err := io.CopyN(io.Discard, resp.Body, rb.transferred-start); err != nil {
+				return fmt.Errorf("discard overlapped data failed, %v", err)
+			}
+		} else {
+			return fmt.Errorf("unexpected resume start %d, wanted: %d", start, rb.transferred)
+		}
+	case http.StatusOK:
+		if rb.transferred > 0 {
+			if _, err = io.CopyN(io.Discard, resp.Body, rb.transferred); err != nil {
+				return err
+			}
+		}
+	case http.StatusRequestedRangeNotSatisfiable:
+		if contentRange := resp.Header.Get("Content-Range"); contentRange != "" && strings.HasPrefix(contentRange, "bytes */") {
+			if total, err = strconv.ParseInt(strings.TrimPrefix(contentRange, "bytes */"), 10, 64); err == nil && total >= 0 && rb.transferred >= total {
+				return io.EOF
+			}
+		}
+
+		fallthrough
+	default:
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func parseContentRange(contentRange string) (start, end, size int64, err error) {
+	if contentRange == "" {
+		return -1, -1, -1, errors.New("unexpected empty content range")
+	}
+
+	matches := contentRangeRe.FindStringSubmatch(contentRange)
+	if len(matches) != 4 {
+		return -1, -1, -1, fmt.Errorf("invalid content range: %s", contentRange)
+	}
+
+	if start, err = strconv.ParseInt(matches[1], 10, 64); err != nil {
+		return -1, -1, -1, fmt.Errorf("unexpected start from content range '%s', %v", contentRange, err)
+	}
+
+	if end, err = strconv.ParseInt(matches[2], 10, 64); err != nil {
+		return -1, -1, -1, fmt.Errorf("unexpected end from content range '%s', %v", contentRange, err)
+	}
+
+	if start > end {
+		return -1, -1, -1, fmt.Errorf("invalid content range: %s", contentRange)
+	}
+
+	if matches[3] == "*" {
+		size = -1
+	} else {
+		size, err = strconv.ParseInt(matches[3], 10, 64)
+		if err != nil {
+			return -1, -1, -1, fmt.Errorf("unexpected total from content range '%s', %v", contentRange, err)
+		}
+
+		if end >= size {
+			return -1, -1, -1, fmt.Errorf("invalid content range: %s", contentRange)
+		}
+	}
+
+	return
+}

--- a/pkg/v1/remote/transport/resumable_test.go
+++ b/pkg/v1/remote/transport/resumable_test.go
@@ -268,7 +268,12 @@ func TestResumableTransport(t *testing.T) {
 	}
 
 	client := &http.Client{
-		Transport: NewResumable(http.DefaultTransport.(*http.Transport).Clone()),
+		Transport: NewResumable(http.DefaultTransport.(*http.Transport).Clone(), Backoff{
+			Duration: 1.0 * time.Second,
+			Factor:   3.0,
+			Jitter:   0.1,
+			Steps:    3,
+		}),
 	}
 
 	tests := []struct {

--- a/pkg/v1/remote/transport/resumable_test.go
+++ b/pkg/v1/remote/transport/resumable_test.go
@@ -1,0 +1,298 @@
+package transport
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	stdrand "math/rand"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var rangeRe = regexp.MustCompile(`bytes=(\d+)-(\d+)?`)
+
+func handleResumableLayer(data []byte, w http.ResponseWriter, r *http.Request, t *testing.T) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	contentRange := r.Header.Get("Range")
+	if contentRange == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	matches := rangeRe.FindStringSubmatch(contentRange)
+	if len(matches) != 3 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	contentLength := int64(len(data))
+	start, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil || start < 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if start >= int64(contentLength) {
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+
+	var end = int64(contentLength) - 1
+	if matches[2] != "" {
+		end, err = strconv.ParseInt(matches[2], 10, 64)
+		if err != nil || end < 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if end >= int64(contentLength) {
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+	}
+
+	var currentContentLength = end - start + 1
+	if currentContentLength <= 0 {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if currentContentLength > 4096 {
+		if currentContentLength = stdrand.Int63n(currentContentLength); currentContentLength < 1024 {
+			currentContentLength = 1024
+		}
+
+		if r.Header.Get("X-Overlap") == "true" {
+			overlapSize := int64(stdrand.Int31n(64))
+			if start > overlapSize {
+				start -= overlapSize
+				// t.Logf("Overlap data size: %d", overlapSize)
+			}
+		}
+	}
+
+	end = start + currentContentLength - 1
+
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, contentLength))
+	w.Header().Set("Content-Length", strconv.FormatInt(currentContentLength, 10))
+	w.WriteHeader(http.StatusPartialContent)
+	w.Write(data[start : end+1])
+	time.Sleep(time.Second)
+}
+
+func resumableRequest(client *http.Client, url string, size int64, digest string, overlap bool, t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): %v", err)
+	}
+
+	if overlap {
+		req.Header.Set("X-Overlap", "true")
+	}
+
+	resp, err := client.Do(req.WithContext(t.Context()))
+	if err != nil {
+		t.Fatalf("client.Do(): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if _, ok := resp.Body.(*resumableBody); !ok {
+		t.Error("expected resumable body")
+		return
+	}
+
+	hash := sha256.New()
+
+	if _, err = io.Copy(hash, resp.Body); err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	actualDigest := "sha256:" + hex.EncodeToString(hash.Sum(nil))
+
+	if actualDigest != digest {
+		t.Errorf("unexpected digest: %s, actually: %s", digest, actualDigest)
+	}
+}
+
+func nonResumableRequest(client *http.Client, url string, t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do(): %v", err)
+	}
+
+	_, ok := resp.Body.(*resumableBody)
+	if ok {
+		t.Error("expected non-resumable body")
+	}
+}
+
+func resumableStopByTimeoutRequest(client *http.Client, url string, t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*3)
+	defer cancel()
+
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("client.Do(): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if _, ok := resp.Body.(*resumableBody); !ok {
+		t.Error("expected resumable body")
+		return
+	}
+
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("expected context deadline exceeded error")
+	}
+}
+
+func resumableStopByCancelRequest(client *http.Client, url string, t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	time.AfterFunc(time.Second*3, cancel)
+
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("client.Do(): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if _, ok := resp.Body.(*resumableBody); !ok {
+		t.Error("expected resumable body")
+		return
+	}
+
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil && !errors.Is(err, context.Canceled) {
+		t.Error("expected context cancel error")
+	}
+}
+
+func TestResumableTransport(t *testing.T) {
+	logs.Debug.SetOutput(os.Stdout)
+	layer, err := random.Layer(2<<20, types.DockerLayer)
+	if err != nil {
+		t.Fatalf("random.Layer(): %v", err)
+	}
+
+	digest, err := layer.Digest()
+	if err != nil {
+		t.Fatalf("layer.Digest(): %v", err)
+	}
+
+	size, err := layer.Size()
+	if err != nil {
+		t.Fatalf("layer.Size(): %v", err)
+	}
+
+	rc, err := layer.Compressed()
+	if err != nil {
+		t.Fatalf("layer.Compressed(): %v", err)
+	}
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("io.ReadAll(): %v", err)
+	}
+
+	layerPath := fmt.Sprintf("/v2/foo/bar/blobs/%s", digest.String())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case layerPath:
+			handleResumableLayer(data, w, r, t)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	address, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	client := &http.Client{
+		Transport: NewResumable(http.DefaultTransport.(*http.Transport).Clone()),
+	}
+
+	tests := []struct {
+		name         string
+		digest       string
+		size         int64
+		timeout      bool
+		cancel       bool
+		nonResumable bool
+		overlap      bool
+	}{
+		{
+			name:   "resumable",
+			digest: digest.String(),
+			size:   size,
+		},
+		{
+			name:    "resumable-overlap",
+			digest:  digest.String(),
+			size:    size,
+			overlap: true,
+		},
+		{
+			name:         "non-resumable",
+			nonResumable: true,
+		},
+		{
+			name:   "resumable stop by timeout",
+			cancel: true,
+		},
+		{
+			name:   "resumable stop by cancel",
+			cancel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := address.String() + layerPath
+			if tt.nonResumable {
+				nonResumableRequest(client, address.String(), t)
+			} else if tt.cancel {
+				resumableStopByCancelRequest(client, url, t)
+			} else if tt.timeout {
+				resumableStopByTimeoutRequest(client, url, t)
+			} else if tt.digest != "" && tt.size > 0 {
+				resumableRequest(client, url, tt.size, tt.digest, tt.overlap, t)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add resumable transport support for pulling images from registry, which is useful for huge image pulling operation, and avoid downloading all image/layer data again when error hanpens