### PR TITLE
Anchor loopback registry scheme checks

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -28,10 +28,10 @@ import (
 var reLocal = regexp.MustCompile(`.*\.localhost(?::\d{1,5})?$`)
 
 // Detect the loopback IP (127.0.0.1)
-var reLoopback = regexp.MustCompile(regexp.QuoteMeta("127.0.0.1"))
+var reLoopback = regexp.MustCompile(`^127\.0\.0\.1(?::\d{1,5})?$`)
 
 // Detect the loopback IPV6 (::1)
-var reipv6Loopback = regexp.MustCompile(regexp.QuoteMeta("::1"))
+var reipv6Loopback = regexp.MustCompile(`^(?:\[::1\](?::\d{1,5})?|::1)$`)
 
 // Registry stores a docker registry name in a structured form.
 type Registry struct {

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -216,6 +216,18 @@ func TestRegistryScheme(t *testing.T) {
 		domain: "127.0.0.1",
 		scheme: "http",
 	}, {
+		domain: "127.0.0.1.evil.com",
+		scheme: "https",
+	}, {
+		domain: "my127.0.0.1registry.io",
+		scheme: "https",
+	}, {
+		domain: "evil.com.127.0.0.1.nip.io",
+		scheme: "https",
+	}, {
+		domain: "x127.0.0.1x.com",
+		scheme: "https",
+	}, {
 		domain: "localhost:8080",
 		scheme: "http",
 	}, {
@@ -227,6 +239,15 @@ func TestRegistryScheme(t *testing.T) {
 	}, {
 		domain: "::1",
 		scheme: "http",
+	}, {
+		domain: "[::1]:5000",
+		scheme: "http",
+	}, {
+		domain: "[2001:db8::1]:5000",
+		scheme: "https",
+	}, {
+		domain: "[fe80::1]:5000",
+		scheme: "https",
 	}, {
 		domain: "10.2.3.4:5000",
 		scheme: "http",


### PR DESCRIPTION
## Summary

`Registry.Scheme()` treats loopback registries as HTTP, but the existing loopback regexes also matched those literals as substrings inside non-loopback hostnames.

This anchors the IPv4 and IPv6 loopback checks so only exact loopback authorities keep the HTTP scheme. It also adds regression coverage for hostnames that contain `127.0.0.1` or `::1` without being loopback addresses.

Fixes #2313.

## Testing

- `go test ./pkg/name`
- `git diff --check`
