### PR TITLE
Add default repository prefix option

### DIFF
--- a/pkg/name/doc.go
+++ b/pkg/name/doc.go
@@ -40,5 +40,6 @@
 // "library", the missing registry "index.docker.io", and the missing tag
 // "latest". To disable this defaulting, use the StrictValidation option. This
 // is useful e.g. to only allow image references that explicitly set a tag or
-// digest, so that you don't accidentally pull "latest".
+// digest, so that you don't accidentally pull "latest". Use
+// WithDefaultRepositoryPrefix to override the missing repository prefix.
 package name

--- a/pkg/name/options.go
+++ b/pkg/name/options.go
@@ -26,16 +26,19 @@ const (
 )
 
 type options struct {
-	strict          bool // weak by default
-	insecure        bool // secure by default
-	defaultRegistry string
-	defaultTag      string
+	strict                     bool // weak by default
+	insecure                   bool // secure by default
+	defaultRegistry            string
+	defaultRepositoryPrefix    string
+	defaultRepositoryPrefixSet bool
+	defaultTag                 string
 }
 
 func makeOptions(opts ...Option) options {
 	opt := options{
-		defaultRegistry: DefaultRegistry,
-		defaultTag:      DefaultTag,
+		defaultRegistry:         DefaultRegistry,
+		defaultRepositoryPrefix: defaultNamespace,
+		defaultTag:              DefaultTag,
 	}
 	for _, o := range opts {
 		o(&opt)
@@ -72,6 +75,15 @@ type OptionFn func() Option
 func WithDefaultRegistry(r string) Option {
 	return func(opts *options) {
 		opts.defaultRegistry = r
+	}
+}
+
+// WithDefaultRepositoryPrefix sets the default repository prefix that will be
+// used for single-component repository names such as "ubuntu".
+func WithDefaultRepositoryPrefix(prefix string) Option {
+	return func(opts *options) {
+		opts.defaultRepositoryPrefix = prefix
+		opts.defaultRepositoryPrefixSet = true
 	}
 }
 

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -49,6 +49,43 @@ func TestParseReferenceDefaulting(t *testing.T) {
 	}
 }
 
+func TestParseReferenceDefaultRepositoryPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want string
+	}{
+		{
+			name: "ubuntu",
+			opts: []Option{WithDefaultRepositoryPrefix("base")},
+			want: "index.docker.io/base/ubuntu:latest",
+		},
+		{
+			name: "ubuntu",
+			opts: []Option{
+				WithDefaultRegistry(testDefaultRegistry),
+				WithDefaultRepositoryPrefix("base"),
+				WithDefaultTag(testDefaultTag),
+			},
+			want: "registry.upbound.io/base/ubuntu:stable",
+		},
+		{
+			name: "crossplane/provider-gcp",
+			opts: []Option{WithDefaultRepositoryPrefix("base")},
+			want: "index.docker.io/crossplane/provider-gcp:latest",
+		},
+	}
+	for _, tt := range tests {
+		ref, err := ParseReference(tt.name, tt.opts...)
+		if err != nil {
+			t.Errorf("ParseReference(%q); %v", tt.name, err)
+		}
+		if ref.Name() != tt.want {
+			t.Errorf("ParseReference(%q); got %v, want %v", tt.name, ref.String(), tt.want)
+		}
+	}
+}
+
 func TestParseReference(t *testing.T) {
 	for _, name := range goodWeakValidationDigestNames {
 		ref, err := ParseReference(name, WeakValidation)

--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -30,7 +30,9 @@ const (
 // Repository stores a docker repository name in a structured form.
 type Repository struct {
 	Registry
-	repository string
+	repository                 string
+	defaultRepositoryPrefix    string
+	defaultRepositoryPrefixSet bool
 }
 
 var _ encoding.TextMarshaler = (*Repository)(nil)
@@ -38,15 +40,27 @@ var _ encoding.TextUnmarshaler = (*Repository)(nil)
 var _ json.Marshaler = (*Repository)(nil)
 var _ json.Unmarshaler = (*Repository)(nil)
 
-// See https://docs.docker.com/docker-hub/official_repos
-func hasImplicitNamespace(repo string, reg Registry) bool {
-	return !strings.ContainsRune(repo, '/') && reg.RegistryStr() == DefaultRegistry
+func (r Repository) hasImplicitNamespace() bool {
+	// Docker Hub single-component names default to "library" for historical
+	// compatibility. Explicit repository-prefix defaulting applies to any
+	// default registry selected by the caller.
+	return !strings.ContainsRune(r.repository, '/') &&
+		(r.RegistryStr() == DefaultRegistry || r.defaultRepositoryPrefixSet)
+}
+
+func (r Repository) repositoryPrefix() string {
+	if r.defaultRepositoryPrefixSet {
+		return r.defaultRepositoryPrefix
+	}
+	return defaultNamespace
 }
 
 // RepositoryStr returns the repository component of the Repository.
 func (r Repository) RepositoryStr() string {
-	if hasImplicitNamespace(r.repository, r.Registry) {
-		return fmt.Sprintf("%s/%s", defaultNamespace, r.repository)
+	if r.hasImplicitNamespace() {
+		if prefix := r.repositoryPrefix(); prefix != "" {
+			return fmt.Sprintf("%s/%s", prefix, r.repository)
+		}
 	}
 	return r.repository
 }
@@ -102,10 +116,22 @@ func NewRepository(name string, opts ...Option) (Repository, error) {
 	if err != nil {
 		return Repository{}, err
 	}
-	if hasImplicitNamespace(repo, reg) && opt.strict {
-		return Repository{}, newErrBadName("strict validation requires the full repository path (missing 'library')")
+	r := Repository{
+		Registry:                   reg,
+		repository:                 repo,
+		defaultRepositoryPrefix:    opt.defaultRepositoryPrefix,
+		defaultRepositoryPrefixSet: opt.defaultRepositoryPrefixSet,
 	}
-	return Repository{reg, repo}, nil
+	if r.hasImplicitNamespace() && opt.strict {
+		return Repository{}, newErrBadName(
+			"strict validation requires the full repository path (missing '%s')", r.repositoryPrefix())
+	}
+	if r.hasImplicitNamespace() {
+		if err := checkRepository(r.RepositoryStr()); err != nil {
+			return Repository{}, err
+		}
+	}
+	return r, nil
 }
 
 // Tag returns a Tag in this Repository.

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -123,6 +123,24 @@ func TestRepositoryBadDefaulting(t *testing.T) {
 	}
 }
 
+func TestRepositoryDefaultPrefix(t *testing.T) {
+	repo, err := NewRepository("ubuntu", WithDefaultRepositoryPrefix("base"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := repo.Name(), "index.docker.io/base/ubuntu"; got != want {
+		t.Errorf("repo.Name(): got %s want %s", got, want)
+	}
+
+	repo, err = NewRepository("ubuntu", WithDefaultRegistry("registry.example.com"), WithDefaultRepositoryPrefix("base"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := repo.Name(), "registry.example.com/base/ubuntu"; got != want {
+		t.Errorf("repo.Name(): got %s want %s", got, want)
+	}
+}
+
 func TestRepositoryChildren(t *testing.T) {
 	repo, err := NewRepository("example.com/repo", Insecure)
 	if err != nil {


### PR DESCRIPTION
Adds `name.WithDefaultRepositoryPrefix` so callers can choose the default prefix used for single-component repository names.

The existing behavior stays the same unless the option is set:
- `ubuntu` still defaults to `index.docker.io/library/ubuntu:latest`
- `WithDefaultRegistry(...)` still defaults only the registry/tag unless a repository prefix is explicitly provided
- `WithDefaultRepositoryPrefix("base")` makes `ubuntu` parse as `index.docker.io/base/ubuntu:latest`

Fixes #2145.

Tests:
- go test ./pkg/name
- go test ./pkg/name ./pkg/v1/remote/transport
- git diff --check
