### PR TITLE
transport: restore resp.Body in retryError so CheckError can parse it

### DIFF
--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -189,6 +190,11 @@ func retryError(resp *http.Response) error {
 	if err != nil {
 		return err
 	}
+
+	// Restore the body so that a subsequent CheckError call (after the
+	// retry loop exhausts its retries) can still read and parse the
+	// structured registry error from the response.
+	resp.Body = io.NopCloser(bytes.NewReader(b))
 
 	rerr := makeError(resp, b)
 	rerr.temporary = true

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -259,8 +259,8 @@ func TestRetryErrorRestoresBody(t *testing.T) {
 	if finalErr == nil {
 		t.Fatal("CheckError() returned nil after retryError, wanted structured error")
 	}
-	terr, ok := finalErr.(*Error)
-	if !ok {
+	var terr *Error
+	if !errors.As(finalErr, &terr) {
 		t.Fatalf("CheckError() returned %T, wanted *Error", finalErr)
 	}
 	if len(terr.Errors) == 0 || terr.Errors[0].Code != ManifestUnknownErrorCode {

--- a/pkg/v1/remote/transport/error_test.go
+++ b/pkg/v1/remote/transport/error_test.go
@@ -234,3 +234,36 @@ func (e *errReadCloser) Read(_ []byte) (int, error) {
 func (e *errReadCloser) Close() error {
 	return e.err
 }
+
+// TestRetryErrorRestoresBody is a regression test for
+// https://github.com/google/go-containerregistry/issues/2125.
+// retryError must restore resp.Body after reading it so that a subsequent
+// CheckError call can still parse the structured registry error.
+func TestRetryErrorRestoresBody(t *testing.T) {
+	body := `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Request:    &http.Request{URL: &url.URL{}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	// Simulate what the retry transport does: call retryError, then — after
+	// retries are exhausted — call CheckError.
+	rerr := retryError(resp)
+	if rerr == nil {
+		t.Fatal("retryError() returned nil, wanted error")
+	}
+
+	// The body must be restored so CheckError can produce the structured error.
+	finalErr := CheckError(resp, http.StatusOK)
+	if finalErr == nil {
+		t.Fatal("CheckError() returned nil after retryError, wanted structured error")
+	}
+	terr, ok := finalErr.(*Error)
+	if !ok {
+		t.Fatalf("CheckError() returned %T, wanted *Error", finalErr)
+	}
+	if len(terr.Errors) == 0 || terr.Errors[0].Code != ManifestUnknownErrorCode {
+		t.Errorf("CheckError() after retryError = %v, wanted MANIFEST_UNKNOWN error", terr)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #2125.

`retryError` consumed `resp.Body` with `io.ReadAll` but never restored it. When the retry loop exhausted its attempts and fell through to `CheckError`, that function tried to read the same body and got nothing — producing a generic `"unexpected status code 404"` instead of the structured registry error (`MANIFEST_UNKNOWN: manifest unknown; ...`).

### Fix

After reading the body, restore it with `io.NopCloser(bytes.NewReader(b))` so subsequent callers see the same bytes. This is a one-line addition matching the same pattern used elsewhere in the codebase.

### Before

```
With 404 retry:
GET …/manifests/0.0.46-bad-version: unexpected status code 404 Not Found
```

### After

```
With 404 retry:
GET …/manifests/0.0.46-bad-version: MANIFEST_UNKNOWN: manifest unknown; unknown tag=0.0.46-bad-version
```

## Testing

Added `TestRetryErrorRestoresBody`: calls `retryError` then `CheckError` on the same response and asserts the structured `MANIFEST_UNKNOWN` error comes through. All existing tests pass.