### PR TITLE
Follow OCI distribution spec for artifactType and annotations

### DIFF
--- a/pkg/v1/manifest.go
+++ b/pkg/v1/manifest.go
@@ -29,6 +29,7 @@ type Manifest struct {
 	Layers        []Descriptor      `json:"layers"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
 	Subject       *Descriptor       `json:"subject,omitempty"`
+	ArtifactType  string            `json:"artifactType,omitempty"`
 }
 
 // IndexManifest represents an OCI image index in a structured way.
@@ -38,6 +39,7 @@ type IndexManifest struct {
 	Manifests     []Descriptor      `json:"manifests"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
 	Subject       *Descriptor       `json:"subject,omitempty"`
+	ArtifactType  string            `json:"artifactType,omitempty"`
 }
 
 // Descriptor holds a reference from the manifest to one of its constituent elements.

--- a/pkg/v1/mutate/index_test.go
+++ b/pkg/v1/mutate/index_test.go
@@ -182,17 +182,17 @@ func TestIndexImmutability(t *testing.T) {
 	})
 }
 
-// TestAppend_ArtifactType tests that appending an image manifest that has a
-// non-standard config.mediaType to an index, results in the image's
-// config.mediaType being hoisted into the descriptor inside the index,
-// as artifactType.
+// TestAppend_ArtifactType tests that appending an image manifest to an
+// index results in the image's artifactType being set in the descriptor
+// inside the index. Per the OCI distribution spec, if artifactType is
+// not set in the manifest, it falls back to config.mediaType.
 func TestAppend_ArtifactType(t *testing.T) {
 	for _, c := range []struct {
 		desc, configMediaType, wantArtifactType string
 	}{{
-		desc:             "standard config.mediaType, no artifactType",
+		desc:             "standard config.mediaType, artifactType falls back to config.mediaType",
 		configMediaType:  string(types.DockerConfigJSON),
-		wantArtifactType: "",
+		wantArtifactType: string(types.DockerConfigJSON),
 	}, {
 		desc:             "non-standard config.mediaType, want artifactType",
 		configMediaType:  "application/vnd.custom.something",

--- a/pkg/v1/partial/with.go
+++ b/pkg/v1/partial/with.go
@@ -337,8 +337,12 @@ func Descriptor(d Describable) (*v1.Descriptor, error) {
 			mf, _ := Manifest(wrm)
 			// Failing to parse as a manifest should just be ignored.
 			// The manifest might not be valid, and that's okay.
-			if mf != nil && !mf.Config.MediaType.IsConfig() {
-				desc.ArtifactType = string(mf.Config.MediaType)
+			if mf != nil {
+				if mf.ArtifactType != "" {
+					desc.ArtifactType = mf.ArtifactType
+				} else {
+					desc.ArtifactType = string(mf.Config.MediaType)
+				}
 			}
 		}
 	}
@@ -429,7 +433,10 @@ func ArtifactType(w WithManifest) (string, error) {
 	mf, _ := w.Manifest()
 	// Failing to parse as a manifest should just be ignored.
 	// The manifest might not be valid, and that's okay.
-	if mf != nil && !mf.Config.MediaType.IsConfig() {
+	if mf != nil {
+		if mf.ArtifactType != "" {
+			return mf.ArtifactType, nil
+		}
 		return string(mf.Config.MediaType), nil
 	}
 	return "", nil

--- a/pkg/v1/partial/with_test.go
+++ b/pkg/v1/partial/with_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -242,5 +243,127 @@ func TestExists(t *testing.T) {
 	}
 	if got, want := ok, true; got != want {
 		t.Errorf("Exists() = %t != %t", got, want)
+	}
+}
+
+// TestArtifactType_Fallback tests that partial.ArtifactType falls back to
+// config.mediaType when the manifest has no explicit artifactType.
+func TestArtifactType_Fallback(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		configMediaType  types.MediaType
+		wantArtifactType string
+	}{{
+		desc:             "standard config mediaType",
+		configMediaType:  types.DockerConfigJSON,
+		wantArtifactType: string(types.DockerConfigJSON),
+	}, {
+		desc:             "OCI config mediaType",
+		configMediaType:  types.OCIConfigJSON,
+		wantArtifactType: string(types.OCIConfigJSON),
+	}, {
+		desc:             "custom config mediaType",
+		configMediaType:  "application/vnd.custom.thing",
+		wantArtifactType: "application/vnd.custom.thing",
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			img, err := random.Image(1, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			img = mutate.ConfigMediaType(img, tc.configMediaType)
+
+			got, err := partial.ArtifactType(img)
+			if err != nil {
+				t.Fatalf("partial.ArtifactType: %v", err)
+			}
+			if got != tc.wantArtifactType {
+				t.Errorf("ArtifactType: got %q, want %q", got, tc.wantArtifactType)
+			}
+		})
+	}
+}
+
+// TestDescriptor_ArtifactType_Fallback tests that partial.Descriptor falls
+// back to config.mediaType when the manifest has no explicit artifactType.
+func TestDescriptor_ArtifactType_Fallback(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		configMediaType  types.MediaType
+		wantArtifactType string
+	}{{
+		desc:             "standard config mediaType",
+		configMediaType:  types.DockerConfigJSON,
+		wantArtifactType: string(types.DockerConfigJSON),
+	}, {
+		desc:             "custom config mediaType",
+		configMediaType:  "application/vnd.custom.thing",
+		wantArtifactType: "application/vnd.custom.thing",
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			img, err := random.Image(1, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			img = mutate.ConfigMediaType(img, tc.configMediaType)
+
+			desc, err := partial.Descriptor(img)
+			if err != nil {
+				t.Fatalf("partial.Descriptor: %v", err)
+			}
+			if got := desc.ArtifactType; got != tc.wantArtifactType {
+				t.Errorf("ArtifactType: got %q, want %q", got, tc.wantArtifactType)
+			}
+		})
+	}
+}
+
+// fakeWithManifest is a test helper that implements partial.WithManifest
+// with a caller-controlled v1.Manifest.
+type fakeWithManifest struct {
+	manifest *v1.Manifest
+}
+
+func (f fakeWithManifest) Manifest() (*v1.Manifest, error) {
+	return f.manifest, nil
+}
+
+func (f fakeWithManifest) RawManifest() ([]byte, error) {
+	return nil, nil
+}
+
+// TestArtifactType_ExplicitArtifactType tests that partial.ArtifactType
+// returns the manifest's explicit artifactType when set, rather than
+// falling back to config.mediaType.
+func TestArtifactType_ExplicitArtifactType(t *testing.T) {
+	fake := fakeWithManifest{
+		manifest: &v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+			},
+			ArtifactType: "application/vnd.my.custom.artifact",
+		},
+	}
+	got, err := partial.ArtifactType(fake)
+	if err != nil {
+		t.Fatalf("partial.ArtifactType: %v", err)
+	}
+	if want := "application/vnd.my.custom.artifact"; got != want {
+		t.Errorf("ArtifactType: got %q, want %q", got, want)
+	}
+}
+
+// TestArtifactType_NilManifest tests that partial.ArtifactType returns
+// empty string when the manifest is nil.
+func TestArtifactType_NilManifest(t *testing.T) {
+	fake := fakeWithManifest{manifest: nil}
+	got, err := partial.ArtifactType(fake)
+	if err != nil {
+		t.Fatalf("partial.ArtifactType: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ArtifactType: got %q, want empty", got)
 	}
 }

