### PR TITLE
BUGFIX: Fail with error when read exceeds maximum

### DIFF
--- a/internal/limit/limit.go
+++ b/internal/limit/limit.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package limit provides bounded reads from io.Readers.
+package limit
+
+import (
+	"fmt"
+	"io"
+)
+
+// ReadAll reads from r until EOF and returns the data. If r produces more
+// than max bytes, it returns an error instead of a silently truncated
+// slice. Use this in preference to io.ReadAll(io.LimitReader(r, max))
+// when callers must distinguish a complete read from a truncated one.
+func ReadAll(r io.Reader, max int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > max {
+		return nil, fmt.Errorf("body exceeds %d byte limit", max)
+	}
+	return b, nil
+}

--- a/internal/limit/limit_test.go
+++ b/internal/limit/limit_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limit
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestReadAll(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		max     int64
+		want    string
+		wantErr bool
+	}{
+		{name: "under limit", input: "hello", max: 10, want: "hello"},
+		{name: "at limit", input: "hello", max: 5, want: "hello"},
+		{name: "over limit", input: "hello world", max: 5, wantErr: true},
+		{name: "empty under limit", input: "", max: 5, want: ""},
+		{name: "empty zero limit", input: "", max: 0, want: ""},
+		{name: "one byte over zero limit", input: "x", max: 0, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ReadAll(bytes.NewReader([]byte(tc.input)), tc.max)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestReadAllPropagatesError(t *testing.T) {
+	want := errors.New("boom")
+	if _, err := ReadAll(errReader{err: want}, 10); !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestReadAllReadsExactlyMax(t *testing.T) {
+	// Ensure we don't return after reading max+1 bytes from a long stream.
+	r := io.MultiReader(bytes.NewReader(bytes.Repeat([]byte("a"), 1024)), errReader{err: errors.New("should not be read")})
+	if _, err := ReadAll(r, 10); err == nil {
+		t.Fatal("expected over-limit error")
+	}
+}

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/go-containerregistry/internal/limit"
 	"github.com/google/go-containerregistry/internal/redact"
 	"github.com/google/go-containerregistry/internal/verify"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -168,7 +169,7 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 		return nil, nil, err
 	}
 
-	manifest, err := io.ReadAll(io.LimitReader(resp.Body, manifestLimit))
+	manifest, err := limit.ReadAll(resp.Body, manifestLimit)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"strings"
 
+	"github.com/google/go-containerregistry/internal/limit"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -67,7 +67,7 @@ func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, 
 
 	var b []byte
 	if resp.StatusCode == http.StatusOK && resp.Header.Get("Content-Type") == string(types.OCIImageIndex) {
-		b, err = io.ReadAll(io.LimitReader(resp.Body, manifestLimit))
+		b, err = limit.ReadAll(resp.Body, manifestLimit)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -19,13 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 
+	"github.com/google/go-containerregistry/internal/limit"
 	"github.com/google/go-containerregistry/internal/redact"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -420,7 +420,7 @@ func (bt *bearerTransport) refreshOauth(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(io.LimitReader(resp.Body, maxTokenBodySize))
+	return limit.ReadAll(resp.Body, maxTokenBodySize)
 }
 
 // https://docs.docker.com/registry/spec/auth/token/
@@ -465,5 +465,5 @@ func (bt *bearerTransport) refreshBasic(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	return io.ReadAll(io.LimitReader(resp.Body, maxTokenBodySize))
+	return limit.ReadAll(resp.Body, maxTokenBodySize)
 }

--- a/pkg/v1/remote/transport/error.go
+++ b/pkg/v1/remote/transport/error.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/go-containerregistry/internal/limit"
 	"github.com/google/go-containerregistry/internal/redact"
 )
 
@@ -167,7 +168,7 @@ func CheckError(resp *http.Response, codes ...int) error {
 		}
 	}
 
-	b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	b, err := limit.ReadAll(resp.Body, maxErrorBodySize)
 	if err != nil {
 		return err
 	}
@@ -191,7 +192,7 @@ func makeError(resp *http.Response, body []byte) *Error {
 }
 
 func retryError(resp *http.Response) error {
-	b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	b, err := limit.ReadAll(resp.Body, maxErrorBodySize)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`io.ReadAll(io.LimitReader(...))` prevents OOM issues but does silently truncate long bodies. Instead, we should throw an error when a body exceeds the read limit