### PR TITLE
remote: limit concurrent layer pulls

### DIFF
--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -40,8 +40,9 @@ const (
 
 // fetcher implements methods for reading from a registry.
 type fetcher struct {
-	target resource
-	client *http.Client
+	target  resource
+	client  *http.Client
+	limiter *pullLimiter
 }
 
 func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, error) {
@@ -68,8 +69,9 @@ func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, er
 		return nil, err
 	}
 	return &fetcher{
-		target: target,
-		client: &http.Client{Transport: tr},
+		target:  target,
+		client:  &http.Client{Transport: tr},
+		limiter: o.limiter,
 	}, nil
 }
 
@@ -257,18 +259,30 @@ func (f *fetcher) headManifest(ctx context.Context, ref name.Reference, acceptab
 
 func (f *fetcher) fetchBlob(ctx context.Context, size int64, h v1.Hash) (io.ReadCloser, error) {
 	u := f.url("blobs", h.String())
+	return f.fetchBlobURL(ctx, u, size, h)
+}
+
+func (f *fetcher) fetchBlobURL(ctx context.Context, u url.URL, size int64, h v1.Hash) (io.ReadCloser, error) {
+	release, err := f.limiter.acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
+		release()
 		return nil, err
 	}
 
 	resp, err := f.client.Do(req.WithContext(ctx))
 	if err != nil {
+		release()
 		return nil, redact.Error(err)
 	}
 
 	if err := transport.CheckError(resp, http.StatusOK); err != nil {
 		resp.Body.Close()
+		release()
 		return nil, err
 	}
 
@@ -279,11 +293,22 @@ func (f *fetcher) fetchBlob(ctx context.Context, size int64, h v1.Hash) (io.Read
 		if size == verify.SizeUnknown {
 			size = hsize
 		} else if hsize != size {
+			resp.Body.Close()
+			release()
 			return nil, fmt.Errorf("GET %s: Content-Length header %d does not match expected size %d", u.String(), hsize, size)
 		}
 	}
 
-	return verify.ReadCloser(resp.Body, size, h)
+	rc, err := verify.ReadCloser(resp.Body, size, h)
+	if err != nil {
+		resp.Body.Close()
+		release()
+		return nil, err
+	}
+	return &limitedReadCloser{
+		ReadCloser: rc,
+		release:    release,
+	}, nil
 }
 
 func (f *fetcher) headBlob(ctx context.Context, h v1.Hash) (*http.Response, error) {

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/http"
 	"net/url"
 	"sync"
 
@@ -27,7 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -201,24 +199,12 @@ func (rl *remoteImageLayer) Compressed() (io.ReadCloser, error) {
 	// TODO: Maybe we don't want to try pulling from the registry first?
 	var lastErr error
 	for _, u := range urls {
-		req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-		if err != nil {
-			return nil, err
-		}
-
-		resp, err := rl.ri.fetcher.Do(req.WithContext(ctx))
+		rc, err := rl.ri.fetcher.fetchBlobURL(ctx, u, d.Size, rl.digest)
 		if err != nil {
 			lastErr = err
 			continue
 		}
-
-		if err := transport.CheckError(resp, http.StatusOK); err != nil {
-			resp.Body.Close()
-			lastErr = err
-			continue
-		}
-
-		return verify.ReadCloser(resp.Body, d.Size, rl.digest)
+		return rc, nil
 	}
 
 	return nil, lastErr

--- a/pkg/v1/remote/limiter.go
+++ b/pkg/v1/remote/limiter.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+type pullLimiter struct {
+	tokens chan struct{}
+}
+
+func newPullLimiter(jobs int) *pullLimiter {
+	return &pullLimiter{
+		tokens: make(chan struct{}, jobs),
+	}
+}
+
+func (l *pullLimiter) acquire(ctx context.Context) (func(), error) {
+	if l == nil {
+		return func() {}, nil
+	}
+	select {
+	case l.tokens <- struct{}{}:
+		return func() { <-l.tokens }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+type limitedReadCloser struct {
+	io.ReadCloser
+	release func()
+	once    sync.Once
+}
+
+func (l *limitedReadCloser) Close() error {
+	err := l.ReadCloser.Close()
+	l.once.Do(l.release)
+	return err
+}

--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -45,6 +45,7 @@ type options struct {
 	retryBackoff                   Backoff
 	retryPredicate                 retry.Predicate
 	retryStatusCodes               []int
+	limiter                        *pullLimiter
 
 	// Only these options can overwrite Reuse()d options.
 	platform v1.Platform
@@ -142,6 +143,7 @@ func makeOptions(opts ...Option) (*options, error) {
 			return nil, err
 		}
 	}
+	o.limiter = newPullLimiter(o.jobs)
 
 	switch {
 	case o.auth != nil && o.keychain != nil:


### PR DESCRIPTION
`remote.WithJobs` controls remote operation parallelism, but lazy images returned by `remote.Get(...).Image()` did not carry that limit into later layer reads. Consumers such as `layout.ReplaceImage` could start one remote blob GET per layer at once.

Carry the configured job limit into remote-backed blob reads and hold a limiter token until each response body is closed.

Fixes #2140

Reproduced:

Added a local repro that pulled an image with 6 layers using `remote.WithJobs(2)`, then concurrently opened every layer's `Compressed()` stream. Before the fix, the test server observed 6 concurrent layer GETs. After the fix, the maximum observed concurrency was 2.

Tested:

`go test ./pkg/v1/remote`

`go test ./pkg/v1/layout ./pkg/v1/remote`