### PR TITLE
tarball: return error instead of panicking on missing rootfs.diff_ids

### DIFF
--- a/pkg/v1/tarball/image.go
+++ b/pkg/v1/tarball/image.go
@@ -374,6 +374,9 @@ func (c *compressedImage) Manifest() (*v1.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
+		if i >= len(cfg.RootFS.DiffIDs) {
+			return nil, fmt.Errorf("tarball manifest references %d layer(s) but config has %d rootfs.diff_ids; the config may not describe a runnable image (for example, a buildkit cacheconfig)", len(c.imgDescriptor.Layers), len(cfg.RootFS.DiffIDs))
+		}
 		diffid := cfg.RootFS.DiffIDs[i]
 		if d, ok := c.imgDescriptor.LayerSources[diffid]; ok {
 			// If it's a foreign layer, just append the descriptor so we can avoid

--- a/pkg/v1/tarball/image_test.go
+++ b/pkg/v1/tarball/image_test.go
@@ -17,6 +17,7 @@ package tarball
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"io"
 	"strings"
 	"testing"
@@ -183,5 +184,60 @@ func TestLoadManifest(t *testing.T) {
 	}
 	if len(manifest) == 0 {
 		t.Fatalf("get nothing")
+	}
+}
+
+// TestManifestEmptyDiffIDs verifies Manifest() returns an error instead of
+// panicking when the config has no rootfs.diff_ids. See #2192.
+func TestManifestEmptyDiffIDs(t *testing.T) {
+	configBytes := []byte(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}`)
+	// Layer payload must be gzip-detectable so Image() routes to compressedImage,
+	// the path #2192 panicked on.
+	var lb bytes.Buffer
+	gw := gzip.NewWriter(&lb)
+	if _, err := gw.Write([]byte("not-really-a-layer")); err != nil {
+		t.Fatalf("gzip Write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	layerBytes := lb.Bytes()
+	manifestBytes := []byte(`[{"Config":"config.json","RepoTags":["foo:latest"],"Layers":["layer.tar.gz"]}]`)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range []struct {
+		name string
+		data []byte
+	}{
+		{"config.json", configBytes},
+		{"layer.tar.gz", layerBytes},
+		{"manifest.json", manifestBytes},
+	} {
+		if err := tw.WriteHeader(&tar.Header{Name: e.name, Mode: 0644, Size: int64(len(e.data))}); err != nil {
+			t.Fatalf("WriteHeader(%q): %v", e.name, err)
+		}
+		if _, err := tw.Write(e.data); err != nil {
+			t.Fatalf("Write(%q): %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+
+	tarBytes := buf.Bytes()
+	img, err := Image(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(tarBytes)), nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("Image(): %v", err)
+	}
+
+	_, err = img.Manifest()
+	if err == nil {
+		t.Fatal("img.Manifest(): expected error for config with empty diff_ids, got nil")
+	}
+	if !strings.Contains(err.Error(), "diff_ids") {
+		t.Errorf("img.Manifest(): expected error mentioning diff_ids, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2192.

`compressedImage.Manifest()` indexed `cfg.RootFS.DiffIDs[i]` inside the layer loop without checking the slice length. When the embedded config has fewer `diff_ids` than the tarball manifest has layers, the index goes out of range and the process panics. The canonical case reported in #2192 is a buildkit cacheconfig image (`application/vnd.buildkit.cacheconfig.v0`) loaded via `tarball.ImageFromPath` and then walked with `Layers()`.

Stack from the report:

```
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
github.com/google/go-containerregistry/pkg/v1/tarball.(*compressedImage).Manifest(...)
    pkg/v1/tarball/image.go:368
```

## Fix

Add a length check before the index and return a descriptive error. Callers (e.g. `partial.FSLayers`, `Validate`, user code) then surface the failure cleanly instead of crashing.

```go
if i >= len(cfg.RootFS.DiffIDs) {
    return nil, fmt.Errorf("tarball manifest references %d layer(s) but config has %d rootfs.diff_ids; ...", ...)
}
```

This intentionally does not try to *support* cacheconfig as an image, only to fail safely. Supporting non-image config media types is a separate design discussion.

## Test plan

- New `TestManifestEmptyDiffIDs` in `pkg/v1/tarball/image_test.go` builds an in-memory docker-save tarball whose config has `rootfs.diff_ids: []` and a single (gzip-compressed) layer, then asserts `Manifest()` returns a descriptive error rather than panicking.
- `go test ./pkg/v1/tarball/... -count=1` — all existing tests still pass.
- `go vet ./pkg/v1/tarball/...` — clean.