### PR TITLE
feat(kubernetes): allow ignoring pull secrets

### DIFF
--- a/pkg/authn/kubernetes/keychain.go
+++ b/pkg/authn/kubernetes/keychain.go
@@ -59,6 +59,11 @@ type Options struct {
 	// Namespace) containing credential data to use for the image pull.
 	ImagePullSecrets []string
 
+	// IgnorePullSecrets determines whether image pull secrets should be ignored.
+	// This is useful for push-only workflows that only want mount secrets from
+	// the ServiceAccount.
+	IgnorePullSecrets bool
+
 	// UseMountSecrets determines whether or not mount secrets in the ServiceAccount
 	// should be considered. Mount secrets are those listed under the `.secrets`
 	// attribute of the ServiceAccount resource. Ignored if ServiceAccountName is set
@@ -85,15 +90,17 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 
 	// First, fetch all of the explicitly declared pull secrets
 	var pullSecrets []corev1.Secret
-	for _, name := range opt.ImagePullSecrets {
-		ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
-			logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, name)
-			continue
-		} else if err != nil {
-			return nil, err
+	if !opt.IgnorePullSecrets {
+		for _, name := range opt.ImagePullSecrets {
+			ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, name, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, name)
+				continue
+			} else if err != nil {
+				return nil, err
+			}
+			pullSecrets = append(pullSecrets, *ps)
 		}
-		pullSecrets = append(pullSecrets, *ps)
 	}
 
 	// Second, fetch all of the pull secrets attached to our service account,
@@ -107,15 +114,17 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 			return nil, err
 		}
 		if sa != nil {
-			for _, localObj := range sa.ImagePullSecrets {
-				ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
-				if k8serrors.IsNotFound(err) {
-					logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
-					continue
-				} else if err != nil {
-					return nil, err
+			if !opt.IgnorePullSecrets {
+				for _, localObj := range sa.ImagePullSecrets {
+					ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
+					if k8serrors.IsNotFound(err) {
+						logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
+						continue
+					} else if err != nil {
+						return nil, err
+					}
+					pullSecrets = append(pullSecrets, *ps)
 				}
-				pullSecrets = append(pullSecrets, *ps)
 			}
 
 			if opt.UseMountSecrets {

--- a/pkg/authn/kubernetes/keychain_test.go
+++ b/pkg/authn/kubernetes/keychain_test.go
@@ -161,6 +161,35 @@ func TestImagePullSecretAttachedServiceAccount(t *testing.T) {
 		&authn.Basic{Username: username, Password: password})
 }
 
+func TestIgnorePullSecrets(t *testing.T) {
+	client := fakeclient.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "svcacct", Namespace: "ns"},
+		ImagePullSecrets: []corev1.LocalObjectReference{{
+			Name: "pull-secret",
+		}},
+		Secrets: []corev1.ObjectReference{{
+			Name: "mount-secret",
+		}},
+	},
+		dockerCfgSecretType.Create(t, "ns", "explicit-pull-secret", "fake.registry.io", authn.AuthConfig{Username: "pull", Password: "explicit"}),
+		dockerCfgSecretType.Create(t, "ns", "pull-secret", "fake.registry.io", authn.AuthConfig{Username: "pull", Password: "sa"}),
+		dockerCfgSecretType.Create(t, "ns", "mount-secret", "fake.registry.io", authn.AuthConfig{Username: "mount", Password: "secret"}),
+	)
+
+	kc, err := New(context.Background(), client, Options{
+		Namespace:          "ns",
+		ServiceAccountName: "svcacct",
+		ImagePullSecrets:   []string{"explicit-pull-secret"},
+		IgnorePullSecrets:  true,
+		UseMountSecrets:    true,
+	})
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	testResolve(t, kc, registry(t, "fake.registry.io"), &authn.Basic{Username: "mount", Password: "secret"})
+}
+
 func TestSecretAttachedServiceAccount(t *testing.T) {
 	username, password := "foo", "bar"
 


### PR DESCRIPTION
Fixes #2089

## Summary
This adds an `IgnorePullSecrets` option to the Kubernetes keychain.

## Why
Some push-only workflows only want credentials from ServiceAccount mount secrets. Before this change, read-only credentials from explicit pull secrets or ServiceAccount `imagePullSecrets` could be loaded first and selected for the same registry, causing push auth to fail even when a write credential was available in `.secrets`.

## Test plan
- `cd pkg/authn/kubernetes && go test ./...`
