### PR TITLE
crane: preserve Cmd when --entrypoint is used without --cmd

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -101,14 +101,13 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 				return err
 			}
 
-			// Set entrypoint.
-			if len(entrypoint) > 0 {
+			// Set entrypoint and/or cmd only when the user passed those flags,
+			// so overriding one doesn't silently wipe the other inherited from
+			// the base image. Matches Dockerfile ENTRYPOINT/CMD semantics.
+			if c.Flags().Changed("entrypoint") {
 				cfg.Config.Entrypoint = entrypoint
-				cfg.Config.Cmd = nil // This matches Docker's behavior.
 			}
-
-			// Set cmd.
-			if len(cmd) > 0 {
+			if c.Flags().Changed("cmd") {
 				cfg.Config.Cmd = cmd
 			}
 

--- a/cmd/crane/cmd/mutate_test.go
+++ b/cmd/crane/cmd/mutate_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"slices"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// TestMutateEntrypointCmdPreservation verifies that --entrypoint and --cmd are
+// independently respected: overriding one preserves the other inherited from
+// the base image. Regression test for #2041.
+func TestMutateEntrypointCmdPreservation(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := path.Join(u.Host, "test/mutate")
+
+	// Build a base image with both Entrypoint and Cmd populated.
+	base, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := base.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg = cfg.DeepCopy()
+	cfg.Config.Entrypoint = []string{"/old-entry"}
+	cfg.Config.Cmd = []string{"old-cmd-arg"}
+	base, err = mutate.ConfigFile(base, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantEntry    []string
+		wantCmd      []string
+	}{
+		{
+			name:      "only --entrypoint preserves base Cmd",
+			args:      []string{"--entrypoint", "/new-entry"},
+			wantEntry: []string{"/new-entry"},
+			wantCmd:   []string{"old-cmd-arg"},
+		},
+		{
+			name:      "only --cmd preserves base Entrypoint",
+			args:      []string{"--cmd", "new-cmd-arg"},
+			wantEntry: []string{"/old-entry"},
+			wantCmd:   []string{"new-cmd-arg"},
+		},
+		{
+			name:      "both flags override both",
+			args:      []string{"--entrypoint", "/new-entry", "--cmd", "new-cmd-arg"},
+			wantEntry: []string{"/new-entry"},
+			wantCmd:   []string{"new-cmd-arg"},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srcRef, err := name.ParseReference(repo + ":src")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := remote.Write(srcRef, base); err != nil {
+				t.Fatalf("seeding src: %v", err)
+			}
+
+			// Each subtest writes to a distinct mutated tag.
+			dstTag := repo + ":mutated-" + tc.name[:4] + string(rune('a'+i))
+
+			options := []crane.Option{}
+			c := NewCmdMutate(&options)
+			c.SetOut(io.Discard)
+			c.SetErr(io.Discard)
+			c.SetArgs(append([]string{srcRef.String(), "--tag", dstTag}, tc.args...))
+			if err := c.Execute(); err != nil {
+				t.Fatalf("mutate: %v", err)
+			}
+
+			mutatedRef, err := name.ParseReference(dstTag)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mutated, err := remote.Image(mutatedRef)
+			if err != nil {
+				t.Fatalf("fetching mutated: %v", err)
+			}
+			mcfg, err := mutated.ConfigFile()
+			if err != nil {
+				t.Fatalf("ConfigFile: %v", err)
+			}
+			if !slices.Equal(mcfg.Config.Entrypoint, tc.wantEntry) {
+				t.Errorf("Entrypoint = %v, want %v", mcfg.Config.Entrypoint, tc.wantEntry)
+			}
+			if !slices.Equal(mcfg.Config.Cmd, tc.wantCmd) {
+				t.Errorf("Cmd = %v, want %v", mcfg.Config.Cmd, tc.wantCmd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2041

## Summary
- `crane mutate --entrypoint X` previously cleared `Cmd` even when `--cmd` wasn't passed, silently dropping the base image's command. Workaround was to read the base config and re-pass `--cmd` manually.
- Switch from `len(...) > 0` to `Flags().Changed(...)` so `--entrypoint` and `--cmd` are independently respected. Matches Dockerfile ENTRYPOINT/CMD semantics.

## Test plan
- [x] New `TestMutateEntrypointCmdPreservation` covers three cases: `--entrypoint` only preserves base Cmd, `--cmd` only preserves base Entrypoint, both flags override both.
- [x] Verified the bug-reproduction subtest fails on the unfixed code (`Cmd = [], want [old-cmd-arg]`).
- [x] `go test ./cmd/crane/... ./pkg/crane/...` and `go vet ./...` clean.