### PR TITLE
Fix Extract hardlinks after target overwrite

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -267,6 +267,8 @@ func extract(img v1.Image, w io.Writer) error {
 	defer tarWriter.Close()
 
 	fileMap := map[string]bool{}
+	// Tracks old hardlink names that were overwritten by newer layers.
+	hardlinkRewrites := map[string]string{}
 
 	layers, err := img.Layers()
 	if err != nil {
@@ -277,14 +279,14 @@ func extract(img v1.Image, w io.Writer) error {
 	// whiteout layers more efficient, since we can just keep track of the removed
 	// files as we see .wh. layers and ignore those in previous layers.
 	for i := len(layers) - 1; i >= 0; i-- {
-		if err := extractLayer(tarWriter, fileMap, layers[i]); err != nil {
+		if err := extractLayer(tarWriter, fileMap, hardlinkRewrites, layers[i]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, layer v1.Layer) error {
+func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, hardlinkRewrites map[string]string, layer v1.Layer) error {
 	layerReader, err := layer.Uncompressed()
 	if err != nil {
 		return fmt.Errorf("reading layer contents: %w", err)
@@ -343,6 +345,9 @@ func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, layer v1.Layer
 		}
 
 		if _, ok := fileMap[name]; ok && !tombstone {
+			if header.Typeflag == tar.TypeLink {
+				rememberHardlinkRewrite(hardlinkRewrites, name, header.Linkname)
+			}
 			continue
 		}
 
@@ -355,6 +360,9 @@ func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, layer v1.Layer
 		// any entries with a matching (or child) name
 		fileMap[name] = tombstone || (header.Typeflag != tar.TypeDir)
 		if !tombstone {
+			if header.Typeflag == tar.TypeLink {
+				header.Linkname = resolveHardlinkRewrite(hardlinkRewrites, header.Linkname)
+			}
 			if err := tarWriter.WriteHeader(header); err != nil {
 				return err
 			}
@@ -375,6 +383,26 @@ func extractLayer(tarWriter *tar.Writer, fileMap map[string]bool, layer v1.Layer
 		return fmt.Errorf("verifying layer: %w", err)
 	}
 	return nil
+}
+
+func rememberHardlinkRewrite(hardlinkRewrites map[string]string, name, linkname string) {
+	linkname = resolveHardlinkRewrite(hardlinkRewrites, linkname)
+	if linkname == name {
+		return
+	}
+	hardlinkRewrites[name] = linkname
+}
+
+func resolveHardlinkRewrite(hardlinkRewrites map[string]string, linkname string) string {
+	seen := map[string]bool{}
+	for {
+		next, ok := hardlinkRewrites[linkname]
+		if !ok || seen[linkname] {
+			return linkname
+		}
+		seen[linkname] = true
+		linkname = next
+	}
 }
 
 func inWhiteoutDir(fileMap map[string]bool, file string) bool {

--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -274,6 +274,8 @@ func extract(img v1.Image, w io.Writer) error {
 	// opaqueDirs holds directories opaqued by an upper layer; entries under them
 	// from lower (later-iterated) layers are hidden.
 	opaqueDirs := map[string]bool{}
+	// Tracks old hardlink names that were overwritten by newer layers.
+	hardlinkRewrites := map[string]string{}
 
 	layers, err := img.Layers()
 	if err != nil {
@@ -284,14 +286,14 @@ func extract(img v1.Image, w io.Writer) error {
 	// whiteout layers more efficient, since we can just keep track of the removed
 	// files as we see .wh. layers and ignore those in previous layers.
 	for i := len(layers) - 1; i >= 0; i-- {
-		if err := extractLayer(tarWriter, fileMap, opaqueDirs, layers[i]); err != nil {
+		if err := extractLayer(tarWriter, fileMap, opaqueDirs, hardlinkRewrites, layers[i]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func extractLayer(tarWriter *tar.Writer, fileMap, opaqueDirs map[string]bool, layer v1.Layer) error {
+func extractLayer(tarWriter *tar.Writer, fileMap, opaqueDirs map[string]bool, hardlinkRewrites map[string]string, layer v1.Layer) error {
 	// Opaque markers in this layer hide only lower layers, so stage them and
 	// promote to opaqueDirs after the whole layer is processed.
 	layerOpaque := map[string]bool{}
@@ -362,6 +364,9 @@ func extractLayer(tarWriter *tar.Writer, fileMap, opaqueDirs map[string]bool, la
 		}
 
 		if _, ok := fileMap[name]; ok && !tombstone {
+			if header.Typeflag == tar.TypeLink {
+				rememberHardlinkRewrite(hardlinkRewrites, name, header.Linkname)
+			}
 			continue
 		}
 
@@ -379,6 +384,9 @@ func extractLayer(tarWriter *tar.Writer, fileMap, opaqueDirs map[string]bool, la
 		// any entries with a matching (or child) name
 		fileMap[name] = tombstone || (header.Typeflag != tar.TypeDir)
 		if !tombstone {
+			if header.Typeflag == tar.TypeLink {
+				header.Linkname = resolveHardlinkRewrite(hardlinkRewrites, header.Linkname)
+			}
 			if err := tarWriter.WriteHeader(header); err != nil {
 				return err
 			}
@@ -418,6 +426,26 @@ func inOpaqueDir(opaqueDirs map[string]bool, file string) bool {
 		file = dirname
 	}
 	return false
+}
+
+func rememberHardlinkRewrite(hardlinkRewrites map[string]string, name, linkname string) {
+	linkname = resolveHardlinkRewrite(hardlinkRewrites, linkname)
+	if linkname == name {
+		return
+	}
+	hardlinkRewrites[name] = linkname
+}
+
+func resolveHardlinkRewrite(hardlinkRewrites map[string]string, linkname string) string {
+	seen := map[string]bool{}
+	for {
+		next, ok := hardlinkRewrites[linkname]
+		if !ok || seen[linkname] {
+			return linkname
+		}
+		seen[linkname] = true
+		linkname = next
+	}
 }
 
 func inWhiteoutDir(fileMap map[string]bool, file string) bool {

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -276,6 +276,95 @@ func TestExtractRoundTrip(t *testing.T) {
 	}
 }
 
+func TestExtractRewritesHardlinkTargetOverwrittenByNewerLayer(t *testing.T) {
+	type entry struct {
+		header *tar.Header
+		body   string
+	}
+
+	makeLayer := func(entries []entry) v1.Layer {
+		t.Helper()
+
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		for _, e := range entries {
+			if e.body != "" {
+				e.header.Size = int64(len(e.body))
+			}
+			if err := tw.WriteHeader(e.header); err != nil {
+				t.Fatalf("writing header for %s: %v", e.header.Name, err)
+			}
+			if e.body != "" {
+				if _, err := tw.Write([]byte(e.body)); err != nil {
+					t.Fatalf("writing body for %s: %v", e.header.Name, err)
+				}
+			}
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("closing tar writer: %v", err)
+		}
+
+		layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		})
+		if err != nil {
+			t.Fatalf("creating layer: %v", err)
+		}
+		return layer
+	}
+
+	base := makeLayer([]entry{
+		{header: &tar.Header{Name: "t2", Typeflag: tar.TypeReg, Mode: 0o644}, body: "123\n"},
+	})
+	links := makeLayer([]entry{
+		{header: &tar.Header{Name: "t1", Typeflag: tar.TypeLink, Linkname: "t2"}},
+		{header: &tar.Header{Name: "t3", Typeflag: tar.TypeLink, Linkname: "t1"}},
+	})
+	update := makeLayer([]entry{
+		{header: &tar.Header{Name: "t1", Typeflag: tar.TypeReg, Mode: 0o644}, body: "456\n"},
+	})
+
+	img, err := mutate.AppendLayers(empty.Image, base, links, update)
+	if err != nil {
+		t.Fatalf("appending layers: %v", err)
+	}
+
+	extracted := map[string]*tar.Header{}
+	extractedBodies := map[string]string{}
+	tr := tar.NewReader(mutate.Extract(img))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading extracted tar: %v", err)
+		}
+		extracted[hdr.Name] = hdr
+		if hdr.Typeflag == tar.TypeReg {
+			var b bytes.Buffer
+			if _, err := io.Copy(&b, tr); err != nil {
+				t.Fatalf("reading body for %s: %v", hdr.Name, err)
+			}
+			extractedBodies[hdr.Name] = b.String()
+		}
+	}
+
+	if got := extractedBodies["t1"]; got != "456\n" {
+		t.Fatalf("t1 body = %q, want %q", got, "456\n")
+	}
+	if got := extractedBodies["t2"]; got != "123\n" {
+		t.Fatalf("t2 body = %q, want %q", got, "123\n")
+	}
+	t3, ok := extracted["t3"]
+	if !ok {
+		t.Fatal("t3 not found in extracted output")
+	}
+	if got := t3.Linkname; got != "t2" {
+		t.Fatalf("t3 linkname = %q, want %q", got, "t2")
+	}
+}
+
 // invalidImage is an image which returns an error when Layers() is called.
 type invalidImage struct {
 	v1.Image

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -334,6 +334,95 @@ func TestExtractRoundTrip(t *testing.T) {
 	}
 }
 
+func TestExtractRewritesHardlinkTargetOverwrittenByNewerLayer(t *testing.T) {
+	type entry struct {
+		header *tar.Header
+		body   string
+	}
+
+	makeLayer := func(entries []entry) v1.Layer {
+		t.Helper()
+
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		for _, e := range entries {
+			if e.body != "" {
+				e.header.Size = int64(len(e.body))
+			}
+			if err := tw.WriteHeader(e.header); err != nil {
+				t.Fatalf("writing header for %s: %v", e.header.Name, err)
+			}
+			if e.body != "" {
+				if _, err := tw.Write([]byte(e.body)); err != nil {
+					t.Fatalf("writing body for %s: %v", e.header.Name, err)
+				}
+			}
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("closing tar writer: %v", err)
+		}
+
+		layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		})
+		if err != nil {
+			t.Fatalf("creating layer: %v", err)
+		}
+		return layer
+	}
+
+	base := makeLayer([]entry{
+		{header: &tar.Header{Name: "t2", Typeflag: tar.TypeReg, Mode: 0o644}, body: "123\n"},
+	})
+	links := makeLayer([]entry{
+		{header: &tar.Header{Name: "t1", Typeflag: tar.TypeLink, Linkname: "t2"}},
+		{header: &tar.Header{Name: "t3", Typeflag: tar.TypeLink, Linkname: "t1"}},
+	})
+	update := makeLayer([]entry{
+		{header: &tar.Header{Name: "t1", Typeflag: tar.TypeReg, Mode: 0o644}, body: "456\n"},
+	})
+
+	img, err := mutate.AppendLayers(empty.Image, base, links, update)
+	if err != nil {
+		t.Fatalf("appending layers: %v", err)
+	}
+
+	extracted := map[string]*tar.Header{}
+	extractedBodies := map[string]string{}
+	tr := tar.NewReader(mutate.Extract(img))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading extracted tar: %v", err)
+		}
+		extracted[hdr.Name] = hdr
+		if hdr.Typeflag == tar.TypeReg {
+			var b bytes.Buffer
+			if _, err := io.Copy(&b, tr); err != nil {
+				t.Fatalf("reading body for %s: %v", hdr.Name, err)
+			}
+			extractedBodies[hdr.Name] = b.String()
+		}
+	}
+
+	if got := extractedBodies["t1"]; got != "456\n" {
+		t.Fatalf("t1 body = %q, want %q", got, "456\n")
+	}
+	if got := extractedBodies["t2"]; got != "123\n" {
+		t.Fatalf("t2 body = %q, want %q", got, "123\n")
+	}
+	t3, ok := extracted["t3"]
+	if !ok {
+		t.Fatal("t3 not found in extracted output")
+	}
+	if got := t3.Linkname; got != "t2" {
+		t.Fatalf("t3 linkname = %q, want %q", got, "t2")
+	}
+}
+
 // invalidImage is an image which returns an error when Layers() is called.
 type invalidImage struct {
 	v1.Image


### PR DESCRIPTION
Fixes #2002.

## What changed
- Track hardlink names that are skipped because a newer layer already overwrote that path.
- Rewrite older hardlinks that point at those overwritten names so they target the original older-layer path instead of the newer file.
- Add a regression test for the reported layer sequence: base file, hardlink aliases, then a later overwrite of one alias.

## Why
`mutate.Extract` flattens images by walking layers from newest to oldest. That makes whiteouts efficient, but it also means an older hardlink entry can point at a path that has already been replaced by a newer layer. In that case the exported tar can make an untouched hardlink name resolve to the newer file contents.

In the issue case, `t3` should keep pointing at the old `t2` content after `t1` is overwritten. Before this change, `t3` could still link to `t1` and inherit the newer `456` contents.

## Validation
- `go test ./pkg/v1/mutate -run TestExtractRewritesHardlinkTargetOverwrittenByNewerLayer`
- `go test ./pkg/v1/mutate`
- `PATH="$(go env GOPATH)/bin:$PATH" ./hack/presubmit.sh`
