### PR TITLE
remote: verify schema1 digest pulls by body hash

### DIFF
--- a/pkg/v1/remote/descriptor_test.go
+++ b/pkg/v1/remote/descriptor_test.go
@@ -93,6 +93,79 @@ func TestGetSchema1(t *testing.T) {
 	}
 }
 
+func TestGetSchema1DigestUsesBodyHash(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifest := []byte("schema1 manifest body")
+	bodyDigest, _, err := v1.SHA256(strings.NewReader(string(manifest)))
+	if err != nil {
+		t.Fatalf("SHA256() = %v", err)
+	}
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, bodyDigest.String())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema1Signed))
+			w.Header().Set("Docker-Content-Digest", fakeDigest)
+			w.Write(manifest)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	digest := mustNewDigest(t, fmt.Sprintf("%s/%s@%s", u.Host, expectedRepo, bodyDigest.String()))
+	desc, err := Get(digest)
+	if err != nil {
+		t.Fatalf("Get(%s) = %v", digest, err)
+	}
+
+	if desc.Digest != bodyDigest {
+		t.Errorf("Descriptor.Digest = %q, want body digest %q", desc.Digest, bodyDigest)
+	}
+}
+
+func TestGetSchema1DigestRejectsHeaderOverride(t *testing.T) {
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/%s", expectedRepo, fakeDigest)
+	manifest := []byte("schema1 manifest body")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Header().Set("Content-Type", string(types.DockerManifestSchema1Signed))
+			w.Header().Set("Docker-Content-Digest", fakeDigest)
+			w.Write(manifest)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	digest := mustNewDigest(t, fmt.Sprintf("%s/%s@%s", u.Host, expectedRepo, fakeDigest))
+	if _, err := Get(digest); err == nil {
+		t.Fatalf("Get(%s): expected error, got nil", digest)
+	}
+}
+
 func TestGetImageAsIndex(t *testing.T) {
 	expectedRepo := "foo/bar"
 	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -149,18 +149,19 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 	}
 
 	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
-	contentDigest, err := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
-	if err == nil && mediaType == types.DockerManifestSchema1Signed {
-		// If we can parse the digest from the header, and it's a signed schema 1
-		// manifest, let's use that for the digest to appease older registries.
-		digest = contentDigest
-	}
+	contentDigest, contentDigestErr := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
 
-	// Validate the digest matches what we asked for, if pulling by digest.
+	// Validate the computed body digest for digest pulls. Older schema1 registries
+	// may report a header digest that does not match the response body, but digest
+	// references must still validate the returned content by body hash.
 	if dgst, ok := ref.(name.Digest); ok {
 		if digest.String() != dgst.DigestStr() {
 			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), ref)
 		}
+	} else if contentDigestErr == nil && mediaType == types.DockerManifestSchema1Signed {
+		// For tag pulls, preserve the historical schema1 header behavior to
+		// remain compatible with older registries.
+		digest = contentDigest
 	}
 
 	var artifactType string

--- a/pkg/v1/remote/write_test.go
+++ b/pkg/v1/remote/write_test.go
@@ -54,6 +54,14 @@ func mustNewTag(t *testing.T, s string) name.Tag {
 	return tag
 }
 
+func mustNewDigest(t *testing.T, s string) name.Digest {
+	digest, err := name.NewDigest(s, name.WeakValidation)
+	if err != nil {
+		t.Fatalf("NewDigest(%v) = %v", s, err)
+	}
+	return digest
+}
+
 func TestUrl(t *testing.T) {
 	tests := []struct {
 		tag  string


### PR DESCRIPTION
## summary

- validate schema1 digest pulls against the returned manifest body hash instead of trusting `Docker-Content-Digest`
- preserve the historical schema1 header-based digest behavior for tag pulls to avoid breaking older registries
- add regression coverage for both digest-pull validation and schema1 tag compatibility

## root cause

for schema1 signed manifests, `fetchManifest` computed the body digest and then replaced it with `Docker-Content-Digest` before checking digest references. that meant digest pulls could succeed based on the header value instead of the manifest bytes that were actually returned.

## testing

- `go test ./pkg/v1/remote`
