### PR TITLE
pkg/registry: reject corrupt disk blobs

### DIFF
--- a/pkg/registry/blobs_disk.go
+++ b/pkg/registry/blobs_disk.go
@@ -17,6 +17,7 @@ package registry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -35,13 +36,22 @@ func (m *diskHandler) blobHashPath(h v1.Hash) string {
 }
 
 func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
-	fi, err := os.Stat(m.blobHashPath(h))
+	f, err := os.Open(m.blobHashPath(h))
 	if errors.Is(err, os.ErrNotExist) {
 		return 0, errNotFound
 	} else if err != nil {
 		return 0, err
 	}
-	return fi.Size(), nil
+	defer f.Close()
+
+	got, size, err := v1.SHA256(f)
+	if err != nil {
+		return 0, err
+	}
+	if got != h {
+		return 0, fmt.Errorf("%w: blob %s has digest %s", errNotFound, h, got)
+	}
+	return size, nil
 }
 func (m *diskHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
 	return os.Open(m.blobHashPath(h))

--- a/pkg/registry/blobs_disk_test.go
+++ b/pkg/registry/blobs_disk_test.go
@@ -15,7 +15,9 @@
 package registry_test
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
@@ -81,4 +84,59 @@ func TestDiskPush(t *testing.T) {
 		}
 		t.Logf("Found %s", dig)
 	}
+}
+
+func TestDiskStatCorruptBlob(t *testing.T) {
+	dir := t.TempDir()
+	h := writeEmptyBlobAtDigest(t, dir)
+
+	bh := registry.NewDiskBlobHandler(dir)
+	bsh, ok := bh.(registry.BlobStatHandler)
+	if !ok {
+		t.Fatal("NewDiskBlobHandler() does not implement Stat")
+	}
+	if _, err := bsh.Stat(context.Background(), "foo/bar", h); err == nil {
+		t.Fatal("Stat() succeeded for corrupt blob, wanted error")
+	}
+}
+
+func TestDiskCorruptBlobReturnsBlobUnknown(t *testing.T) {
+	dir := t.TempDir()
+	h := writeEmptyBlobAtDigest(t, dir)
+
+	reg := registry.New(registry.WithBlobHandler(registry.NewDiskBlobHandler(dir)))
+	srv := httptest.NewServer(reg)
+	defer srv.Close()
+
+	for _, method := range []string{http.MethodHead, http.MethodGet} {
+		req, err := http.NewRequest(method, srv.URL+"/v2/foo/bar/blobs/"+h.String(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s corrupt blob status: got %d, want %d", method, resp.StatusCode, http.StatusNotFound)
+		}
+	}
+}
+
+func writeEmptyBlobAtDigest(t *testing.T, dir string) v1.Hash {
+	t.Helper()
+
+	h, _, err := v1.SHA256(strings.NewReader("blob contents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, h.Algorithm), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, h.Algorithm, h.Hex), nil, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	return h
 }


### PR DESCRIPTION
Disk-backed blob metadata was based on `os.Stat`, so a corrupt or zero-byte file left at a digest path could be reported as an existing blob and served with the wrong `Content-Length`.

Hash disk blob contents during `Stat` and treat digest mismatches as missing blobs so `HEAD` and `GET` return `BLOB_UNKNOWN` instead of serving corrupt data.

Fixes #2124

Tested:

go test ./pkg/registry -run 'TestDisk(Push|StatCorruptBlob|CorruptBlobReturnsBlobUnknown)$' -count=1 -v

go test ./pkg/registry