### PR TITLE
actions: attach Codecov token to coverage tests on main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,3 +22,5 @@ jobs:
       - run: go test -coverprofile=coverage.txt -covermode=atomic -race ./...
 
       - uses: codecov/codecov-action@v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
See https://github.com/google/go-containerregistry/actions/runs/24527556650/job/71701783007 under "Run codecov/codecov-action@v6.0.0" for an example error