### PR TITLE
name: treat localhost as an explicit registry

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -92,7 +92,7 @@ func (r Registry) Scheme() string {
 	if r.isRFC1918() {
 		return "http"
 	}
-	if strings.HasPrefix(r.Name(), "localhost:") {
+	if r.Name() == "localhost" || strings.HasPrefix(r.Name(), "localhost:") {
 		return "http"
 	}
 	if reLocal.MatchString(r.Name()) {

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -222,6 +222,9 @@ func TestRegistryScheme(t *testing.T) {
 		domain: "my127.0.0.1registry.io",
 		scheme: "https",
 	}, {
+		domain: "localhost",
+		scheme: "http",
+	}, {
 		domain: "localhost:8080",
 		scheme: "http",
 	}, {

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -27,6 +27,7 @@ var goodStrictValidationRepositoryNames = []string{
 	"example.text/foo/bar",
 	"mirror.gcr.io/ubuntu",
 	"index.docker.io/library/ubuntu",
+	"localhost/testimage",
 }
 
 var goodWeakValidationRepositoryNames = []string{

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -32,6 +32,7 @@ var goodStrictValidationRepositoryNames = []string{
 	// alpha-numeric  := /[a-z0-9]+/
 	"example.com/a",
 	"example.com/a/b",
+	"localhost/testimage",
 }
 
 var goodWeakValidationRepositoryNames = []string{

--- a/pkg/name/tag_test.go
+++ b/pkg/name/tag_test.go
@@ -27,6 +27,7 @@ var goodStrictValidationTagNames = []string{
 	"us.gcr.io/project-id/image:with.period.in.tag",
 	"gcr.io/project-id/image:w1th-alpha_num3ric.PLUScaps",
 	"domain.with.port:9001/image:latest",
+	"localhost/testimage:mytag",
 }
 
 var goodWeakValidationTagNames = []string{
@@ -110,6 +111,28 @@ func TestTagComponents(t *testing.T) {
 	}
 	if got, want := tag.String(), tagNameStr; got != want {
 		t.Errorf("String() was incorrect for %v. Wanted: `%s` Got: `%s`", tag, want, got)
+	}
+}
+
+func TestLocalhostTagComponents(t *testing.T) {
+	t.Parallel()
+
+	tag, err := NewTag("localhost/testimage:mytag", StrictValidation)
+	if err != nil {
+		t.Fatalf("NewTag() = %v", err)
+	}
+
+	if got, want := tag.RegistryStr(), "localhost"; got != want {
+		t.Errorf("RegistryStr() = %q, want %q", got, want)
+	}
+	if got, want := tag.RepositoryStr(), "testimage"; got != want {
+		t.Errorf("RepositoryStr() = %q, want %q", got, want)
+	}
+	if got, want := tag.TagStr(), "mytag"; got != want {
+		t.Errorf("TagStr() = %q, want %q", got, want)
+	}
+	if got, want := tag.Scheme(), "http"; got != want {
+		t.Errorf("Scheme() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2048.

Docker-style image reference parsing treats the first path component as a registry when it contains `.` or `:`, and also when it is exactly `localhost`. `NewRepository` only handled the `.` / `:` cases, so `localhost/testimage:mytag` was parsed as a Docker Hub repository path instead of using `localhost` as the registry. That caused daemon lookups for Podman-tagged images such as `localhost/testimage:mytag` to resolve as `index.docker.io/localhost/testimage:mytag` / `docker.io/library/testimage:mytag` instead of the local daemon tag.

This change recognizes `localhost` as an explicit registry component and also makes the bare `localhost` registry use the same `http` scheme fallback as `localhost:<port>`.

## Test plan

- go test ./pkg/name
- go test ./pkg/name ./pkg/v1/daemon ./pkg/v1/remote
- go test ./...
- git diff --check