### PR TITLE
Better handle redirects to https in ping

### DIFF
--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -75,7 +76,10 @@ func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, sch
 		resp.Body.Close()
 	}()
 
-	insecure := scheme == "http"
+	// If resp.Request is set, we may have followed a redirect,
+	// so we want to prefer resp.Request.URL.Scheme (if it's set)
+	// falling back to the original request's scheme.
+	insecure := cmp.Or(resp.Request, req).URL.Scheme == "http"
 
 	switch resp.StatusCode {
 	case http.StatusOK:


### PR DESCRIPTION
When we pass --insecure into crane, we permit http responses for any host, which means we do this fun little happy eyeballs race between https and http for hosts-that-we-expect-to-be-served-over-https.

A common thing for web servers to do is to redirect http to https.

Our little happy eyeballs race assumes that if we ping http and get a successful response, that we should use http going forward. This is naive in the case where the reason we received a happy response is that the server redirected us to the https version (and we followed it).

This happens rarely (when the https reponse takes longer than the fallback delay) so we don't often see it, but if that does happen we end up failing to attach credentials, which isn't great.

To fix this, we can just look the scheme we used in the (sometimes redirected) request URL rather than the scheme we used for the original request.