### PR TITLE
fix(crane): avoid creating export tar on pull failure

### DIFF
--- a/cmd/crane/cmd/export.go
+++ b/cmd/crane/cmd/export.go
@@ -46,12 +46,6 @@ func NewCmdExport(options *[]crane.Option) *cobra.Command {
 				dst = args[1]
 			}
 
-			f, err := openFile(dst)
-			if err != nil {
-				return fmt.Errorf("failed to open %s: %w", dst, err)
-			}
-			defer f.Close()
-
 			var img v1.Image
 			if src == "-" {
 				tmpfile, err := os.CreateTemp("", "crane")
@@ -86,6 +80,12 @@ func NewCmdExport(options *[]crane.Option) *cobra.Command {
 					}
 				}
 			}
+
+			f, err := openFile(dst)
+			if err != nil {
+				return fmt.Errorf("failed to open %s: %w", dst, err)
+			}
+			defer f.Close()
 
 			return crane.Export(img, f)
 		},

--- a/cmd/crane/cmd/export_test.go
+++ b/cmd/crane/cmd/export_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+func TestExportDoesNotCreateDestinationWhenPullFails(t *testing.T) {
+	t.Parallel()
+
+	s := httptest.NewServer(http.NotFoundHandler())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "missing.tar")
+	options := []crane.Option{crane.Insecure}
+	cmd := NewCmdExport(&options)
+
+	err = cmd.RunE(cmd, []string{fmt.Sprintf("%s/missing:latest", u.Host), dst})
+	if err == nil {
+		t.Fatal("NewCmdExport returned nil error, want pull failure")
+	}
+	if !strings.Contains(err.Error(), "pulling") {
+		t.Fatalf("NewCmdExport error = %v, want pulling error", err)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("destination file exists after pull failure: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #2066

## What changed
- Delay opening the destination tarball in `crane export` until after the source image has been loaded successfully.
- Add a command-level regression test using a local 404 registry to verify failed pulls do not create the destination tar file.

## Why
`crane export IMAGE out.tar` previously created/truncated `out.tar` before pulling `IMAGE`. If the pull failed, an empty or partial destination file could still be left behind.

## Validation
- `go test ./cmd/crane/cmd`
- `go test ./cmd/crane/...`
- `git diff --check`