### PR TITLE
fix: handle missing DiffIDs in tarball Manifest() to prevent panic

### DIFF
--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -374,6 +374,25 @@ func (c *compressedImage) Manifest() (*v1.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
+		if i >= len(cfg.RootFS.DiffIDs) {
+			// Config formats like buildkit cacheconfig don't have DiffIDs.
+			// Fall through to read the layer from the tar directly.
+			l, err := extractFileFromTar(c.opener, p)
+			if err != nil {
+				return nil, err
+			}
+			defer l.Close()
+			sha, size, err := v1.SHA256(l)
+			if err != nil {
+				return nil, err
+			}
+			c.manifest.Layers = append(c.manifest.Layers, v1.Descriptor{
+				MediaType: types.DockerLayer,
+				Size:      size,
+				Digest:    sha,
+			})
+			continue
+		}
 		diffid := cfg.RootFS.DiffIDs[i]
 		if d, ok := c.imgDescriptor.LayerSources[diffid]; ok {
 			// If it's a foreign layer, just append the descriptor so we can avoid


### PR DESCRIPTION
Fixes #2192

## Problem

`(*compressedImage).Manifest()` accesses `cfg.RootFS.DiffIDs[i]` without bounds checking. When loading a tar image whose config is a non-standard type (e.g. `application/vnd.buildkit.cacheconfig.v0`), `DiffIDs` is empty, causing:

```
panic: runtime error: index out of range [0] with length 0
```

## Fix

Add a bounds check before accessing `DiffIDs[i]`. When the index exceeds the DiffIDs length (as with buildkit cache configs), fall through to read the layer directly from the tar archive to compute its digest and size, similar to the existing non-foreign-layer path.