### PR TITLE
tarball: close layer readers during Write

### DIFF
--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -191,16 +191,7 @@ func writeImagesToTar(imageToTags map[v1.Image][]string, m []byte, size int64, w
 			}
 			seenLayerDigests[hex] = struct{}{}
 
-			r, err := l.Compressed()
-			if err != nil {
-				return sendProgressWriterReturn(pw, err)
-			}
-			blobSize, err := l.Size()
-			if err != nil {
-				return sendProgressWriterReturn(pw, err)
-			}
-
-			if err := writeTarEntry(tf, layerFiles[i], r, blobSize); err != nil {
+			if err := writeLayer(tf, layerFiles[i], l); err != nil {
 				return sendProgressWriterReturn(pw, err)
 			}
 		}
@@ -366,6 +357,24 @@ func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]stri
 }
 
 // writeTarEntry writes a file to the provided writer with a corresponding tar header
+// writeLayer streams a layer's compressed blob into the tar writer at name,
+// ensuring the layer reader is closed as soon as it has been written. Closing
+// the reader releases any pull-limiter slot held by remote-backed layers
+// (see remote.WithJobs / pkg/v1/remote.limiter), so leaving readers open here
+// could deadlock the write loop after defaultJobs layers.
+func writeLayer(tf *tar.Writer, name string, l v1.Layer) error {
+	r, err := l.Compressed()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	blobSize, err := l.Size()
+	if err != nil {
+		return err
+	}
+	return writeTarEntry(tf, name, r, blobSize)
+}
+
 func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 	hdr := &tar.Header{
 		Mode:     0644,

--- a/pkg/v1/tarball/write.go
+++ b/pkg/v1/tarball/write.go
@@ -357,24 +357,6 @@ func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]stri
 }
 
 // writeTarEntry writes a file to the provided writer with a corresponding tar header
-// writeLayer streams a layer's compressed blob into the tar writer at name,
-// ensuring the layer reader is closed as soon as it has been written. Closing
-// the reader releases any pull-limiter slot held by remote-backed layers
-// (see remote.WithJobs / pkg/v1/remote.limiter), so leaving readers open here
-// could deadlock the write loop after defaultJobs layers.
-func writeLayer(tf *tar.Writer, name string, l v1.Layer) error {
-	r, err := l.Compressed()
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-	blobSize, err := l.Size()
-	if err != nil {
-		return err
-	}
-	return writeTarEntry(tf, name, r, blobSize)
-}
-
 func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 	hdr := &tar.Header{
 		Mode:     0644,
@@ -387,6 +369,23 @@ func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 	}
 	_, err := io.Copy(tf, r)
 	return err
+}
+
+// writeLayer streams a layer's compressed blob into the tar writer and closes
+// the reader before returning. The close releases any pull-limiter slot held
+// by a remote-backed layer (remote.WithJobs); leaving it open would deadlock
+// the write loop after defaultJobs layers.
+func writeLayer(tf *tar.Writer, name string, l v1.Layer) error {
+	r, err := l.Compressed()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	blobSize, err := l.Size()
+	if err != nil {
+		return err
+	}
+	return writeTarEntry(tf, name, r, blobSize)
 }
 
 // ComputeManifest get the manifest.json that will be written to the tarball

--- a/pkg/v1/tarball/write_test.go
+++ b/pkg/v1/tarball/write_test.go
@@ -500,3 +500,81 @@ func getLayersFilenames(hashes []string) []string {
 	}
 	return filenames
 }
