### PR TITLE
mutate: close layer readers during export

### DIFF
--- a/pkg/crane/export.go
+++ b/pkg/crane/export.go
@@ -44,6 +44,7 @@ func Export(img v1.Image, w io.Writer) error {
 			if err != nil {
 				return err
 			}
+			defer rc.Close()
 			_, err = io.Copy(w, rc)
 			return err
 		}

--- a/pkg/crane/export_test.go
+++ b/pkg/crane/export_test.go
@@ -16,8 +16,11 @@ package crane
 
 import (
 	"bytes"
+	"io"
+	"strings"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/static"
@@ -38,4 +41,70 @@ func TestExport(t *testing.T) {
 	if got := buf.Bytes(); !bytes.Equal(got, want) {
 		t.Errorf("got: %s\nwant: %s", got, want)
 	}
+}
+
+func TestExportClosesSingleLayerReader(t *testing.T) {
+	var closed bool
+	img := singleLayerImage{layer: closeTrackingLayer{closed: &closed}}
+
+	var buf bytes.Buffer
+	if err := Export(img, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "contents"; got != want {
+		t.Fatalf("Export() = %q, want %q", got, want)
+	}
+	if !closed {
+		t.Fatal("Export() did not close the layer reader")
+	}
+}
+
+type singleLayerImage struct {
+	v1.Image
+	layer v1.Layer
+}
+
+func (i singleLayerImage) Layers() ([]v1.Layer, error) {
+	return []v1.Layer{i.layer}, nil
+}
+
+type closeTrackingLayer struct {
+	closed *bool
+}
+
+func (l closeTrackingLayer) Digest() (v1.Hash, error) {
+	return v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("0", 64)}, nil
+}
+
+func (l closeTrackingLayer) DiffID() (v1.Hash, error) {
+	return v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("1", 64)}, nil
+}
+
+func (l closeTrackingLayer) Compressed() (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("contents")), nil
+}
+
+func (l closeTrackingLayer) MediaType() (types.MediaType, error) {
+	return types.MediaType("application/json"), nil
+}
+
+func (l closeTrackingLayer) Size() (int64, error) {
+	return int64(len("contents")), nil
+}
+
+func (l closeTrackingLayer) Uncompressed() (io.ReadCloser, error) {
+	return &closeTrackingReadCloser{
+		Reader: strings.NewReader("contents"),
+		closed: l.closed,
+	}, nil
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed *bool
+}
+
+func (rc *closeTrackingReadCloser) Close() error {
+	*rc.closed = true
+	return nil
 }

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -277,67 +277,74 @@ func extract(img v1.Image, w io.Writer) error {
 	// whiteout layers more efficient, since we can just keep track of the removed
 	// files as we see .wh. layers and ignore those in previous layers.
 	for i := len(layers) - 1; i >= 0; i-- {
-		layer := layers[i]
-		layerReader, err := layer.Uncompressed()
-		if err != nil {
-			return fmt.Errorf("reading layer contents: %w", err)
+		if err := extractLayer(tarWriter, fileMap, layers[i]); err != nil {
+			return err
 		}
-		defer layerReader.Close()
-		tarReader := tar.NewReader(layerReader)
-		for {
-			header, err := tarReader.Next()
-			if errors.Is(err, io.EOF) {
-				break
+	}
+	return nil
+}
+
+func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, layer v1.Layer) error {
+	layerReader, err := layer.Uncompressed()
+	if err != nil {
+		return fmt.Errorf("reading layer contents: %w", err)
+	}
+	defer layerReader.Close()
+
+	tarReader := tar.NewReader(layerReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		// Some tools prepend everything with "./", so if we don't Clean the
+		// name, we may have duplicate entries, which angers tar-split.
+		header.Name = filepath.Clean(header.Name)
+
+		// force PAX format to remove Name/Linkname length limit of 100 characters
+		// required by USTAR and to not depend on internal tar package guess which
+		// prefers USTAR over PAX
+		header.Format = tar.FormatPAX
+
+		basename := filepath.Base(header.Name)
+		dirname := filepath.Dir(header.Name)
+		tombstone := strings.HasPrefix(basename, whiteoutPrefix)
+		if tombstone {
+			basename = basename[len(whiteoutPrefix):]
+		}
+
+		// check if we have seen value before
+		// if we're checking a directory, don't filepath.Join names
+		var name string
+		if header.Typeflag == tar.TypeDir {
+			name = header.Name
+		} else {
+			name = filepath.Join(dirname, basename)
+		}
+
+		if _, ok := fileMap[name]; ok && !tombstone {
+			continue
+		}
+
+		// check for a whited out parent directory
+		if inWhiteoutDir(fileMap, name) {
+			continue
+		}
+
+		// mark file as handled. non-directory implicitly tombstones
+		// any entries with a matching (or child) name
+		fileMap[name] = tombstone || (header.Typeflag != tar.TypeDir)
+		if !tombstone {
+			if err := tarWriter.WriteHeader(header); err != nil {
+				return err
 			}
-			if err != nil {
-				return fmt.Errorf("reading tar: %w", err)
-			}
-
-			// Some tools prepend everything with "./", so if we don't Clean the
-			// name, we may have duplicate entries, which angers tar-split.
-			header.Name = filepath.Clean(header.Name)
-
-			// force PAX format to remove Name/Linkname length limit of 100 characters
-			// required by USTAR and to not depend on internal tar package guess which
-			// prefers USTAR over PAX
-			header.Format = tar.FormatPAX
-
-			basename := filepath.Base(header.Name)
-			dirname := filepath.Dir(header.Name)
-			tombstone := strings.HasPrefix(basename, whiteoutPrefix)
-			if tombstone {
-				basename = basename[len(whiteoutPrefix):]
-			}
-
-			// check if we have seen value before
-			// if we're checking a directory, don't filepath.Join names
-			var name string
-			if header.Typeflag == tar.TypeDir {
-				name = header.Name
-			} else {
-				name = filepath.Join(dirname, basename)
-			}
-
-			if _, ok := fileMap[name]; ok && !tombstone {
-				continue
-			}
-
-			// check for a whited out parent directory
-			if inWhiteoutDir(fileMap, name) {
-				continue
-			}
-
-			// mark file as handled. non-directory implicitly tombstones
-			// any entries with a matching (or child) name
-			fileMap[name] = tombstone || (header.Typeflag != tar.TypeDir)
-			if !tombstone {
-				if err := tarWriter.WriteHeader(header); err != nil {
+			if header.Size > 0 {
+				if _, err := io.CopyN(tarWriter, tarReader, header.Size); err != nil {
 					return err
-				}
-				if header.Size > 0 {
-					if _, err := io.CopyN(tarWriter, tarReader, header.Size); err != nil {
-						return err
-					}
 				}
 			}
 		}

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -104,6 +104,23 @@ func TestExtractOverwrittenFile(t *testing.T) {
 	}
 }
 
+func TestExtractClosesLayerBeforeOpeningNext(t *testing.T) {
+	tokens := make(chan struct{}, 4)
+	layers := make([]v1.Layer, cap(tokens)+1)
+	for i := range layers {
+		layers[i] = tokenLimitedLayer{tokens: tokens}
+	}
+
+	rc := mutate.Extract(tokenLimitedImage{layers: layers})
+	defer rc.Close()
+	if _, err := io.Copy(io.Discard, rc); err != nil {
+		t.Fatalf("mutate.Extract() = %v", err)
+	}
+	if got := len(tokens); got != 0 {
+		t.Fatalf("open layer readers after extraction: got %d, want 0", got)
+	}
+}
+
 // TestExtractError tests that if there are any errors encountered
 func TestExtractError(t *testing.T) {
 	rc := mutate.Extract(invalidImage{})
@@ -787,4 +804,44 @@ func (m mockLayer) Compressed() (io.ReadCloser, error) {
 }
 func (m mockLayer) Uncompressed() (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader("uncompressed")), nil
+}
+
+type tokenLimitedImage struct {
+	v1.Image
+	layers []v1.Layer
+}
+
+func (i tokenLimitedImage) Layers() ([]v1.Layer, error) {
+	return i.layers, nil
+}
+
+type tokenLimitedLayer struct {
+	mockLayer
+	tokens chan struct{}
+}
+
+func (l tokenLimitedLayer) Uncompressed() (io.ReadCloser, error) {
+	select {
+	case l.tokens <- struct{}{}:
+		return &tokenReleasingReadCloser{
+			Reader:  bytes.NewReader(nil),
+			release: func() { <-l.tokens },
+		}, nil
+	default:
+		return nil, errors.New("layer reader opened before previous readers were closed")
+	}
+}
+
+type tokenReleasingReadCloser struct {
+	io.Reader
+	release func()
+	closed  bool
+}
+
+func (rc *tokenReleasingReadCloser) Close() error {
+	if !rc.closed {
+		rc.closed = true
+		rc.release()
+	}
+	return nil
 }


### PR DESCRIPTION
### Summary

`crane export` normally ends up in `mutate.Extract`, which walks the image layers and reads each one with `Uncompressed()`.

The problem is that `mutate.Extract` was deferring each layer reader close until the whole extraction returned. That used to be mostly harmless, but after #2271 remote layer reads hold a pull slot until the response body is closed. So with enough layers, export can use up all the available pull slots and then block while trying to open the next layer.

While checking that path, I also noticed the single-layer export shortcut copied from `Uncompressed()` without closing the reader.

This change closes each layer reader as soon as that layer has been processed, and also closes the reader in the single-layer export path.

Fixes #2276

### Reproduced:

I added a local test image whose layer readers behave like the remote pull limiter: opening a reader takes one of four slots, and closing it gives the slot back. Before the fix, extracting five layers failed when the fifth reader opened before the earlier readers had been closed. After the fix, extraction completes and all slots are released.

### Tests added:

- `TestExtractClosesLayerBeforeOpeningNext`
- `TestExportClosesSingleLayerReader`

### Tested:

`go test ./pkg/v1/mutate`

`go test ./pkg/crane`

`go test ./pkg/v1/remote ./pkg/v1/mutate ./pkg/crane`

`./cmd/crane/rebase_test.sh`