### PR TITLE
Bound remote config blob reads

### DIFF
--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -37,7 +37,19 @@ const (
 	kib           = 1024
 	mib           = 1024 * kib
 	manifestLimit = 100 * mib
+	configLimit   = 100 * mib
 )
+
+func readAllLimit(r io.Reader, max int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > max {
+		return nil, fmt.Errorf("response body exceeds %d bytes", max)
+	}
+	return b, nil
+}
 
 // fetcher implements methods for reading from a registry.
 type fetcher struct {

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -40,13 +40,13 @@ const (
 	configLimit   = 100 * mib
 )
 
-func readAllLimit(r io.Reader, max int64) ([]byte, error) {
-	b, err := io.ReadAll(io.LimitReader(r, max+1))
+func readAllLimit(r io.Reader, limit int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, limit+1))
 	if err != nil {
 		return nil, err
 	}
-	if int64(len(b)) > max {
-		return nil, fmt.Errorf("response body exceeds %d bytes", max)
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("response body exceeds %d bytes", limit)
 	}
 	return b, nil
 }

--- a/pkg/v1/remote/fetcher_test.go
+++ b/pkg/v1/remote/fetcher_test.go
@@ -15,6 +15,7 @@
 package remote
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +28,22 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+func TestReadAllLimit(t *testing.T) {
+	got, err := readAllLimit(strings.NewReader("hello"), 5)
+	if err != nil {
+		t.Fatalf("readAllLimit() = %v", err)
+	}
+	if want := []byte("hello"); !bytes.Equal(got, want) {
+		t.Errorf("readAllLimit() = %q, want %q", got, want)
+	}
+
+	if _, err := readAllLimit(strings.NewReader("hello!"), 5); err == nil {
+		t.Fatal("readAllLimit() = nil, want error")
+	} else if !strings.Contains(err.Error(), "response body exceeds 5 bytes") {
+		t.Errorf("readAllLimit() = %v, want limit error", err)
+	}
+}
 
 func TestCheckRedirectSSRF(t *testing.T) {
 	// makeReq builds a redirect target request (dest) with a non-nil Response

--- a/pkg/v1/remote/image.go
+++ b/pkg/v1/remote/image.go
@@ -17,6 +17,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"sync"
@@ -118,13 +119,17 @@ func (r *remoteImage) RawConfigFile() ([]byte, error) {
 		return r.config, nil
 	}
 
+	if m.Config.Size > configLimit {
+		return nil, fmt.Errorf("config blob size %d exceeds limit %d", m.Config.Size, configLimit)
+	}
+
 	body, err := r.fetcher.fetchBlob(r.ctx, m.Config.Size, m.Config.Digest)
 	if err != nil {
 		return nil, err
 	}
 	defer body.Close()
 
-	r.config, err = io.ReadAll(body)
+	r.config, err = readAllLimit(body, configLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -269,6 +269,55 @@ func TestRawConfigFileNotFound(t *testing.T) {
 	}
 }
 
+func TestRawConfigFileRejectsLargeConfigDescriptor(t *testing.T) {
+	img := randomImage(t)
+	expectedRepo := "foo/bar"
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", expectedRepo)
+	configPath := fmt.Sprintf("/v2/%s/blobs/%s", expectedRepo, mustConfigName(t, img))
+
+	manifest := mustManifest(t, img)
+	manifest.Config.Size = configLimit + 1
+	rawManifest, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case manifestPath:
+			if r.Method != http.MethodGet {
+				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
+			}
+			w.Write(rawManifest)
+		case configPath:
+			t.Fatalf("RawConfigFile should reject large config before fetching %s", r.URL.Path)
+		default:
+			t.Fatalf("Unexpected path: %v", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%v) = %v", server.URL, err)
+	}
+
+	ref := mustNewTag(t, fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo))
+	rmt := remoteImage{
+		ref: ref,
+		ctx: context.Background(),
+		fetcher: fetcher{
+			target: ref.Context(),
+			client: http.DefaultClient,
+		},
+	}
+
+	if _, err := rmt.RawConfigFile(); err == nil {
+		t.Fatal("RawConfigFile() = nil, want error")
+	} else if !strings.Contains(err.Error(), "config blob size") {
+		t.Errorf("RawConfigFile() = %v, want config size error", err)
+	}
+}
+
 func TestAcceptHeaders(t *testing.T) {
 	img := randomImage(t)
 	expectedRepo := "foo/bar"


### PR DESCRIPTION
## Summary
- add a bounded read helper that reads max+1 bytes and returns a clear error when a response exceeds the limit
- cap remote image config blobs at 100 MiB before fetching and while reading
- add tests for the limit helper and for rejecting an oversized config descriptor before issuing a blob request

Fixes #2204 for current main; the other issue-listed remote error, auth token, and referrers reads are already bounded there.

## Testing
- `go test ./pkg/v1/remote`
- `go test ./pkg/v1/remote/transport`
- `git diff --check`
- `./hack/presubmit.sh` *(package tests passed, then local script failed because `registry` was not found on PATH for `cmd/crane/rebase_test.sh`; this left no source changes)*