### PR TITLE
Support OCI layout tarballs in crane load

### DIFF
--- a/cmd/crane/cmd/push.go
+++ b/cmd/crane/cmd/push.go
@@ -34,7 +34,7 @@ func NewCmdPush(options *[]crane.Option) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push PATH IMAGE",
 		Short: "Push local image contents to a remote registry",
-		Long:  `If the PATH is a directory, it will be read as an OCI image layout. Otherwise, PATH is assumed to be a docker-style tarball.`,
+		Long:  `If the PATH is a directory, it will be read as an OCI image layout. Otherwise, PATH is assumed to be a docker-style or OCI layout tarball.`,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, tag := args[0], args[1]

--- a/cmd/crane/doc/crane_push.md
+++ b/cmd/crane/doc/crane_push.md
@@ -4,7 +4,7 @@ Push local image contents to a remote registry
 
 ### Synopsis
 
-If the PATH is a directory, it will be read as an OCI image layout. Otherwise, PATH is assumed to be a docker-style tarball.
+If the PATH is a directory, it will be read as an OCI image layout. Otherwise, PATH is assumed to be a docker-style or OCI layout tarball.
 
 ```
 crane push PATH IMAGE [flags]

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -411,6 +412,85 @@ func TestCraneSaveOCI(t *testing.T) {
 	if err := crane.SaveOCI(img, tmp); err != nil {
 		t.Errorf("SaveOCI: %v", err)
 	}
+}
+
+func TestCraneLoadOCILayoutTarball(t *testing.T) {
+	t.Parallel()
+
+	layoutDir := t.TempDir()
+	tarPath := filepath.Join(t.TempDir(), "image.tar")
+
+	img, err := random.Image(1024, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crane.SaveOCI(img, layoutDir); err != nil {
+		t.Fatalf("SaveOCI: %v", err)
+	}
+	if err := writeTarFromDir(tarPath, layoutDir); err != nil {
+		t.Fatalf("writeTarFromDir: %v", err)
+	}
+
+	img, err = crane.Load(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != digest {
+		t.Errorf("digest mismatch: %v != %v", d, digest)
+	}
+}
+
+func writeTarFromDir(tarPath, root string) error {
+	f, err := os.Create(tarPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	tw := tar.NewWriter(f)
+	defer tw.Close()
+
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
 }
 
 func TestCraneFilesystem(t *testing.T) {

--- a/pkg/crane/crane_test.go
+++ b/pkg/crane/crane_test.go
@@ -448,6 +448,42 @@ func TestCraneLoadOCILayoutTarball(t *testing.T) {
 	}
 }
 
+func TestCraneLoadOCILayoutTarballRejectsEscapingEntry(t *testing.T) {
+	t.Parallel()
+
+	tarPath := filepath.Join(t.TempDir(), "image.tar")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(f)
+	content := []byte("escape")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "../escape",
+		Mode: 0600,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = crane.Load(tarPath)
+	if err == nil {
+		t.Fatal("Load returned nil error for escaping tar entry")
+	}
+	if !strings.Contains(err.Error(), "tar entry escapes destination") {
+		t.Fatalf("Load error = %v, want escaping tar entry error", err)
+	}
+}
+
 func writeTarFromDir(tarPath, root string) error {
 	f, err := os.Create(tarPath)
 	if err != nil {

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -15,24 +15,40 @@
 package crane
 
 import (
+	"archive/tar"
+	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 // Load reads the tarball at path as a v1.Image.
+// It supports Docker tarballs and single-image OCI layout tarballs.
 func Load(path string, opt ...Option) (v1.Image, error) {
 	return LoadTag(path, "", opt...)
 }
 
 // LoadTag reads a tag from the tarball at path as a v1.Image.
-// If tag is "", will attempt to read the tarball as a single image.
+// If tag is "", it will attempt to read the tarball as a single image.
 func LoadTag(path, tag string, opt ...Option) (v1.Image, error) {
 	if tag == "" {
-		return tarball.ImageFromPath(path, nil)
+		img, err := tarball.ImageFromPath(path, nil)
+		if err == nil {
+			return img, nil
+		}
+		ociImg, ociErr := loadOCILayoutTarball(path)
+		if ociErr == nil {
+			return ociImg, nil
+		}
+		return nil, fmt.Errorf("loading as docker tarball: %w; loading as OCI layout tarball: %v", err, ociErr)
 	}
 
 	o := makeOptions(opt...)
@@ -41,6 +57,95 @@ func LoadTag(path, tag string, opt ...Option) (v1.Image, error) {
 		return nil, fmt.Errorf("parsing tag %q: %w", tag, err)
 	}
 	return tarball.ImageFromPath(path, &t)
+}
+
+func loadOCILayoutTarball(path string) (v1.Image, error) {
+	dir, err := os.MkdirTemp("", "crane-oci-layout-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	if err := extractTar(path, dir); err != nil {
+		return nil, err
+	}
+
+	idx, err := layout.ImageIndexFromPath(dir)
+	if err != nil {
+		return nil, err
+	}
+	img, err := idx.Image(v1.Hash{})
+	if err != nil {
+		return nil, err
+	}
+
+	ref := name.MustParseReference("example.com/oci-layout:latest")
+	var b bytes.Buffer
+	if err := tarball.Write(ref, img, &b); err != nil {
+		return nil, err
+	}
+	return tarball.Image(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(b.Bytes())), nil
+	}, nil)
+}
+
+func extractTar(path, dir string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	tr := tar.NewReader(f)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		name := filepath.Clean(header.Name)
+		if name == "." {
+			continue
+		}
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("tar entry escapes destination: %q", header.Name)
+		}
+
+		target := filepath.Join(dir, name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			if err := writeTarFile(target, tr, header.FileInfo().Mode()); err != nil {
+				return err
+			}
+		case tar.TypeXHeader, tar.TypeXGlobalHeader:
+			continue
+		default:
+			return fmt.Errorf("unsupported tar entry %q type %d", header.Name, header.Typeflag)
+		}
+	}
+}
+
+func writeTarFile(path string, r io.Reader, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(f, r)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }
 
 // Push pushes the v1.Image img to a registry as dst.

--- a/pkg/crane/push.go
+++ b/pkg/crane/push.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -48,7 +47,7 @@ func LoadTag(path, tag string, opt ...Option) (v1.Image, error) {
 		if ociErr == nil {
 			return ociImg, nil
 		}
-		return nil, fmt.Errorf("loading as docker tarball: %w; loading as OCI layout tarball: %v", err, ociErr)
+		return nil, fmt.Errorf("loading as docker tarball: %w; loading as OCI layout tarball: %w", err, ociErr)
 	}
 
 	o := makeOptions(opt...)
@@ -106,21 +105,20 @@ func extractTar(path, dir string) error {
 			return err
 		}
 
-		name := filepath.Clean(header.Name)
-		if name == "." {
+		target, skip, err := tarEntryPath(dir, header.Name)
+		if err != nil {
+			return err
+		}
+		if skip {
 			continue
 		}
-		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("tar entry escapes destination: %q", header.Name)
-		}
 
-		target := filepath.Join(dir, name)
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0755); err != nil {
 				return err
 			}
-		case tar.TypeReg, tar.TypeRegA:
+		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 				return err
 			}
@@ -133,6 +131,17 @@ func extractTar(path, dir string) error {
 			return fmt.Errorf("unsupported tar entry %q type %d", header.Name, header.Typeflag)
 		}
 	}
+}
+
+func tarEntryPath(dir, name string) (string, bool, error) {
+	name = filepath.Clean(name)
+	if name == "." {
+		return "", true, nil
+	}
+	if !filepath.IsLocal(name) {
+		return "", false, fmt.Errorf("tar entry escapes destination: %q", name)
+	}
+	return filepath.Join(dir, name), false, nil
 }
 
 func writeTarFile(path string, r io.Reader, mode os.FileMode) error {


### PR DESCRIPTION
Fixes #2109.

## Summary
- let `crane.Load` fall back from Docker tarball parsing to single-image OCI layout tarballs
- safely extract OCI layout tarballs to a temporary directory and materialize the image before cleanup
- update `crane push` help text now that non-directory inputs can be Docker or OCI layout tarballs
- add coverage for loading an OCI layout tarball created from `crane.SaveOCI`

## Testing
- `go test ./pkg/crane -run TestCraneLoadOCILayoutTarball -count=1`
- `go test ./pkg/crane ./cmd/crane/cmd -count=1`
- `go test ./...`