### PR TITLE
fix(name): preserve localhost registry references

### DIFF
--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -26,12 +26,14 @@ var (
 		"crossplane/provider-gcp:v0.14.0",
 		"ubuntu",
 		"gcr.io/crossplane/provider-gcp:latest",
+		"localhost/testimage:mytag",
 	}
 	outputDefaultNames = []string{
 		"registry.upbound.io/crossplane/provider-gcp:stable",
 		"registry.upbound.io/crossplane/provider-gcp:v0.14.0",
 		"registry.upbound.io/ubuntu:stable",
 		"gcr.io/crossplane/provider-gcp:latest",
+		"localhost/testimage:mytag",
 	}
 )
 

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -85,11 +85,12 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 	var registry string
 	repo := name
 	parts := strings.SplitN(name, regRepoDelimiter, 2)
-	if len(parts) == 2 && (strings.ContainsRune(parts[0], '.') || strings.ContainsRune(parts[0], ':')) {
+	maybeRegistry := parts[0]
+	if len(parts) == 2 && (maybeRegistry == "localhost" || strings.ContainsAny(maybeRegistry, ".:")) {
 		// The first part of the repository is treated as the registry domain
-		// iff it contains a '.' or ':' character, otherwise it is all repository
-		// and the domain defaults to Docker Hub.
-		registry = parts[0]
+		// if it is localhost or contains a '.' or ':' character, otherwise it
+		// is all repository and the domain defaults to Docker Hub.
+		registry = maybeRegistry
 		repo = parts[1]
 	}
 


### PR DESCRIPTION
Fixes #2048

## Summary
This treats `localhost/...` as an explicit registry reference when parsing image names.

## Why
Podman tags local images as `localhost/name:tag`. Before this change, `localhost/testimage:mytag` was parsed as a Docker Hub repository and became `index.docker.io/library/testimage:mytag`, so daemon lookups failed with “image not known”.

## Test plan
- `go test ./pkg/name`
- `git diff --check`
