### PR TITLE
Fix reviewdog arguments

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -48,4 +48,4 @@ jobs:
           github-token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: error
-          fail-on-error: true
+          fail-level: error


### PR DESCRIPTION
`fail-on-error: true` was deprecated in favor of `fail-level: error`.