### PR TITLE
transport: block unspecified IPs (0.0.0.0, ::) in validateRealmURL

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -130,7 +130,7 @@ func validateRealmURL(realm string, insecure bool) error {
 	// here; callers should apply network-level controls if needed.
 	host := u.Hostname()
 	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() || ip.IsUnspecified() {
 			return fmt.Errorf("realm host %q is a private or link-local address", host)
 		}
 	}

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -559,3 +559,35 @@ func TestInsufficientScope(t *testing.T) {
 		t.Error("didn't refresh insufficient scope")
 	}
 }
+
+func TestValidateRealmURLUnspecified(t *testing.T) {
+	// 0.0.0.0 and :: resolve to localhost on most OSes.
+	// They should be blocked like other private addresses.
+	tests := []struct {
+		realm   string
+		wantErr bool
+	}{
+		{"https://0.0.0.0/token", true},
+		{"https://0.0.0.0:8443/token", true},
+		{"https://[::]/token", true},
+		{"https://[::]:8443/token", true},
+		// existing checks still work
+		{"https://127.0.0.1/token", true},
+		{"https://[::1]/token", true},
+		{"https://10.0.0.1/token", true},
+		{"https://192.168.1.1/token", true},
+		{"https://169.254.169.254/token", true},
+		// public IPs are fine
+		{"https://8.8.8.8/token", false},
+		{"https://registry.example.com/token", false},
+	}
+	for _, tt := range tests {
+		err := validateRealmURL(tt.realm, false)
+		if tt.wantErr && err == nil {
+			t.Errorf("validateRealmURL(%q) should have been rejected", tt.realm)
+		}
+		if !tt.wantErr && err != nil {
+			t.Errorf("validateRealmURL(%q) unexpected error: %v", tt.realm, err)
+		}
+	}
+}


### PR DESCRIPTION
validateRealmURL checks IsLoopback, IsPrivate, IsLinkLocalUnicast,
and IsLinkLocalMulticast but not IsUnspecified. On Linux and macOS,
0.0.0.0 resolves to 127.0.0.1, so a malicious registry can redirect
auth requests to localhost by setting realm to https://0.0.0.0:PORT.

Add ip.IsUnspecified() to the existing check.

Fixes #2284