### PR TITLE
gcrane: honor --platform flag in copy

### DIFF
--- a/cmd/gcrane/cmd/copy.go
+++ b/cmd/gcrane/cmd/copy.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/gcrane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -33,10 +34,22 @@ func NewCmdCopy() *cobra.Command {
 		RunE: func(cc *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
 			ctx := cc.Context()
-			if recursive {
-				return gcrane.CopyRepository(ctx, src, dst, gcrane.WithJobs(jobs), gcrane.WithUserAgent(userAgent()), gcrane.WithContext(ctx))
+			opts := []gcrane.Option{
+				gcrane.WithUserAgent(userAgent()),
+				gcrane.WithContext(ctx),
 			}
-			return gcrane.Copy(src, dst, gcrane.WithUserAgent(userAgent()), gcrane.WithContext(ctx))
+			platform, err := rootPlatform(cc)
+			if err != nil {
+				return err
+			}
+			if platform != nil {
+				opts = append(opts, gcrane.WithPlatform(platform))
+			}
+			if recursive {
+				opts = append(opts, gcrane.WithJobs(jobs))
+				return gcrane.CopyRepository(ctx, src, dst, opts...)
+			}
+			return gcrane.Copy(src, dst, opts...)
 		},
 	}
 
@@ -44,4 +57,18 @@ func NewCmdCopy() *cobra.Command {
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", runtime.GOMAXPROCS(0), "The maximum number of concurrent copies")
 
 	return cmd
+}
+
+// rootPlatform reads the persistent --platform flag inherited from the crane
+// root command. "all" and the empty string both mean "no platform filter".
+func rootPlatform(cmd *cobra.Command) (*v1.Platform, error) {
+	f := cmd.Root().PersistentFlags().Lookup("platform")
+	if f == nil {
+		return nil, nil
+	}
+	s := f.Value.String()
+	if s == "" || s == "all" {
+		return nil, nil
+	}
+	return v1.ParsePlatform(s)
 }

--- a/pkg/gcrane/copy_test.go
+++ b/pkg/gcrane/copy_test.go
@@ -34,7 +34,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -196,6 +199,75 @@ func TestCopy(t *testing.T) {
 
 	if err := CopyRepository(context.Background(), src, dst); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestCopyWithPlatform verifies that Copy with WithPlatform resolves the
+// multi-platform source index to the single requested manifest at the dst.
+// Regression test for #2059.
+func TestCopyWithPlatform(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := path.Join(u.Host, "test/gcrane") + ":multi"
+	dst := path.Join(u.Host, "test/gcrane/copy") + ":amd64"
+
+	amdImg, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	armImg, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: amdImg,
+			Descriptor: v1.Descriptor{
+				Platform: &v1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: armImg,
+			Descriptor: v1.Descriptor{
+				Platform: &v1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+	)
+
+	srcRef, err := name.ParseReference(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(srcRef, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Copy(src, dst, WithPlatform(&v1.Platform{OS: "linux", Architecture: "amd64"})); err != nil {
+		t.Fatal(err)
+	}
+
+	dstRef, err := name.ParseReference(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc, err := remote.Get(dstRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desc.MediaType.IsIndex() {
+		t.Fatalf("dst is an index (%s); expected a single-platform manifest", desc.MediaType)
+	}
+	amdDigest, err := amdImg.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desc.Digest != amdDigest {
+		t.Errorf("dst digest = %s, want %s (amd64 manifest)", desc.Digest, amdDigest)
 	}
 }
 

--- a/pkg/gcrane/options.go
+++ b/pkg/gcrane/options.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
@@ -91,6 +92,14 @@ func WithContext(ctx context.Context) Option {
 		o.remote = append(o.remote, remote.WithContext(ctx))
 		o.google = append(o.google, google.WithContext(ctx))
 		o.crane = append(o.crane, crane.WithContext(ctx))
+	}
+}
+
+// WithPlatform is a functional option for selecting a single platform from
+// a multi-platform image. A nil platform copies the index unchanged.
+func WithPlatform(platform *v1.Platform) Option {
+	return func(o *options) {
+		o.crane = append(o.crane, crane.WithPlatform(platform))
 	}
 }
 


### PR DESCRIPTION
Fixes #2059

## Summary
- `gcrane cp --platform linux/amd64 src dst` previously ignored `--platform` and copied the entire multi-arch index. `crane cp` already honored it.
- Thread the persistent root `--platform` flag through `gcrane.Copy` / `gcrane.CopyRepository` via a new `gcrane.WithPlatform` option.

## Test plan
- [x] New `TestCopyWithPlatform` builds a multi-arch index, runs `Copy` with `WithPlatform(linux/amd64)`, asserts dst is a single-platform manifest with the expected digest.
- [x] `go test ./pkg/gcrane/... ./cmd/gcrane/... ./cmd/crane/...` passes.
- [x] `go vet ./...` clean.