### PR TITLE
validate: skip non-layer layers

### DIFF
--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -119,6 +119,12 @@ func validateLayers(img v1.Image, opt ...Option) error {
 	udiffids := []v1.Hash{}
 	sizes := []int64{}
 	for i, layer := range layers {
+		if mt, err := layer.MediaType(); err != nil {
+			return fmt.Errorf("getting mediaType[%d]: %w", i, err)
+		} else if !mt.IsLayer() {
+			continue
+		}
+
 		cl, err := computeLayer(layer)
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			// Errored while reading tar content of layer because a header or
@@ -153,6 +159,14 @@ func validateLayers(img v1.Image, opt ...Option) error {
 
 	errs := []string{}
 	for i, layer := range layers {
+		mediaType, err := layer.MediaType()
+		if err != nil {
+			return err
+		}
+		if !mediaType.IsLayer() {
+			continue
+		}
+
 		digest, err := layer.Digest()
 		if err != nil {
 			return err
@@ -162,10 +176,6 @@ func validateLayers(img v1.Image, opt ...Option) error {
 			return err
 		}
 		size, err := layer.Size()
-		if err != nil {
-			return err
-		}
-		mediaType, err := layer.MediaType()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Docker Official Images like busybox and ubuntu now include "layers" in image manifests that are not layers, but are instead in-toto attestations about the layers. This confuses 'crane validate', which expected layers to be gzipped tarballs.

```
$ crane validate --remote=busybox
FAIL: busybox: validating children: failed to validate image Manifests[1](sha256:85018c50e23d1abd4dddbcfd55c5b7ee6516e956376e882eaa1b6009fbb2cc9b): validating layers: gzip: invalid header
failed to validate image Manifests[3](sha256:746ece13b4b267510484033c6b612a64e04fc32345321a159148b3894f6c79ef): validating layers: gzip: invalid header
failed to validate image Manifests[6](sha256:9e3e867b9f5db234dd756639e86d932c3c20f9d73610f80827d51ea73ddd708f): validating layers: gzip: invalid header
...
```

This change skips validation of layers that are not a layer media type.

With this change:

    $ go run ./cmd/crane validate --remote=busybox
    PASS: busybox