### PR TITLE
fix(name): anchor loopback registry detection

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -28,10 +28,10 @@ import (
 var reLocal = regexp.MustCompile(`.*\.localhost(?::\d{1,5})?$`)
 
 // Detect the loopback IP (127.0.0.1)
-var reLoopback = regexp.MustCompile(regexp.QuoteMeta("127.0.0.1"))
+var reLoopback = regexp.MustCompile(`^127\.0\.0\.1(?::\d{1,5})?$`)
 
 // Detect the loopback IPV6 (::1)
-var reipv6Loopback = regexp.MustCompile(regexp.QuoteMeta("::1"))
+var reipv6Loopback = regexp.MustCompile(`^(::1|\[::1\](?::\d{1,5})?)$`)
 
 // Registry stores a docker registry name in a structured form.
 type Registry struct {

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -216,6 +216,12 @@ func TestRegistryScheme(t *testing.T) {
 		domain: "127.0.0.1",
 		scheme: "http",
 	}, {
+		domain: "127.0.0.1.evil.com",
+		scheme: "https",
+	}, {
+		domain: "my127.0.0.1registry.io",
+		scheme: "https",
+	}, {
 		domain: "localhost:8080",
 		scheme: "http",
 	}, {
@@ -227,6 +233,12 @@ func TestRegistryScheme(t *testing.T) {
 	}, {
 		domain: "::1",
 		scheme: "http",
+	}, {
+		domain: "[::1]:5000",
+		scheme: "http",
+	}, {
+		domain: "[2001:db8::1]:5000",
+		scheme: "https",
 	}, {
 		domain: "10.2.3.4:5000",
 		scheme: "http",


### PR DESCRIPTION
Fixes #2313

## Summary

This anchors the loopback registry checks used by `Registry.Scheme()`.

Before this change, any registry hostname containing `127.0.0.1` or `::1` as a substring could be treated as loopback and use plain HTTP. Now only the actual loopback forms match: `127.0.0.1`, `127.0.0.1:<port>`, `::1`, and `[::1]:<port>`.

## Why

Non-loopback registries like `127.0.0.1.evil.com` or `[2001:db8::1]:5000` should keep the default HTTPS scheme. The old unanchored regexes matched those strings accidentally.

## Test plan

- `go test ./pkg/name`
- `go test ./pkg/...`
