### PR TITLE
test(mutate): add Extract round-trip test for filesystem object preservation

### DIFF
--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -143,6 +143,138 @@ func TestExtractPartialRead(t *testing.T) {
 	}
 }
 
+// TestExtractRoundTrip builds an image layer containing every common filesystem
+// object type (regular files, directories, symlinks, hard links, various
+// permission modes) and verifies that mutate.Extract preserves all entries.
+//
+// This prevents regressions like #2244 where a security fix inadvertently
+// dropped legitimate symlinks during extraction.
+func TestExtractRoundTrip(t *testing.T) {
+	// Build a tar layer with diverse filesystem objects.
+	type entry struct {
+		header *tar.Header
+		body   string // only for regular files
+	}
+	entries := []entry{
+		// Directories
+		{header: &tar.Header{Name: "app/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		{header: &tar.Header{Name: "app/bin/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		{header: &tar.Header{Name: "app/lib/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		{header: &tar.Header{Name: "app/node_modules/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		{header: &tar.Header{Name: "app/node_modules/.bin/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		{header: &tar.Header{Name: "restricted/", Typeflag: tar.TypeDir, Mode: 0o700}},
+
+		// Regular files with various permissions
+		{header: &tar.Header{Name: "app/main.js", Typeflag: tar.TypeReg, Mode: 0o644}, body: "console.log('hello')\n"},
+		{header: &tar.Header{Name: "app/bin/run.sh", Typeflag: tar.TypeReg, Mode: 0o755}, body: "#!/bin/sh\n\n"},
+		{header: &tar.Header{Name: "restricted/secret.key", Typeflag: tar.TypeReg, Mode: 0o600}, body: "secret\n"},
+		{header: &tar.Header{Name: "app/lib/utils.js", Typeflag: tar.TypeReg, Mode: 0o644}, body: "// ok\n"},
+
+		// Relative symlinks (the most common case, e.g. node_modules/.bin)
+		{header: &tar.Header{Name: "app/node_modules/.bin/acorn", Typeflag: tar.TypeSymlink, Linkname: "../acorn/bin/acorn"}},
+		{header: &tar.Header{Name: "app/node_modules/.bin/eslint", Typeflag: tar.TypeSymlink, Linkname: "../eslint/bin/eslint.js"}},
+
+		// Absolute symlink (pointing within the image)
+		{header: &tar.Header{Name: "app/link-to-main", Typeflag: tar.TypeSymlink, Linkname: "/app/main.js"}},
+
+		// Symlink to a directory
+		{header: &tar.Header{Name: "app/modules", Typeflag: tar.TypeSymlink, Linkname: "node_modules"}},
+
+		// Hard link
+		{header: &tar.Header{Name: "app/main-hardlink.js", Typeflag: tar.TypeLink, Linkname: "app/main.js"}},
+	}
+
+	// Write entries into a tar archive.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		if e.body != "" {
+			e.header.Size = int64(len(e.body))
+		}
+		if err := tw.WriteHeader(e.header); err != nil {
+			t.Fatalf("writing header for %s: %v", e.header.Name, err)
+		}
+		if e.body != "" {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("writing body for %s: %v", e.header.Name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+
+	// Build a single-layer image from the tar.
+	tarBytes := buf.Bytes()
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(tarBytes)), nil
+	})
+	if err != nil {
+		t.Fatalf("creating layer: %v", err)
+	}
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		t.Fatalf("appending layer: %v", err)
+	}
+
+	// Extract and collect all entries from the flattened output.
+	extracted := map[string]*tar.Header{}
+	extractedBodies := map[string]string{}
+	tr := tar.NewReader(mutate.Extract(img))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading extracted tar: %v", err)
+		}
+		extracted[hdr.Name] = hdr
+		if hdr.Typeflag == tar.TypeReg && hdr.Size > 0 {
+			var b bytes.Buffer
+			if _, err := io.Copy(&b, tr); err != nil {
+				t.Fatalf("reading body of %s: %v", hdr.Name, err)
+			}
+			extractedBodies[hdr.Name] = b.String()
+		}
+	}
+
+	// Verify every input entry is present in the output with correct metadata.
+	for _, e := range entries {
+		name := filepath.Clean(e.header.Name)
+		got, ok := extracted[name]
+		if !ok {
+			t.Errorf("entry %q not found in extracted output", name)
+			continue
+		}
+
+		if got.Typeflag != e.header.Typeflag {
+			t.Errorf("%s: typeflag = %d, want %d", name, got.Typeflag, e.header.Typeflag)
+		}
+
+		// Verify symlink and hard link targets are preserved.
+		if e.header.Typeflag == tar.TypeSymlink || e.header.Typeflag == tar.TypeLink {
+			if got.Linkname != e.header.Linkname {
+				t.Errorf("%s: linkname = %q, want %q", name, got.Linkname, e.header.Linkname)
+			}
+		}
+
+		// Verify file permissions.
+		if e.header.Typeflag == tar.TypeReg || e.header.Typeflag == tar.TypeDir {
+			if got.Mode != e.header.Mode {
+				t.Errorf("%s: mode = %o, want %o", name, got.Mode, e.header.Mode)
+			}
+		}
+
+		// Verify file contents.
+		if e.body != "" {
+			if extractedBodies[name] != e.body {
+				t.Errorf("%s: body = %q, want %q", name, extractedBodies[name], e.body)
+			}
+		}
+	}
+}
+
 // invalidImage is an image which returns an error when Layers() is called.
 type invalidImage struct {
 	v1.Image


### PR DESCRIPTION
## Summary

Adds `TestExtractRoundTrip`, a comprehensive round-trip test for `mutate.Extract` that verifies all common filesystem object types survive extraction.

The test programmatically builds a single-layer image containing:

| Object type | Examples |
|---|---|
| Regular files | Various permission modes (0644, 0755, 0600) |
| Directories | Standard and restricted modes |
| Relative symlinks | `node_modules/.bin/acorn -> ../acorn/bin/acorn` |
| Absolute symlinks | `/app/link-to-main -> /app/main.js` |
| Directory symlinks | `app/modules -> node_modules` |
| Hard links | `app/main-hardlink.js -> app/main.js` |

For each entry, the test verifies: type flag, link target, permission mode, and file contents.

## Motivation

Addresses #2252. The regression in #2244 (where #2227 inadvertently dropped all symlinks during extraction) would have been caught by this test. The existing Extract tests cover whiteouts and overwritten files but don't verify that symlinks, hard links, and permission modes are preserved.

## Testing

```
$ go test -run TestExtractRoundTrip -v ./pkg/v1/mutate/
=== RUN   TestExtractRoundTrip
--- PASS: TestExtractRoundTrip (0.00s)
PASS
```

Full `pkg/v1/mutate/` test suite passes.