### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: 1.25
           check-latest: true
-      - uses: goreleaser/goreleaser-action@v6.4.0
+      - uses: goreleaser/goreleaser-action@v7.0.0
         id: run-goreleaser
         with:
           version: "~> v1.19"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: chainguard-dev/actions/eof-newline@main
         if: ${{ always() }}
 
-      - uses: reviewdog/action-misspell@v1
+      - uses: reviewdog/action-misspell@v1.27.0
         if: ${{ always() }}
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `goreleaser/goreleaser-action` | [`v6.4.0`](https://github.com/goreleaser/goreleaser-action/releases/tag/v6.4.0) | [`v7.0.0`](https://github.com/goreleaser/goreleaser-action/releases/tag/v7.0.0) | [Release](https://github.com/goreleaser/goreleaser-action/releases/tag/v7) | release.yml |
| `reviewdog/action-misspell` | [`v1`](https://github.com/reviewdog/action-misspell/releases/tag/v1) | [`v1.27.0`](https://github.com/reviewdog/action-misspell/releases/tag/v1.27.0) | [Release](https://github.com/reviewdog/action-misspell/releases/tag/v1.27.0) | style.yaml |

## Breaking Changes

- **goreleaser/goreleaser-action** (v6.4.0 → v7.0.0): Major version upgrade — review the [release notes](https://github.com/goreleaser/goreleaser-action/releases) for breaking changes

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
