### PR TITLE
transport: allow bearer realm at same host:port as registry

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -90,7 +90,7 @@ func fromChallenge(reg name.Registry, auth authn.Authenticator, t http.RoundTrip
 	// registry can supply a realm pointing at an internal service or cloud
 	// metadata endpoint (e.g. 169.254.169.254), causing SSRF when the client
 	// subsequently fetches a token.
-	if err := validateRealmURL(realm, pr.Insecure); err != nil {
+	if err := validateRealmURL(realm, reg.RegistryStr(), pr.Insecure); err != nil {
 		return nil, fmt.Errorf("invalid realm in www-authenticate: %w", err)
 	}
 	service := pr.Parameters["service"]
@@ -111,12 +111,12 @@ func fromChallenge(reg name.Registry, auth authn.Authenticator, t http.RoundTrip
 
 // realmRedirectCheck mimics the default http.Client redirect policy but also
 // validates each redirect URL with validateRealmURL.
-func realmRedirectCheck(insecure bool) func(*http.Request, []*http.Request) error {
+func realmRedirectCheck(registryHost string, insecure bool) func(*http.Request, []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return fmt.Errorf("stopped after 10 redirects")
 		}
-		if err := validateRealmURL(req.URL.String(), insecure); err != nil {
+		if err := validateRealmURL(req.URL.String(), registryHost, insecure); err != nil {
 			return fmt.Errorf("refusing token-server redirect to %q: %w", req.URL, err)
 		}
 		return nil
@@ -124,9 +124,9 @@ func realmRedirectCheck(insecure bool) func(*http.Request, []*http.Request) erro
 }
 
 // validateRealmURL returns an error if the realm URL uses a disallowed scheme
-// or resolves to a private / link-local IP address. This prevents a crafted
-// WWW-Authenticate header from redirecting token fetches to internal services.
-func validateRealmURL(realm string, insecure bool) error {
+// or resolves to a private / link-local IP address. Realm URLs matching the
+// registry host:port are always allowed. See #2258.
+func validateRealmURL(realm, registryHost string, insecure bool) error {
 	u, err := url.Parse(realm)
 	if err != nil {
 		return fmt.Errorf("parsing realm %q: %w", realm, err)
@@ -140,6 +140,10 @@ func validateRealmURL(realm string, insecure bool) error {
 		}
 	default:
 		return fmt.Errorf("realm scheme %q not allowed; must be https (or http for insecure registries)", u.Scheme)
+	}
+	// Always allow realms matching the registry host:port.
+	if registryHost != "" && u.Host == registryHost {
+		return nil
 	}
 	// Reject IP literals that resolve to private or link-local ranges.
 	// This blocks direct references to RFC 1918 addresses, loopback, and
@@ -393,7 +397,7 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 	}
 
 	allowInsecure := bt.scheme == "http"
-	client := http.Client{Transport: bt.inner, CheckRedirect: realmRedirectCheck(allowInsecure)}
+	client := http.Client{Transport: bt.inner, CheckRedirect: realmRedirectCheck(bt.registry.RegistryStr(), allowInsecure)}
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
@@ -431,7 +435,7 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 		target: u.Host,
 	}
 	allowInsecure := bt.scheme == "http"
-	client := http.Client{Transport: b, CheckRedirect: realmRedirectCheck(allowInsecure)}
+	client := http.Client{Transport: b, CheckRedirect: realmRedirectCheck(bt.registry.RegistryStr(), allowInsecure)}
 
 	v := u.Query()
 	bt.mx.RLock()

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -618,12 +618,82 @@ func TestValidateRealmURLUnspecified(t *testing.T) {
 		{"https://registry.example.com/token", false},
 	}
 	for _, tt := range tests {
-		err := validateRealmURL(tt.realm, false)
+		err := validateRealmURL(tt.realm, "", false)
 		if tt.wantErr && err == nil {
 			t.Errorf("validateRealmURL(%q) should have been rejected", tt.realm)
 		}
 		if !tt.wantErr && err != nil {
 			t.Errorf("validateRealmURL(%q) unexpected error: %v", tt.realm, err)
 		}
+	}
+}
+
+// TestValidateRealmURLSameHost verifies the same-host exception: a realm URL
+// pointing at the same host the user is already talking to is allowed even
+// when that host is private/loopback/link-local. See
+// https://github.com/google/go-containerregistry/issues/2258.
+func TestValidateRealmURLSameHost(t *testing.T) {
+	tests := []struct {
+		name         string
+		realm        string
+		registryHost string
+		insecure     bool
+		wantErr      bool
+	}{
+		{
+			name:         "same loopback host:port allowed",
+			realm:        "http://127.0.0.1:5000/auth",
+			registryHost: "127.0.0.1:5000",
+			insecure:     true,
+		},
+		{
+			name:         "same loopback host but different port still blocked",
+			realm:        "http://127.0.0.1:8080/auth",
+			registryHost: "127.0.0.1:5000",
+			insecure:     true,
+			wantErr:      true,
+		},
+		{
+			name:         "same private host (no port) allowed",
+			realm:        "https://10.0.0.1/auth",
+			registryHost: "10.0.0.1",
+		},
+		{
+			name:         "same IPv6 loopback host:port allowed",
+			realm:        "http://[::1]:5000/auth",
+			registryHost: "[::1]:5000",
+			insecure:     true,
+		},
+		{
+			name:         "cross-host loopback redirect still blocked",
+			realm:        "http://127.0.0.1:5000/auth",
+			registryHost: "registry.example.com",
+			insecure:     true,
+			wantErr:      true,
+		},
+		{
+			name:         "cross-host metadata redirect still blocked",
+			realm:        "https://169.254.169.254/auth",
+			registryHost: "registry.example.com",
+			wantErr:      true,
+		},
+		{
+			name:         "scheme check still applies on same host",
+			realm:        "http://127.0.0.1:5000/auth",
+			registryHost: "127.0.0.1:5000",
+			insecure:     false,
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRealmURL(tt.realm, tt.registryHost, tt.insecure)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateRealmURL(%q, %q) should have returned an error", tt.realm, tt.registryHost)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateRealmURL(%q, %q) unexpected error: %v", tt.realm, tt.registryHost, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2258.

The realm-URL validation introduced in #2243 rejects realms whose host resolves to a private, loopback, or link-local IP. This is the right default for the cross-host SSRF case (a malicious registry pointing the token endpoint at `169.254.169.254` or at a sister internal service), but it breaks legitimate setups where a user explicitly targets a private/loopback registry that returns a same-host token endpoint — e.g. test suites running an authenticated registry on `127.0.0.1`, or on-prem deployments that colocate registry and token server.

This PR adds the same-host:port exception agreed in the issue thread (cc @evilgensec, @Subserial): if the realm URL host:port equals the registry host:port the user is already talking to, the private/link-local check is skipped. The realm is by definition not crossing a trust boundary the user did not already trust by passing the reference.

The match is strict — host **and** port — so that the "different port on the same loopback host" case (e.g. a realm pointed at a local database or metadata-service port that happens to live alongside the registry) remains blocked.

This mirrors the same-host exception pattern already used by the blob upload Location-header check in [`pkg/v1/remote/write.go`](pkg/v1/remote/write.go).

## Changes

| Where | Change |
|---|---|
| `validateRealmURL` | Add `registryHost` parameter; return `nil` early when `u.Host == registryHost`. Scheme check still applies. |
| `realmRedirectCheck` | Threads `registryHost` through to `validateRealmURL` so redirects honor the same exception. |
| `fromChallenge` callsite | Passes `reg.RegistryStr()`. |
| `refreshOauth` / `refreshBasic` callsites | Pass `bt.registry.RegistryStr()`. |
| `TestValidateRealmURLUnspecified` | Updated for new signature (empty `registryHost` preserves prior behavior). |
| `TestValidateRealmURLSameHost` (new) | Covers: same host:port allowed (loopback, private, IPv6 loopback); same host **different** port still blocked; cross-host loopback/metadata still blocked; scheme check still applies. |

`pkg/v1/remote/...` tests all pass locally; `go vet ./pkg/v1/remote/transport/...` clean.

## Out of scope

- Adding `localhost` (DNS) to the private blocklist, as suggested by @evilgensec in the issue. That would be a separate change to the threat-model surface and worth its own PR.
- Honoring `Retry-After` on transport-level retries (separate follow-up to #2301).

## Test plan

- [x] `TestValidateRealmURLSameHost` — table-driven, 7 cases
- [x] `TestValidateRealmURLUnspecified` — still passes with new signature
- [x] `TestTokenServerRedirectSSRF` — still rejects cross-host redirects after the closure signature change
- [x] Full `go test ./pkg/v1/remote/...` green

