### PR TITLE
Add Docker certs.d support to crane

### DIFF
--- a/cmd/crane/cmd/docker_certs.go
+++ b/cmd/crane/cmd/docker_certs.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+type dockerCertsTransport struct {
+	base     *http.Transport
+	certsDir string
+
+	mu     sync.Mutex
+	byHost map[string]http.RoundTripper
+}
+
+func newDockerCertsTransport(base *http.Transport, certsDir string) http.RoundTripper {
+	if certsDir == "" {
+		return base
+	}
+	return &dockerCertsTransport{
+		base:     base,
+		certsDir: certsDir,
+		byHost:   map[string]http.RoundTripper{},
+	}
+}
+
+func (t *dockerCertsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Scheme != "https" {
+		return t.base.RoundTrip(req)
+	}
+	rt, err := t.transportForHost(req.URL.Host)
+	if err != nil {
+		return nil, err
+	}
+	return rt.RoundTrip(req)
+}
+
+func (t *dockerCertsTransport) transportForHost(host string) (http.RoundTripper, error) {
+	host = dockerCertsHost(host)
+
+	t.mu.Lock()
+	if rt, ok := t.byHost[host]; ok {
+		t.mu.Unlock()
+		return rt, nil
+	}
+	t.mu.Unlock()
+
+	transport := t.base.Clone()
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+		if tlsConfig.RootCAs != nil {
+			tlsConfig.RootCAs = tlsConfig.RootCAs.Clone()
+		}
+	}
+
+	if err := loadDockerCertsDir(filepath.Join(t.certsDir, host), tlsConfig); err != nil {
+		return nil, err
+	}
+	transport.TLSClientConfig = tlsConfig
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if rt, ok := t.byHost[host]; ok {
+		return rt, nil
+	}
+	t.byHost[host] = transport
+	return transport, nil
+}
+
+func dockerCertsHost(host string) string {
+	if runtime.GOOS == "windows" {
+		host = strings.ReplaceAll(host, ":", "")
+	}
+	return filepath.FromSlash(host)
+}
+
+func defaultDockerCertsDir() string {
+	if runtime.GOOS == "linux" && os.Getenv("ROOTLESSKIT_STATE_DIR") != "" {
+		if configHome, err := os.UserConfigDir(); err == nil && configHome != "" {
+			return filepath.Join(configHome, "docker", "certs.d")
+		}
+	}
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("programdata"), "docker", "certs.d")
+	}
+	return "/etc/docker/certs.d"
+}
+
+func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
+	files, err := os.ReadDir(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		switch filepath.Ext(f.Name()) {
+		case ".crt":
+			if tlsConfig.RootCAs == nil {
+				systemPool, err := x509.SystemCertPool()
+				if err != nil {
+					return fmt.Errorf("unable to get system cert pool: %w", err)
+				}
+				tlsConfig.RootCAs = systemPool
+			}
+			data, err := os.ReadFile(filepath.Join(directory, f.Name()))
+			if err != nil {
+				return err
+			}
+			tlsConfig.RootCAs.AppendCertsFromPEM(data)
+
+		case ".cert":
+			certName := f.Name()
+			keyName := certName[:len(certName)-len(".cert")] + ".key"
+			if !hasDockerCertFile(files, keyName) {
+				return fmt.Errorf("missing key %s for client certificate %s; CA certificates must use the extension .crt", keyName, certName)
+			}
+			cert, err := tls.LoadX509KeyPair(filepath.Join(directory, certName), filepath.Join(directory, keyName))
+			if err != nil {
+				return err
+			}
+			tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+
+		case ".key":
+			keyName := f.Name()
+			certName := keyName[:len(keyName)-len(".key")] + ".cert"
+			if !hasDockerCertFile(files, certName) {
+				return fmt.Errorf("missing client certificate %s for key %s", certName, keyName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func hasDockerCertFile(files []os.DirEntry, name string) bool {
+	for _, f := range files {
+		if f.Name() == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/crane/cmd/docker_certs.go
+++ b/cmd/crane/cmd/docker_certs.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -80,12 +81,13 @@ func (t *dockerCertsTransport) transportForHost(host string) (http.RoundTripper,
 		}
 	}
 
-	certsDir, ok, err := dockerCertsHostDir(t.certsDir, host)
+	certsRoot, ok, err := dockerCertsHostRoot(t.certsDir, host)
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		if err := loadDockerCertsDir(certsDir, tlsConfig); err != nil {
+		defer certsRoot.Close()
+		if err := loadDockerCertsRoot(certsRoot, tlsConfig); err != nil {
 			return nil, err
 		}
 	}
@@ -123,33 +125,45 @@ func defaultDockerCertsDir() string {
 	return "/etc/docker/certs.d"
 }
 
-func dockerCertsHostDir(certsDir, host string) (string, bool, error) {
+func dockerCertsHostRoot(certsDir, host string) (*os.Root, bool, error) {
 	if err := validateDockerCertPathComponent(host, "registry host"); err != nil {
-		return "", false, fmt.Errorf("invalid registry host %q", host)
+		return nil, false, fmt.Errorf("invalid registry host %q", host)
 	}
 
-	entries, err := os.ReadDir(certsDir)
+	certsRoot, err := os.OpenRoot(certsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", false, nil
+			return nil, false, nil
 		}
-		return "", false, err
+		return nil, false, err
+	}
+	defer certsRoot.Close()
+
+	entries, err := fs.ReadDir(certsRoot.FS(), ".")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() || entry.Name() != host {
 			continue
 		}
-		path, err := dockerCertPath(certsDir, entry.Name(), "registry host")
+		hostRoot, err := certsRoot.OpenRoot(entry.Name())
 		if err != nil {
-			return "", false, err
+			if os.IsNotExist(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
 		}
-		return path, true, nil
+		return hostRoot, true, nil
 	}
-	return "", false, nil
+	return nil, false, nil
 }
 
-func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
-	files, err := os.ReadDir(directory)
+func loadDockerCertsRoot(root *os.Root, tlsConfig *tls.Config) error {
+	files, err := fs.ReadDir(root.FS(), ".")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -161,8 +175,12 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 		if f.IsDir() {
 			continue
 		}
+		name := f.Name()
+		if err := validateDockerCertPathComponent(name, "file"); err != nil {
+			return err
+		}
 
-		switch filepath.Ext(f.Name()) {
+		switch filepath.Ext(name) {
 		case ".crt":
 			if tlsConfig.RootCAs == nil {
 				systemPool, err := x509.SystemCertPool()
@@ -171,38 +189,34 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 				}
 				tlsConfig.RootCAs = systemPool
 			}
-			path, err := dockerCertFilePath(directory, f.Name())
-			if err != nil {
-				return err
-			}
-			data, err := os.ReadFile(path)
+			data, err := root.ReadFile(name)
 			if err != nil {
 				return err
 			}
 			tlsConfig.RootCAs.AppendCertsFromPEM(data)
 
 		case ".cert":
-			certName := f.Name()
+			certName := name
 			keyName := certName[:len(certName)-len(".cert")] + ".key"
 			if !hasDockerCertFile(files, keyName) {
 				return fmt.Errorf("missing key %s for client certificate %s; CA certificates must use the extension .crt", keyName, certName)
 			}
-			certPath, err := dockerCertFilePath(directory, certName)
+			certPEM, err := root.ReadFile(certName)
 			if err != nil {
 				return err
 			}
-			keyPath, err := dockerCertFilePath(directory, keyName)
+			keyPEM, err := root.ReadFile(keyName)
 			if err != nil {
 				return err
 			}
-			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			cert, err := tls.X509KeyPair(certPEM, keyPEM)
 			if err != nil {
 				return err
 			}
 			tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
 		case ".key":
-			keyName := f.Name()
+			keyName := name
 			certName := keyName[:len(keyName)-len(".key")] + ".cert"
 			if !hasDockerCertFile(files, certName) {
 				return fmt.Errorf("missing client certificate %s for key %s", certName, keyName)
@@ -211,22 +225,6 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 	}
 
 	return nil
-}
-
-func dockerCertFilePath(directory, name string) (string, error) {
-	return dockerCertPath(directory, name, "file")
-}
-
-func dockerCertPath(directory, name, kind string) (string, error) {
-	if err := validateDockerCertPathComponent(name, kind); err != nil {
-		return "", err
-	}
-	path := filepath.Join(directory, name)
-	rel, err := filepath.Rel(directory, path)
-	if err != nil || rel != name {
-		return "", fmt.Errorf("invalid Docker cert %s %q", kind, name)
-	}
-	return path, nil
 }
 
 func validateDockerCertPathComponent(name, kind string) error {

--- a/cmd/crane/cmd/docker_certs.go
+++ b/cmd/crane/cmd/docker_certs.go
@@ -57,7 +57,10 @@ func (t *dockerCertsTransport) RoundTrip(req *http.Request) (*http.Response, err
 }
 
 func (t *dockerCertsTransport) transportForHost(host string) (http.RoundTripper, error) {
-	host = dockerCertsHost(host)
+	host, err := dockerCertsHost(host)
+	if err != nil {
+		return nil, err
+	}
 
 	t.mu.Lock()
 	if rt, ok := t.byHost[host]; ok {
@@ -91,11 +94,15 @@ func (t *dockerCertsTransport) transportForHost(host string) (http.RoundTripper,
 	return transport, nil
 }
 
-func dockerCertsHost(host string) string {
+func dockerCertsHost(host string) (string, error) {
 	if runtime.GOOS == "windows" {
 		host = strings.ReplaceAll(host, ":", "")
 	}
-	return filepath.FromSlash(host)
+	host = filepath.FromSlash(host)
+	if host == "" || host == "." || host == ".." || host != filepath.Base(host) {
+		return "", fmt.Errorf("invalid registry host %q", host)
+	}
+	return host, nil
 }
 
 func defaultDockerCertsDir() string {
@@ -133,7 +140,11 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 				}
 				tlsConfig.RootCAs = systemPool
 			}
-			data, err := os.ReadFile(filepath.Join(directory, f.Name()))
+			path, err := dockerCertFilePath(directory, f.Name())
+			if err != nil {
+				return err
+			}
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
@@ -145,7 +156,15 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 			if !hasDockerCertFile(files, keyName) {
 				return fmt.Errorf("missing key %s for client certificate %s; CA certificates must use the extension .crt", keyName, certName)
 			}
-			cert, err := tls.LoadX509KeyPair(filepath.Join(directory, certName), filepath.Join(directory, keyName))
+			certPath, err := dockerCertFilePath(directory, certName)
+			if err != nil {
+				return err
+			}
+			keyPath, err := dockerCertFilePath(directory, keyName)
+			if err != nil {
+				return err
+			}
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 			if err != nil {
 				return err
 			}
@@ -161,6 +180,13 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 	}
 
 	return nil
+}
+
+func dockerCertFilePath(directory, name string) (string, error) {
+	if name == "" || name == "." || name == ".." || name != filepath.Base(name) {
+		return "", fmt.Errorf("invalid Docker cert file %q", name)
+	}
+	return filepath.Join(directory, name), nil
 }
 
 func hasDockerCertFile(files []os.DirEntry, name string) bool {

--- a/cmd/crane/cmd/docker_certs.go
+++ b/cmd/crane/cmd/docker_certs.go
@@ -80,8 +80,14 @@ func (t *dockerCertsTransport) transportForHost(host string) (http.RoundTripper,
 		}
 	}
 
-	if err := loadDockerCertsDir(filepath.Join(t.certsDir, host), tlsConfig); err != nil {
+	certsDir, ok, err := dockerCertsHostDir(t.certsDir, host)
+	if err != nil {
 		return nil, err
+	}
+	if ok {
+		if err := loadDockerCertsDir(certsDir, tlsConfig); err != nil {
+			return nil, err
+		}
 	}
 	transport.TLSClientConfig = tlsConfig
 
@@ -99,7 +105,7 @@ func dockerCertsHost(host string) (string, error) {
 		host = strings.ReplaceAll(host, ":", "")
 	}
 	host = filepath.FromSlash(host)
-	if host == "" || host == "." || host == ".." || host != filepath.Base(host) {
+	if err := validateDockerCertPathComponent(host, "registry host"); err != nil {
 		return "", fmt.Errorf("invalid registry host %q", host)
 	}
 	return host, nil
@@ -115,6 +121,31 @@ func defaultDockerCertsDir() string {
 		return filepath.Join(os.Getenv("programdata"), "docker", "certs.d")
 	}
 	return "/etc/docker/certs.d"
+}
+
+func dockerCertsHostDir(certsDir, host string) (string, bool, error) {
+	if err := validateDockerCertPathComponent(host, "registry host"); err != nil {
+		return "", false, fmt.Errorf("invalid registry host %q", host)
+	}
+
+	entries, err := os.ReadDir(certsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() != host {
+			continue
+		}
+		path, err := dockerCertPath(certsDir, entry.Name(), "registry host")
+		if err != nil {
+			return "", false, err
+		}
+		return path, true, nil
+	}
+	return "", false, nil
 }
 
 func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
@@ -183,10 +214,26 @@ func loadDockerCertsDir(directory string, tlsConfig *tls.Config) error {
 }
 
 func dockerCertFilePath(directory, name string) (string, error) {
-	if name == "" || name == "." || name == ".." || name != filepath.Base(name) {
-		return "", fmt.Errorf("invalid Docker cert file %q", name)
+	return dockerCertPath(directory, name, "file")
+}
+
+func dockerCertPath(directory, name, kind string) (string, error) {
+	if err := validateDockerCertPathComponent(name, kind); err != nil {
+		return "", err
 	}
-	return filepath.Join(directory, name), nil
+	path := filepath.Join(directory, name)
+	rel, err := filepath.Rel(directory, path)
+	if err != nil || rel != name {
+		return "", fmt.Errorf("invalid Docker cert %s %q", kind, name)
+	}
+	return path, nil
+}
+
+func validateDockerCertPathComponent(name, kind string) error {
+	if name == "" || name == "." || name == ".." || filepath.IsAbs(name) || name != filepath.Base(name) || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("invalid Docker cert %s %q", kind, name)
+	}
+	return nil
 }
 
 func hasDockerCertFile(files []os.DirEntry, name string) bool {

--- a/cmd/crane/cmd/docker_certs_test.go
+++ b/cmd/crane/cmd/docker_certs_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestDockerCertsTransportUsesRegistryCerts(t *testing.T) {
+	registryCA, registryCAKey, registryCAPEM := newTestCA(t, "registry-ca")
+	serverCert, _, _ := newTestLeafCert(t, registryCA, registryCAKey, "registry", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+
+	clientCA, clientCAKey, _ := newTestCA(t, "client-ca")
+	_, clientCertPEM, clientKeyPEM := newTestLeafCert(t, clientCA, clientCAKey, "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(clientCA)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.TLS.PeerCertificates) != 1 {
+			http.Error(w, "missing client certificate", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientPool,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certsDir := t.TempDir()
+	writeDockerCertsDir(t, certsDir, u.Host, registryCAPEM, clientCertPEM, clientKeyPEM)
+
+	base := remote.DefaultTransport.(*http.Transport).Clone()
+	client := &http.Client{Transport: newDockerCertsTransport(base, certsDir)}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET with docker certs transport: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestLoadDockerCertsDirRequiresClientKey(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "client.cert"), []byte("not a cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := loadDockerCertsDir(dir, &tls.Config{})
+	if err == nil {
+		t.Fatal("loadDockerCertsDir returned nil, want missing key error")
+	}
+	if !strings.Contains(err.Error(), "missing key client.key") {
+		t.Fatalf("loadDockerCertsDir error = %v, want missing key", err)
+	}
+}
+
+func writeDockerCertsDir(t *testing.T, certsDir, host string, caPEM, certPEM, keyPEM []byte) {
+	t.Helper()
+	dir := filepath.Join(certsDir, dockerCertsHost(host))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range map[string][]byte{
+		"ca.crt":      caPEM,
+		"client.cert": certPEM,
+		"client.key":  keyPEM,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func newTestCA(t *testing.T, commonName string) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key, pemEncode(t, "CERTIFICATE", der)
+}
+
+func newTestLeafCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, commonName string, usages []x509.ExtKeyUsage) (tls.Certificate, []byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  usages,
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pemEncode(t, "CERTIFICATE", certDER)
+	keyPEM := pemEncode(t, "EC PRIVATE KEY", keyDER)
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, certPEM, keyPEM
+}
+
+func pemEncode(t *testing.T, typ string, der []byte) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	if err := pem.Encode(&b, &pem.Block{Type: typ, Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}

--- a/cmd/crane/cmd/docker_certs_test.go
+++ b/cmd/crane/cmd/docker_certs_test.go
@@ -87,12 +87,18 @@ func TestLoadDockerCertsDirRequiresClientKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := loadDockerCertsDir(dir, &tls.Config{})
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	err = loadDockerCertsRoot(root, &tls.Config{})
 	if err == nil {
-		t.Fatal("loadDockerCertsDir returned nil, want missing key error")
+		t.Fatal("loadDockerCertsRoot returned nil, want missing key error")
 	}
 	if !strings.Contains(err.Error(), "missing key client.key") {
-		t.Fatalf("loadDockerCertsDir error = %v, want missing key", err)
+		t.Fatalf("loadDockerCertsRoot error = %v, want missing key", err)
 	}
 }
 
@@ -111,51 +117,53 @@ func TestDockerCertsHostRejectsPathSeparators(t *testing.T) {
 	}
 }
 
-func TestDockerCertsHostDirFindsExistingHostDirectory(t *testing.T) {
+func TestDockerCertsHostRootFindsExistingHostDirectory(t *testing.T) {
 	dir := t.TempDir()
 	host := "registry.example.com:443"
 	if err := os.Mkdir(filepath.Join(dir, host), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
-	path, ok, err := dockerCertsHostDir(dir, host)
+	root, ok, err := dockerCertsHostRoot(dir, host)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !ok {
-		t.Fatal("dockerCertsHostDir did not find existing host directory")
+		t.Fatal("dockerCertsHostRoot did not find existing host directory")
 	}
-	if want := filepath.Join(dir, host); path != want {
-		t.Fatalf("dockerCertsHostDir path = %q, want %q", path, want)
+	defer root.Close()
+	if root.Name() != filepath.Join(dir, host) {
+		t.Fatalf("dockerCertsHostRoot path = %q, want %q", root.Name(), filepath.Join(dir, host))
 	}
 }
 
-func TestDockerCertsHostDirIgnoresMissingHostDirectory(t *testing.T) {
-	path, ok, err := dockerCertsHostDir(t.TempDir(), "registry.example.com")
+func TestDockerCertsHostRootIgnoresMissingHostDirectory(t *testing.T) {
+	root, ok, err := dockerCertsHostRoot(t.TempDir(), "registry.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok {
-		t.Fatalf("dockerCertsHostDir ok = true for missing host directory at %q", path)
+		defer root.Close()
+		t.Fatalf("dockerCertsHostRoot ok = true for missing host directory at %q", root.Name())
 	}
 }
 
-func TestDockerCertFilePathRejectsPathSeparators(t *testing.T) {
+func TestValidateDockerCertPathComponentRejectsPathSeparators(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := dockerCertFilePath(dir, filepath.Join(dir, "ca.crt")); err == nil {
-		t.Fatal("dockerCertFilePath returned nil error for absolute file")
+	if err := validateDockerCertPathComponent(filepath.Join(dir, "ca.crt"), "file"); err == nil {
+		t.Fatal("validateDockerCertPathComponent returned nil error for absolute file")
 	}
-	if _, err := dockerCertFilePath(dir, ".."); err == nil {
-		t.Fatal("dockerCertFilePath returned nil error for parent-directory file")
+	if err := validateDockerCertPathComponent("..", "file"); err == nil {
+		t.Fatal("validateDockerCertPathComponent returned nil error for parent-directory file")
 	}
-	if _, err := dockerCertFilePath(dir, "../ca.crt"); err == nil {
-		t.Fatal("dockerCertFilePath returned nil error for path traversal file")
+	if err := validateDockerCertPathComponent("../ca.crt", "file"); err == nil {
+		t.Fatal("validateDockerCertPathComponent returned nil error for path traversal file")
 	}
-	if _, err := dockerCertFilePath(dir, "nested/ca.crt"); err == nil {
-		t.Fatal("dockerCertFilePath returned nil error for nested file")
+	if err := validateDockerCertPathComponent("nested/ca.crt", "file"); err == nil {
+		t.Fatal("validateDockerCertPathComponent returned nil error for nested file")
 	}
-	if _, err := dockerCertFilePath(dir, `nested\ca.crt`); err == nil {
-		t.Fatal("dockerCertFilePath returned nil error for backslash-separated file")
+	if err := validateDockerCertPathComponent(`nested\ca.crt`, "file"); err == nil {
+		t.Fatal("validateDockerCertPathComponent returned nil error for backslash-separated file")
 	}
 }
 

--- a/cmd/crane/cmd/docker_certs_test.go
+++ b/cmd/crane/cmd/docker_certs_test.go
@@ -106,10 +106,45 @@ func TestDockerCertsHostRejectsPathSeparators(t *testing.T) {
 	if _, err := dockerCertsHost("registry.example.com/nested"); err == nil {
 		t.Fatal("dockerCertsHost returned nil error for nested host")
 	}
+	if _, err := dockerCertsHost(`registry.example.com\nested`); err == nil {
+		t.Fatal("dockerCertsHost returned nil error for backslash-separated host")
+	}
+}
+
+func TestDockerCertsHostDirFindsExistingHostDirectory(t *testing.T) {
+	dir := t.TempDir()
+	host := "registry.example.com:443"
+	if err := os.Mkdir(filepath.Join(dir, host), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	path, ok, err := dockerCertsHostDir(dir, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("dockerCertsHostDir did not find existing host directory")
+	}
+	if want := filepath.Join(dir, host); path != want {
+		t.Fatalf("dockerCertsHostDir path = %q, want %q", path, want)
+	}
+}
+
+func TestDockerCertsHostDirIgnoresMissingHostDirectory(t *testing.T) {
+	path, ok, err := dockerCertsHostDir(t.TempDir(), "registry.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("dockerCertsHostDir ok = true for missing host directory at %q", path)
+	}
 }
 
 func TestDockerCertFilePathRejectsPathSeparators(t *testing.T) {
 	dir := t.TempDir()
+	if _, err := dockerCertFilePath(dir, filepath.Join(dir, "ca.crt")); err == nil {
+		t.Fatal("dockerCertFilePath returned nil error for absolute file")
+	}
 	if _, err := dockerCertFilePath(dir, ".."); err == nil {
 		t.Fatal("dockerCertFilePath returned nil error for parent-directory file")
 	}
@@ -118,6 +153,9 @@ func TestDockerCertFilePathRejectsPathSeparators(t *testing.T) {
 	}
 	if _, err := dockerCertFilePath(dir, "nested/ca.crt"); err == nil {
 		t.Fatal("dockerCertFilePath returned nil error for nested file")
+	}
+	if _, err := dockerCertFilePath(dir, `nested\ca.crt`); err == nil {
+		t.Fatal("dockerCertFilePath returned nil error for backslash-separated file")
 	}
 }
 

--- a/cmd/crane/cmd/docker_certs_test.go
+++ b/cmd/crane/cmd/docker_certs_test.go
@@ -96,9 +96,38 @@ func TestLoadDockerCertsDirRequiresClientKey(t *testing.T) {
 	}
 }
 
+func TestDockerCertsHostRejectsPathSeparators(t *testing.T) {
+	if _, err := dockerCertsHost(".."); err == nil {
+		t.Fatal("dockerCertsHost returned nil error for parent-directory host")
+	}
+	if _, err := dockerCertsHost("../registry.example.com"); err == nil {
+		t.Fatal("dockerCertsHost returned nil error for path traversal host")
+	}
+	if _, err := dockerCertsHost("registry.example.com/nested"); err == nil {
+		t.Fatal("dockerCertsHost returned nil error for nested host")
+	}
+}
+
+func TestDockerCertFilePathRejectsPathSeparators(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := dockerCertFilePath(dir, ".."); err == nil {
+		t.Fatal("dockerCertFilePath returned nil error for parent-directory file")
+	}
+	if _, err := dockerCertFilePath(dir, "../ca.crt"); err == nil {
+		t.Fatal("dockerCertFilePath returned nil error for path traversal file")
+	}
+	if _, err := dockerCertFilePath(dir, "nested/ca.crt"); err == nil {
+		t.Fatal("dockerCertFilePath returned nil error for nested file")
+	}
+}
+
 func writeDockerCertsDir(t *testing.T, certsDir, host string, caPEM, certPEM, keyPEM []byte) {
 	t.Helper()
-	dir := filepath.Join(certsDir, dockerCertsHost(host))
+	certsHost, err := dockerCertsHost(host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(certsDir, certsHost)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -83,7 +83,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 				InsecureSkipVerify: insecure, //nolint: gosec
 			}
 
-			var rt http.RoundTripper = transport
+			var rt http.RoundTripper = newDockerCertsTransport(transport, defaultDockerCertsDir())
 
 			// Add any http headers if they are set in the config file.
 			cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))

--- a/cmd/crane/cmd/root.go
+++ b/cmd/crane/cmd/root.go
@@ -83,7 +83,7 @@ func New(use, short string, options []crane.Option) *cobra.Command {
 				InsecureSkipVerify: insecure, //nolint: gosec
 			}
 
-			var rt http.RoundTripper = newDockerCertsTransport(transport, defaultDockerCertsDir())
+			rt := newDockerCertsTransport(transport, defaultDockerCertsDir())
 
 			// Add any http headers if they are set in the config file.
 			cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))


### PR DESCRIPTION
### Summary
- add a crane transport wrapper that loads Docker-style per-registry certificate directories
- support registry CA files (`*.crt`) and client certificate/key pairs (`*.cert`/`*.key`)
- enable the wrapper for crane while keeping the existing transport headers, warnings, and insecure handling intact

### Details
Docker supports custom registry certificates under `certs.d/<registry-host>/`. This teaches crane to look up the request registry host, clone the base transport for that host, and apply matching certs only to that registry. Missing cert directories are ignored, while incomplete client certificate pairs return an early configuration error.

Updates #211.

### Testing
- `go test ./cmd/crane/cmd`
- `go test ./cmd/crane/... ./pkg/crane/...`
- `go test ./pkg/v1/remote/transport`
- `PATH="$PATH:$(go env GOPATH)/bin" ./hack/presubmit.sh`