--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -16,6 +16,7 @@ package remote
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -254,4 +255,181 @@ func (errTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}, nil
 	}
 	return nil, fmt.Errorf("error reaching %s", req.URL.String())
+}
+
+// TestGet_ArtifactTypeAndAnnotations tests that Get returns the correct
+// artifactType and annotations on the descriptor, following the OCI
+// distribution spec:
+//   - If artifactType is set in the manifest, use it.
+//   - Otherwise, fall back to config.mediaType.
+//   - Annotations from the manifest are copied to the descriptor.
+func TestGet_ArtifactTypeAndAnnotations(t *testing.T) {
+	// We need a valid digest in config descriptors so that
+	// v1.ParseManifest can unmarshal the JSON without error.
+	cfgDigest, err := v1.NewHash(fakeDigest)
+	if err != nil {
+		t.Fatalf("v1.NewHash: %v", err)
+	}
+
+	for _, tc := range []struct {
+		desc             string
+		manifest         v1.Manifest
+		wantArtifactType string
+		wantAnnotations  map[string]string
+	}{{
+		desc: "no artifactType, standard config mediaType falls back to config.mediaType",
+		manifest: v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Digest:    cfgDigest,
+				Size:      1,
+			},
+		},
+		wantArtifactType: string(types.OCIConfigJSON),
+	}, {
+		desc: "no artifactType, custom config mediaType falls back to config.mediaType",
+		manifest: v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: "application/vnd.custom.thing",
+				Digest:    cfgDigest,
+				Size:      1,
+			},
+		},
+		wantArtifactType: "application/vnd.custom.thing",
+	}, {
+		desc: "explicit artifactType takes precedence over config.mediaType",
+		manifest: v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Digest:    cfgDigest,
+				Size:      1,
+			},
+			ArtifactType: "application/vnd.my.artifact",
+		},
+		wantArtifactType: "application/vnd.my.artifact",
+	}, {
+		desc: "annotations are copied to the descriptor",
+		manifest: v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Digest:    cfgDigest,
+				Size:      1,
+			},
+			Annotations: map[string]string{
+				"org.opencontainers.image.created": "2024-01-01T00:00:00Z",
+				"org.opencontainers.image.authors": "test",
+			},
+		},
+		wantArtifactType: string(types.OCIConfigJSON),
+		wantAnnotations: map[string]string{
+			"org.opencontainers.image.created": "2024-01-01T00:00:00Z",
+			"org.opencontainers.image.authors": "test",
+		},
+	}, {
+		desc: "artifactType and annotations together",
+		manifest: v1.Manifest{
+			SchemaVersion: 2,
+			MediaType:     types.OCIManifestSchema1,
+			Config: v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Digest:    cfgDigest,
+				Size:      1,
+			},
+			ArtifactType: "application/vnd.my.artifact",
+			Annotations: map[string]string{
+				"foo": "bar",
+			},
+		},
+		wantArtifactType: "application/vnd.my.artifact",
+		wantAnnotations: map[string]string{
+			"foo": "bar",
+		},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			manifestBytes, err := json.Marshal(tc.manifest)
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+
+			expectedRepo := "foo/bar"
+			manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v2/":
+					w.WriteHeader(http.StatusOK)
+				case manifestPath:
+					w.Header().Set("Content-Type", string(types.OCIManifestSchema1))
+					w.Write(manifestBytes)
+				default:
+					t.Fatalf("Unexpected path: %v", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+			u, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+			}
+
+			tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+			desc, err := Get(tag)
+			if err != nil {
+				t.Fatalf("Get(%s) = %v", tag, err)
+			}
+
+			if got := desc.ArtifactType; got != tc.wantArtifactType {
+				t.Errorf("ArtifactType: got %q, want %q", got, tc.wantArtifactType)
+			}
+
+			if diff := cmp.Diff(tc.wantAnnotations, desc.Annotations); diff != "" {
+				t.Errorf("Annotations (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestGet_NonManifestMediaType tests that non-parseable manifests don't
+// produce an artifactType or annotations (the parse failure is silently ignored).
+func TestGet_NonManifestMediaType(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema1Signed))
+			w.Header().Set("Docker-Content-Digest", fakeDigest)
+			w.Write([]byte("not valid json"))
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	tag := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	desc, err := Get(tag)
+	if err != nil {
+		t.Fatalf("Get(%s) = %v", tag, err)
+	}
+
+	if got := desc.ArtifactType; got != "" {
+		t.Errorf("ArtifactType: got %q, want empty", got)
+	}
+	if desc.Annotations != nil {
+		t.Errorf("Annotations: got %v, want nil", desc.Annotations)
+	}
 }

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -162,11 +162,20 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 	}
 
 	var artifactType string
