### PR TITLE
Validate Windows layer paths before conversion

### DIFF
--- a/internal/windows/windows.go
+++ b/internal/windows/windows.go
@@ -71,11 +71,16 @@ func Windows(layer v1.Layer) (v1.Layer, error) {
 			return nil, fmt.Errorf("reading layer: %w", err)
 		}
 
-		if strings.HasPrefix(header.Name, "Files/") {
+		cleanName, err := cleanLayerPath(header.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.HasPrefix(cleanName, "Files/") {
 			return nil, fmt.Errorf("file path %q already suitable for Windows", header.Name)
 		}
 
-		header.Name = path.Join("Files", header.Name)
+		header.Name = path.Join("Files", cleanName)
 		header.Format = tar.FormatPAX
 
 		// TODO: this seems to make the file executable on Windows;
@@ -111,4 +116,12 @@ func Windows(layer v1.Layer) (v1.Layer, error) {
 	}
 
 	return layer, nil
+}
+
+func cleanLayerPath(name string) (string, error) {
+	cleanName := path.Clean(name)
+	if path.IsAbs(name) || cleanName == ".." || strings.HasPrefix(cleanName, "../") {
+		return "", fmt.Errorf("unsafe file path %q", name)
+	}
+	return cleanName, nil
 }

--- a/internal/windows/windows_test.go
+++ b/internal/windows/windows_test.go
@@ -16,12 +16,14 @@ package windows
 
 import (
 	"archive/tar"
+	"bytes"
 	"errors"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
@@ -78,4 +80,45 @@ func TestWindows(t *testing.T) {
 	if !sawFiles {
 		t.Errorf("didn't see Files/ directory")
 	}
+}
+
+func TestWindowsRejectsUnsafePaths(t *testing.T) {
+	for _, name := range []string{"../Hives/escaped.txt", "/Hives/escaped.txt"} {
+		t.Run(name, func(t *testing.T) {
+			layer := layerWithFile(t, name)
+			if _, err := Windows(layer); err == nil {
+				t.Fatalf("Windows accepted unsafe path %q", name)
+			}
+		})
+	}
+}
+
+func layerWithFile(t *testing.T, name string) v1.Layer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("test")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		Size:     int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return layer
 }


### PR DESCRIPTION
## What

Reject unsafe tar entry names before converting a regular layer into a Windows-compatible layer.

`Windows` currently prefixes each source entry with `Files/`, but it does so through `path.Join`, which also cleans parent directory components. This means an input name such as `../Hives/escaped.txt` is normalized outside the intended `Files/` prefix.

This change validates the source tar path before joining it under `Files/`:

- reject absolute paths
- reject paths that clean to `..`
- reject paths that clean under `../`
- keep existing behavior for layers already using the `Files/` prefix

## Why

The Windows conversion code creates `Files` and `Hives` top-level directories. Source filesystem entries should not be able to escape the `Files/` namespace during conversion.

## Tests

```sh
go test ./internal/windows -count=1
go test ./pkg/crane -count=1
PATH="$(go env GOPATH)/bin:$PATH" ./hack/presubmit.sh
```
