### PR TITLE
fix(ping): fix auto detect service scheme issue

### DIFF
--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -75,6 +75,12 @@ func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, sch
 		resp.Body.Close()
 	}()
 
+	// Check actual registry scheme detected, in case of redirecting to different scheme,
+	// update the scheme so subsequent logic (and the returned Challenge) reflects it.
+	if resp.Request != nil && resp.Request.URL != nil && resp.Request.URL.Scheme != "" {
+		scheme = resp.Request.URL.Scheme
+	}
+
 	insecure := scheme == "http"
 
 	switch resp.StatusCode {

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -231,6 +231,36 @@ func TestPingHttpFallback(t *testing.T) {
 	}
 }
 
+func TestPingHttpFixture(t *testing.T) {
+	var httpsPassed bool
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpsPassed = true
+			time.Sleep(time.Second * 3)
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	tprt := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			if httpsPassed {
+				return http.ProxyFromEnvironment(req)
+			}
+
+			return url.Parse(server.URL)
+		},
+	}
+
+	challenge, err := Ping(context.Background(), mustInsecureRegistry("us.gcr.io"), tprt)
+	if err != nil {
+		t.Fatalf("Ping(): %v", err)
+	}
+
+	if challenge.Insecure {
+		t.Fatalf("Insecure fixture is not working")
+	}
+}
+
 func mustRegistry(r string) name.Registry {
 	reg, err := name.NewRegistry(r)
 	if err != nil {

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -232,10 +232,10 @@ func TestPingHttpFallback(t *testing.T) {
 }
 
 func TestPingHttpFixture(t *testing.T) {
-	var httpsPassed bool
+	var httpsPassed atomic.Bool
 	server := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			httpsPassed = true
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			httpsPassed.Store(true)
 			time.Sleep(time.Second * 3)
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -243,7 +243,7 @@ func TestPingHttpFixture(t *testing.T) {
 
 	tprt := &http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
-			if httpsPassed {
+			if httpsPassed.Load() {
 				return http.ProxyFromEnvironment(req)
 			}
 


### PR DESCRIPTION
Add auto registry scheme(https/http) detect for Ping().

If registry auto redirect http to https( or https to http), and we try to use name.Insecure option, Ping() func has chances stopped by http.Client for too many redirects. And the fixture just replace original scheme with successful request's scheme