+	var annotations map[string]string
 	mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
 	// Failing to parse as a manifest should just be ignored.
 	// The manifest might not be valid, and that's okay.
-	if mf != nil && !mf.Config.MediaType.IsConfig() {
-		artifactType = string(mf.Config.MediaType)
+	if mf != nil {
+		// Per the OCI distribution spec, artifactType on the descriptor is
+		// set to the manifest's artifactType if present, otherwise it falls
+		// back to the config descriptor's mediaType.
+		if mf.ArtifactType != "" {
+			artifactType = mf.ArtifactType
+		} else {
+			artifactType = string(mf.Config.MediaType)
+		}
+		annotations = mf.Annotations
 	}
 
 	// Do nothing for tags; I give up.
@@ -183,6 +192,7 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 		Size:         size,
 		MediaType:    mediaType,
 		ArtifactType: artifactType,
+		Annotations:  annotations,
 	}
 
 	return manifest, &desc, nil

--- a/pkg/v1/remote/index.go
+++ b/pkg/v1/remote/index.go
@@ -225,8 +225,12 @@ func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform)
 		mf, _ := v1.ParseManifest(bytes.NewReader(manifest))
 		// Failing to parse as a manifest should just be ignored.
 		// The manifest might not be valid, and that's okay.
-		if mf != nil && !mf.Config.MediaType.IsConfig() {
-			child.ArtifactType = string(mf.Config.MediaType)
+		if mf != nil {
+			if mf.ArtifactType != "" {
+				child.ArtifactType = mf.ArtifactType
+			} else {
+				child.ArtifactType = string(mf.Config.MediaType)
+			}
 		}
 	}
 

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -555,9 +555,10 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		return err
 	}
 	var mf struct {
-		MediaType types.MediaType `json:"mediaType"`
-		Subject   *v1.Descriptor  `json:"subject,omitempty"`
-		Config    struct {
+		MediaType    types.MediaType `json:"mediaType"`
+		Subject      *v1.Descriptor  `json:"subject,omitempty"`
+		ArtifactType string          `json:"artifactType,omitempty"`
+		Config       struct {
 			MediaType types.MediaType `json:"mediaType"`
 		} `json:"config"`
 	}
@@ -599,10 +600,14 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 				return err
 			}
 			desc := v1.Descriptor{
-				ArtifactType: string(mf.Config.MediaType),
-				MediaType:    mf.MediaType,
-				Digest:       h,
-				Size:         size,
+				MediaType: mf.MediaType,
+				Digest:    h,
+				Size:      size,
+			}
+			if mf.ArtifactType != "" {
+				desc.ArtifactType = mf.ArtifactType
+			} else {
+				desc.ArtifactType = string(mf.Config.MediaType)
 			}
 			if err := w.commitSubjectReferrers(ctx,
 				ref.Context().Digest(mf.Subject.Digest.String()),


### PR DESCRIPTION
Per the OCI distribution spec ([distribution-spec#395](https://github.com/opencontainers/distribution-spec/pull/395)), the artifactType
on a descriptor should be set to the manifest's artifactType if present,
falling back to config.mediaType unconditionally (not only for
non-standard config types as was done previously). Additionally,
annotations from the manifest are now copied to the descriptor.

Current wording from the spec:

> Pushing Manifests with Subject
>
> When processing a request for an image manifest with the subject field,
> a registry implementation that supports the referrers API MUST respond
> with the response header OCI-Subject: <subject digest> to indicate to
> the client that the registry processed the request's subject.
>
> When pushing a manifest with the subject field and the OCI-Subject header was not set, the client MUST:
> 1. Pull the current referrers list using the referrers tag schema.
> 2. If that pull returns a manifest other than the expected image index, the client SHOULD report a failure and skip the remaining steps.
> 3. If the tag returns a 404, the client MUST begin with an empty image index.
> 4. Verify the descriptor for the manifest is not already in the referrers list (duplicate entries SHOULD NOT be created).
> 5. Append a descriptor for the pushed manifest to the manifests in the referrers list. The value of the artifactType MUST be set to the artifactType value in the pushed manifest, if present. If the artifactType is empty or missing in a pushed image manifest, the value of artifactType MUST be set to the config descriptor mediaType value. All annotations from the pushed manifest MUST be copied to this descriptor.
> 6. Push the updated referrers list using the same referrers tag schema. The client MAY use conditional HTTP requests to prevent overwriting a referrers list that has changed since it was first pulled.

With this change, we correctly follow step 5.

Changes:
- Add ArtifactType field to v1.Manifest and v1.IndexManifest structs
- Update fetchManifest to prefer manifest artifactType, fall back to
  config.mediaType, and copy manifest annotations to the descriptor
- Apply the same artifactType logic in remote/index.go, remote/write.go,
  and partial/with.go