+
+// TestWriteClosesLayerBeforeOpeningNext is a regression test for the deadlock
+// that occurs when Write does not close each layer reader before opening the
+// next one. Remote layer readers returned by remote.Get(...).Image() hold a
+// pull-job slot until Close (see remote.WithJobs / pkg/v1/remote.limiter),
+// so leaving readers open here deadlocks the write loop once defaultJobs
+// readers are outstanding.
+func TestWriteClosesLayerBeforeOpeningNext(t *testing.T) {
+	tokens := make(chan struct{}, 4)
+	img, err := random.Image(256, int64(cap(tokens)+1))
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	ref, err := name.NewTag("test/limited:latest")
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+	if err := tarball.MultiRefWrite(map[name.Reference]v1.Image{ref: &tokenLimitedImage{Image: img, tokens: tokens}}, io.Discard); err != nil {
+		t.Fatalf("tarball.MultiRefWrite: %v", err)
+	}
+	if got := len(tokens); got != 0 {
+		t.Fatalf("open layer readers after write: got %d, want 0", got)
+	}
+}
+
+// tokenLimitedImage wraps img so each layer's Compressed() reader takes one
+// of cap(tokens) slots, modeling remote.WithJobs slot behavior. The slot is
+// released only when Close() is called on the returned reader.
+type tokenLimitedImage struct {
+	v1.Image
+	tokens chan struct{}
+}
+
+func (i *tokenLimitedImage) Layers() ([]v1.Layer, error) {
+	ls, err := i.Image.Layers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]v1.Layer, len(ls))
+	for j, l := range ls {
+		out[j] = &tokenLimitedLayer{Layer: l, tokens: i.tokens}
+	}
+	return out, nil
+}
+
+type tokenLimitedLayer struct {
+	v1.Layer
+	tokens chan struct{}
+}
+
+func (l *tokenLimitedLayer) Compressed() (io.ReadCloser, error) {
+	select {
+	case l.tokens <- struct{}{}:
+	default:
+		return nil, errors.New("layer reader opened before previous readers were closed")
+	}
+	rc, err := l.Layer.Compressed()
+	if err != nil {
+		<-l.tokens
+		return nil, err
+	}
+	return &tokenReleasingReadCloser{ReadCloser: rc, release: func() { <-l.tokens }}, nil
+}
+
+type tokenReleasingReadCloser struct {
+	io.ReadCloser
+	release func()
+	closed  bool
+}
+
+func (rc *tokenReleasingReadCloser) Close() error {
+	err := rc.ReadCloser.Close()
+	if !rc.closed {
+		rc.closed = true
+		rc.release()
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

`tarball.MultiRefWrite` (and `crane pull`, which uses it) opens each layer's `Compressed()` reader and `io.Copy`s it into the tar without closing the reader. After #2271, remote layer readers hold a pull-job slot until their response body is closed, so writing more than `defaultJobs` (4) layers fills all available slots and the next `l.Compressed()` blocks forever in `pullLimiter.acquire`.

This is the symmetric leak to the one #2277 fixed in `mutate.Extract` / `crane export`.

Fixes #2309.

## Reproduction (before this PR)

```bash
$ curl -sL https://github.com/google/go-containerregistry/releases/download/v0.21.6/go-containerregistry_$(uname -s)_$(uname -m).tar.gz | tar -xz crane
$ timeout 120 ./crane pull postgres:16 /tmp/pg.tar
$ echo $?    # 124, killed — tarball stalls at ~37 MB
```

`postgres:16` has 14 layers. v0.21.5 finishes the same pull in ~30s with a 160 MB tar.

## Fix

Extract the per-layer write into a `writeLayer` helper that uses `defer r.Close()` so the pull-limiter slot is released as soon as the layer is in the tar. Same shape as #2277's `extractLayer`.

## Test

Added `TestWriteClosesLayerBeforeOpeningNext`. It wraps a `random.Image` so each layer's `Compressed()` reader takes one of 4 slots (modeling `remote.WithJobs`), and writes an image with `cap(tokens)+1` layers via `tarball.MultiRefWrite`. Before this change the test fails with `layer reader opened before previous readers were closed`. After this change the test passes and the slot channel is fully drained.

## Tested

```
go test ./pkg/v1/tarball
go test ./pkg/v1/tarball ./pkg/v1/mutate ./pkg/crane
```

All pass.

## Related

- Same root cause as #2276 / #2277, but in the tarball write path rather than mutate extract.