### PR TITLE
transport: block redirects from token server to private/link-local addresses (SSRF fix)

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -105,6 +105,24 @@ func fromChallenge(reg name.Registry, auth authn.Authenticator, t http.RoundTrip
 	}, nil
 }
 
+// realmRedirectCheck returns an http.Client.CheckRedirect function that applies
+// the same private-address and scheme restrictions as validateRealmURL to every
+// redirect hop during a token-fetch request. Without this guard a malicious
+// token server can issue an HTTP redirect to an internal service (e.g. the
+// cloud instance-metadata endpoint at 169.254.169.254), effectively bypassing
+// the initial validateRealmURL check and causing SSRF.
+func realmRedirectCheck(insecure bool) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if err := validateRealmURL(req.URL.String(), insecure); err != nil {
+			return fmt.Errorf("refusing token-server redirect to %q: %w", req.URL, err)
+		}
+		return nil
+	}
+}
+
 // validateRealmURL returns an error if the realm URL uses a disallowed scheme
 // or resolves to a private / link-local IP address. This prevents a crafted
 // WWW-Authenticate header from redirecting token fetches to internal services.
@@ -374,7 +392,7 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 		v.Set("access_type", "offline")
 	}
 
-	client := http.Client{Transport: bt.inner}
+	client := http.Client{Transport: bt.inner, CheckRedirect: realmRedirectCheck(bt.scheme == "http")}
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
@@ -411,7 +429,7 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 		auth:   bt.basic,
 		target: u.Host,
 	}
-	client := http.Client{Transport: b}
+	client := http.Client{Transport: b, CheckRedirect: realmRedirectCheck(bt.scheme == "http")}
 
 	v := u.Query()
 	bt.mx.RLock()

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -560,6 +560,44 @@ func TestInsufficientScope(t *testing.T) {
 	}
 }
 
+// TestTokenServerRedirectSSRF verifies that a malicious token server cannot
+// redirect token-fetch requests to private/loopback addresses, bypassing the
+// initial validateRealmURL check.
+func TestTokenServerRedirectSSRF(t *testing.T) {
+	// internalServer simulates an internal service that should never be reached.
+	internalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a response that looks like a valid token so the test can detect
+		// whether the client actually followed the redirect.
+		fmt.Fprintf(w, `{"token": "should-not-reach-this"}`)
+	}))
+	defer internalServer.Close()
+
+	// tokenServer issues a redirect to the internalServer on every request.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internalServer.URL+"/token", http.StatusFound)
+	}))
+	defer tokenServer.Close()
+
+	registry, err := name.NewRegistry("registry.example.com", name.WeakValidation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bt := &bearerTransport{
+		inner:    http.DefaultTransport,
+		basic:    &authn.Basic{Username: "foo", Password: "bar"},
+		registry: registry,
+		realm:    tokenServer.URL + "/token",
+		scopes:   []string{"repo:example/image:pull"},
+		service:  "registry.example.com",
+		scheme:   "http",
+	}
+
+	if err := bt.refresh(context.Background()); err == nil {
+		t.Error("refresh() should have been rejected when token server redirects to loopback address")
+	}
+}
+
 func TestValidateRealmURLUnspecified(t *testing.T) {
 	// 0.0.0.0 and :: resolve to localhost on most OSes.
 	// They should be blocked like other private addresses.


### PR DESCRIPTION
## Summary

`refreshOauth` and `refreshBasic` in `bearer.go` construct an `http.Client` without a `CheckRedirect` handler. Go's default redirect policy follows up to 10 hops unconditionally, forwarding the request to any URL returned by the server — including private and link-local addresses.

A malicious or compromised token server (or a registry that controls the `realm` parameter in `WWW-Authenticate`) can therefore bypass the existing `validateRealmURL` check by first responding with a valid-looking realm URL and then issuing an HTTP `302` redirect to an internal service:

```
WWW-Authenticate: Bearer realm="https://legit-token-server.example.com/token",...
→ GET https://legit-token-server.example.com/token   ← passes validateRealmURL
← HTTP/1.1 302 Found
   Location: http://169.254.169.254/latest/meta-data/iam/security-credentials/ROLE
→ GET http://169.254.169.254/...                      ← never checked
← {"Token": "AQo...", ...}                            ← AWS session token
→ stored as bt.bearer.RegistryToken
→ sent as Authorization: Bearer <AWS_SESSION_TOKEN> to attacker's registry
```

This is mechanically distinct from the DNS-based SSRF explicitly noted as out-of-scope in the `validateRealmURL` comment — redirect-based SSRF is fully preventable at the HTTP client layer.

## Fix

Add `realmRedirectCheck`, which applies the same scheme and private-IP restrictions as `validateRealmURL` to every redirect hop. Wire it as `CheckRedirect` on both `http.Client` instances used for token fetches.

## Test

`TestTokenServerRedirectSSRF` spins up a loopback token server that redirects to a second loopback "internal service" and confirms that `bt.refresh()` returns an error rather than following the redirect.

## Relation to prior work

PR #2243 added `validateRealmURL` to block direct private-IP realm values. This PR closes the remaining redirect-bypass path that #2243 left open.