### PR TITLE
fix: limit HTTP response body reads to prevent OOM

### DIFF
--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -67,7 +67,7 @@ func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, 
 
 	var b []byte
 	if resp.StatusCode == http.StatusOK && resp.Header.Get("Content-Type") == string(types.OCIImageIndex) {
-		b, err = io.ReadAll(resp.Body)
+		b, err = io.ReadAll(io.LimitReader(resp.Body, manifestLimit))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -397,7 +397,7 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(resp.Body)
+	return io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 }
 
 // https://docs.docker.com/registry/spec/auth/token/
@@ -441,5 +441,5 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(resp.Body)
+	return io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 }

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -33,6 +33,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/internal/authchallenge"
 )
 
+// maxTokenBodySize limits bearer token response body reads to prevent OOM
+// when a token endpoint returns an unexpectedly large body.
+const maxTokenBodySize = 64 * 1024 // 64 KiB
+
 type Token struct {
 	Token        string `json:"token"`
 	AccessToken  string `json:"access_token,omitempty"`
@@ -397,7 +401,7 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	return io.ReadAll(io.LimitReader(resp.Body, maxTokenBodySize))
 }
 
 // https://docs.docker.com/registry/spec/auth/token/
@@ -441,5 +445,5 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	return io.ReadAll(io.LimitReader(resp.Body, maxTokenBodySize))
 }

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -113,6 +113,10 @@ type ErrorCode string
 
 // The set of error conditions a registry may return:
 // https://github.com/distribution/distribution/blob/aac2f6c8b7c5a6c60190848bab5cbeed2b5ba0a9/docs/spec/api.md#errors-2
+// maxErrorBodySize limits HTTP error response body reads to prevent OOM when
+// a registry returns an unexpectedly large error body.
+const maxErrorBodySize = 64 * 1024 // 64 KiB
+
 const (
 	BlobUnknownErrorCode         ErrorCode = "BLOB_UNKNOWN"
 	BlobUploadInvalidErrorCode   ErrorCode = "BLOB_UPLOAD_INVALID"
@@ -162,7 +166,7 @@ func CheckError(resp *http.Response, codes ...int) error {
 		}
 	}
 
-	b, err := io.ReadAll(resp.Body)
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 	if err != nil {
 		return err
 	}
@@ -186,7 +190,7 @@ func makeError(resp *http.Response, body []byte) *Error {
 }
 
 func retryError(resp *http.Response) error {
-	b, err := io.ReadAll(resp.Body)
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

Three paths read HTTP response bodies from a registry with no size limit, allowing a malicious or compromised registry to exhaust client memory:

**1. `pkg/v1/remote/referrers.go`**
```go
b, err = io.ReadAll(resp.Body)  // Referrers API — no size cap
```
The manifest fetch path caps at `manifestLimit` (100 MiB), but the Referrers fast path bypasses this entirely.

**2. `pkg/v1/remote/transport/error.go` — `CheckError` and `retryError`**
```go
b, err := io.ReadAll(resp.Body)  // fires on every non-2xx response
```
Triggered before any authentication succeeds (e.g., on the initial 401 challenge), so a malicious registry can exhaust memory without the client ever authenticating.

**3. `pkg/v1/remote/transport/bearer.go` — `refreshOauth` and `refreshBasic`**
```go
return io.ReadAll(resp.Body)  // token endpoint responses
```
A registry whose `WWW-Authenticate` `realm` points to a large-response server (or a compromised token endpoint) can cause OOM during every token refresh.

## Fix

- Referrers: apply the existing `manifestLimit` (100 MiB) constant.
- Error bodies and token responses: add `maxErrorBodySize` (64 KiB) — sufficient for any structured registry error JSON or token response.

All existing tests pass.