### PR TITLE
transport: retry HTTP 429 (Too Many Requests)

### DIFF
--- a/pkg/v1/remote/options.go
+++ b/pkg/v1/remote/options.go
@@ -93,6 +93,7 @@ var fastBackoff = Backoff{
 
 var defaultRetryStatusCodes = []int{
 	http.StatusRequestTimeout,
+	http.StatusTooManyRequests, // 429: OCI distribution-spec rate limit; TooManyRequestsErrorCode is already classified temporary in transport/error.go
 	http.StatusInternalServerError,
 	http.StatusBadGateway,
 	http.StatusServiceUnavailable,

--- a/pkg/v1/remote/options_test.go
+++ b/pkg/v1/remote/options_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestDefaultRetryStatusCodes_Includes429 pins HTTP 429 (Too Many
+// Requests) in the default retry status code list. The retry transport
+// short-circuits on this list before consulting Temporary(), so 429 has
+// to live here even though TooManyRequestsErrorCode is already classified
+// temporary in transport/error.go. If a future refactor drops 429 this
+// test fails loudly before the regression ships.
+func TestDefaultRetryStatusCodes_Includes429(t *testing.T) {
+	for _, c := range defaultRetryStatusCodes {
+		if c == http.StatusTooManyRequests {
+			return
+		}
+	}
+	t.Fatal("defaultRetryStatusCodes should include http.StatusTooManyRequests so registries returning 429 are retried by the default transport")
+}

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -151,6 +151,7 @@ var temporaryErrorCodes = map[ErrorCode]struct{}{
 
 var temporaryStatusCodes = map[int]struct{}{
 	http.StatusRequestTimeout:      {},
+	http.StatusTooManyRequests:     {}, // matches TooManyRequestsErrorCode in temporaryErrorCodes
 	http.StatusInternalServerError: {},
 	http.StatusBadGateway:          {},
 	http.StatusServiceUnavailable:  {},

--- a/pkg/v1/remote/transport/retry_test.go
+++ b/pkg/v1/remote/transport/retry_test.go
@@ -142,6 +142,57 @@ func TestRetryDefaults(t *testing.T) {
 	}
 }
 
+// TestRetryTransport_TooManyRequests covers two invariants that consumers
+// (including pkg/gcrane/copy.go's outer retry loop) depend on once 429 is
+// in the default retry list:
+//
+//  1. A 429 response is wrapped into a temporary *Error and retried up to
+//     the configured Steps.
+//  2. After retries exhaust, the *Error surfaced to the caller still has
+//     StatusCode == 429 so callers like gcrane's hasStatusCode helper can
+//     route their own application-level backoff (GCRBackoff) on top.
+func TestRetryTransport_TooManyRequests(t *testing.T) {
+	mt := mockTransport{
+		resps: []*http.Response{
+			resp(http.StatusTooManyRequests),
+			resp(http.StatusTooManyRequests),
+			resp(http.StatusTooManyRequests),
+		},
+	}
+
+	tr := NewRetry(&mt,
+		WithRetryBackoff(retry.Backoff{Steps: 3}),
+		WithRetryPredicate(retry.IsTemporary),
+		WithRetryStatusCodes(http.StatusTooManyRequests),
+	)
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ := tr.RoundTrip(req)
+
+	if mt.count != 3 {
+		t.Errorf("expected 3 attempts (1 + 2 retries), got %d", mt.count)
+	}
+	if out == nil || out.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("final response should still surface 429 status; got %v", out)
+	}
+}
+
+// TestTemporaryStatusCodes_Includes429 keeps temporaryStatusCodes (the
+// raw-status fallback path) in sync with temporaryErrorCodes (the
+// parsed-body path), which already contains TooManyRequestsErrorCode.
+// A registry returning 429 with no structured body should still be
+// classified temporary so downstream consumers retrying on
+// transport.Error.Temporary() behave consistently with consumers that
+// retry on a TOOMANYREQUESTS error code in the body.
+func TestTemporaryStatusCodes_Includes429(t *testing.T) {
+	if _, ok := temporaryStatusCodes[http.StatusTooManyRequests]; !ok {
+		t.Fatal("temporaryStatusCodes should contain http.StatusTooManyRequests for parity with temporaryErrorCodes[TooManyRequestsErrorCode]")
+	}
+}
+
 func TestTimeoutContext(t *testing.T) {
 	tr := NewRetry(http.DefaultTransport)
 


### PR DESCRIPTION
## Summary

Fixes #2111.

As filed by @knqyf263, the retry transport never retries HTTP 429 responses even though `TooManyRequestsErrorCode` is already classified temporary in [`pkg/v1/remote/transport/error.go`](pkg/v1/remote/transport/error.go). The retry transport short-circuits on its `codes` list before consulting `Temporary()`, and since 429 isn't in `defaultRetryStatusCodes`, the conversion to a temporary `*transport.Error` never happens and `retry.IsTemporary` never gets called.

The fix is symmetric across the two parallel "is this transient" classifications:

| Where | Before | After |
|---|---|---|
| `defaultRetryStatusCodes` in `pkg/v1/remote/options.go` | 408, 500, 502, 503, 504, 499, 522 | adds `http.StatusTooManyRequests` |
| `temporaryStatusCodes` in `pkg/v1/remote/transport/error.go` | 408, 500, 502, 503, 504 | adds `http.StatusTooManyRequests` for parity with `temporaryErrorCodes[TooManyRequestsErrorCode]` |

429 is now retried by the default transport (`Duration: 1s, Factor: 3, Steps: 3`, ~1.3s total).

## Interaction with `pkg/gcrane/copy.go`

`gcrane`'s copy path has its own outer retry loop that explicitly handles 429:

```go
b := retry.IsTemporary(err) || hasStatusCode(err, http.StatusTooManyRequests) || isServerError(err)
```

After this change the exhausted `*transport.Error` still carries `StatusCode == 429`, so `hasStatusCode` keeps matching and `GCRBackoff` continues to drive longer-term retry at the copy-operation layer. The two layers compose cleanly:

- transport-level: ~1.3s per request, handles transient 429 spikes
- gcrane-level: ~6s → 1min → 10min per copy, handles longer throttling windows

A test asserts the final response still surfaces with `StatusCode == 429`, so this composition is verified.

## Out of scope

Honoring the `Retry-After` response header. The retry backoff is currently static — honoring a server-dictated delay would need plumbing through `internal/retry/wait`. Worth a follow-up; not included here to keep the change focused on the reported bug.

## Test plan

- [x] `TestRetryTransport_TooManyRequests` in [`pkg/v1/remote/transport/retry_test.go`](pkg/v1/remote/transport/retry_test.go): three 429s through the transport, asserts all three attempts made and the final response surfaces with `StatusCode == 429`.
- [x] `TestTemporaryStatusCodes_Includes429` in the same file: pins 429 into the `temporaryStatusCodes` map so the raw-status fallback stays in sync with `temporaryErrorCodes[TooManyRequestsErrorCode]`.
- [x] `TestDefaultRetryStatusCodes_Includes429` in new [`pkg/v1/remote/options_test.go`](pkg/v1/remote/options_test.go): pins 429 into the default list itself.
- [x] `go test ./... -count=1` full suite passes locally.
- [x] `gofmt`, `goimports`, `golangci-lint v2.11` clean.
- [x] `woke` and US-locale `misspell` clean on the diff.