### PR TITLE
fix: prevent SSRF in google.List() pagination

### DIFF
--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -17,6 +17,7 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -143,7 +144,7 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 		// This isn't GCR, just append the tags and keep paginating.
 		tags.Tags = append(tags.Tags, parsed.Tags...)
 
-		uri, err = getNextPageURL(resp)
+		uri, err = getNextPageURL(resp, repo)
 		if err != nil {
 			return nil, err
 		}
@@ -159,8 +160,11 @@ func (l *lister) list(repo name.Repository) (*Tags, error) {
 
 // getNextPageURL checks if there is a Link header in a http.Response which
 // contains a link to the next page. If yes it returns the url.URL of the next
-// page otherwise it returns nil.
-func getNextPageURL(resp *http.Response) (*url.URL, error) {
+// page otherwise it returns nil. It validates that the resolved URL points
+// to the same registry to prevent SSRF attacks where a malicious registry
+// could redirect pagination requests to internal services like cloud metadata
+// endpoints.
+func getNextPageURL(resp *http.Response, repo name.Repository) (*url.URL, error) {
 	link := resp.Header.Get("Link")
 	if link == "" {
 		return nil, nil
@@ -184,7 +188,31 @@ func getNextPageURL(resp *http.Response) (*url.URL, error) {
 		return nil, nil
 	}
 	linkURL = resp.Request.URL.ResolveReference(linkURL)
+
+	// Validate that the pagination URL points to the same registry to prevent SSRF.
+	if err := validatePaginationURL(linkURL, repo); err != nil {
+		return nil, err
+	}
+
 	return linkURL, nil
+}
+
+// validatePaginationURL checks that a pagination URL is safe to follow.
+// It ensures the URL points to the same registry host to prevent SSRF attacks
+// where a malicious registry could include a Link header pointing to internal
+// services (e.g., cloud metadata endpoints at 169.254.169.254).
+func validatePaginationURL(u *url.URL, repo name.Repository) error {
+	// Must use same scheme as the registry
+	if u.Scheme != repo.Scheme() {
+		return fmt.Errorf("pagination URL scheme %q does not match registry scheme %q", u.Scheme, repo.Scheme())
+	}
+
+	// Must point to the same registry host
+	if u.Host != repo.RegistryStr() {
+		return errors.New("pagination URL host does not match registry host: potential SSRF attack")
+	}
+
+	return nil
 }
 
 type rawManifestInfo struct {

--- a/pkg/v1/google/list.go
+++ b/pkg/v1/google/list.go
@@ -179,6 +179,9 @@ func getNextPageURL(resp *http.Response, repo name.Repository) (*url.URL, error)
 		return nil, fmt.Errorf("failed to parse link header: missing '>' in: %s", link)
 	}
 	link = link[1:end]
+	if link == "" {
+		return nil, nil
+	}
 
 	linkURL, err := url.Parse(link)
 	if err != nil {

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -301,39 +301,147 @@ func makeResp(hdr string) *http.Response {
 		Header: http.Header{
 			"Link": []string{hdr},
 		},
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+		},
 	}
 }
 
 func TestGetNextPageURL(t *testing.T) {
+	repo, err := name.NewRepository("example.com/myrepo")
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
+
 	for _, hdr := range []string{
 		"",
 		"<",
 		"><",
-		"<>",
 		fmt.Sprintf("<%c>", 0x7f), // makes url.Parse fail
 	} {
-		u, err := getNextPageURL(makeResp(hdr))
+		u, err := getNextPageURL(makeResp(hdr), repo)
 		if err == nil && u != nil {
-			t.Errorf("Expected err, got %+v", u)
+			t.Errorf("Expected err or nil URL for %q, got %+v", hdr, u)
 		}
+	}
+
+	// "<>" resolves to current URL which is valid
+	emptyU, emptyErr := getNextPageURL(makeResp("<>"), repo)
+	if emptyErr != nil {
+		t.Errorf("Expected <> to resolve to current URL, got err: %v", emptyErr)
+	}
+	if emptyU != nil && emptyU.Host != "example.com" {
+		t.Errorf("Expected <> to resolve to example.com, got %s", emptyU.Host)
 	}
 
 	good := &http.Response{
 		Header: http.Header{
-			"Link": []string{"<example.com>"},
+			"Link": []string{"</v2/myrepo/tags/list?n=100>"},
 		},
 		Request: &http.Request{
 			URL: &url.URL{
 				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/v2/myrepo/tags/list",
 			},
 		},
 	}
-	u, err := getNextPageURL(good)
+	u, err := getNextPageURL(good, repo)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if u.Scheme != "https" {
 		t.Errorf("expected scheme to match request, got %s", u.Scheme)
+	}
+	if u.Host != "example.com" {
+		t.Errorf("expected host to match request, got %s", u.Host)
+	}
+}
+
+func TestValidatePaginationURL(t *testing.T) {
+	repo, err := name.NewRepository("registry.example.com/myrepo")
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{
+			name:    "same host - valid",
+			url:     "https://registry.example.com/v2/myrepo/tags/list?n=100&last=tag1",
+			wantErr: false,
+		},
+		{
+			name:    "cloud metadata endpoint - SSRF attempt",
+			url:     "http://169.254.169.254/latest/meta-data/",
+			wantErr: true,
+		},
+		{
+			name:    "localhost - SSRF attempt",
+			url:     "http://localhost:8080/internal",
+			wantErr: true,
+		},
+		{
+			name:    "internal IP - SSRF attempt",
+			url:     "http://192.168.1.1/admin",
+			wantErr: true,
+		},
+		{
+			name:    "different registry - SSRF attempt",
+			url:     "https://evil-registry.com/v2/myrepo/tags/list",
+			wantErr: true,
+		},
+		{
+			name:    "scheme mismatch - potential downgrade",
+			url:     "http://registry.example.com/v2/myrepo/tags/list",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("failed to parse URL: %v", err)
+			}
+
+			err = validatePaginationURL(u, repo)
+			if tc.wantErr && err == nil {
+				t.Errorf("validatePaginationURL(%q) = nil, want error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validatePaginationURL(%q) = %v, want nil", tc.url, err)
+			}
+		})
+	}
+}
+
+func TestGetNextPageURL_SSRF(t *testing.T) {
+	repo, _ := name.NewRepository("registry.example.com/myrepo")
+
+	// Malicious registry returns Link header pointing to cloud metadata
+	malicious := &http.Response{
+		Header: http.Header{
+			"Link": []string{"<http://169.254.169.254/latest/meta-data/>;rel=\"next\""},
+		},
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "registry.example.com",
+				Path:   "/v2/myrepo/tags/list",
+			},
+		},
+	}
+
+	_, err := getNextPageURL(malicious, repo)
+	if err == nil {
+		t.Error("getNextPageURL should reject Link header pointing to cloud metadata endpoint")
 	}
 }

--- a/pkg/v1/google/list_test.go
+++ b/pkg/v1/google/list_test.go
@@ -320,21 +320,13 @@ func TestGetNextPageURL(t *testing.T) {
 		"",
 		"<",
 		"><",
+		"<>",
 		fmt.Sprintf("<%c>", 0x7f), // makes url.Parse fail
 	} {
 		u, err := getNextPageURL(makeResp(hdr), repo)
 		if err == nil && u != nil {
 			t.Errorf("Expected err or nil URL for %q, got %+v", hdr, u)
 		}
-	}
-
-	// "<>" resolves to current URL which is valid
-	emptyU, emptyErr := getNextPageURL(makeResp("<>"), repo)
-	if emptyErr != nil {
-		t.Errorf("Expected <> to resolve to current URL, got err: %v", emptyErr)
-	}
-	if emptyU != nil && emptyU.Host != "example.com" {
-		t.Errorf("Expected <> to resolve to example.com, got %s", emptyU.Host)
 	}
 
 	good := &http.Response{

--- a/pkg/v1/remote/catalog.go
+++ b/pkg/v1/remote/catalog.go
@@ -122,7 +122,7 @@ func (f *fetcher) catalogPage(ctx context.Context, reg name.Registry, next strin
 		return nil, err
 	}
 
-	uri, err := getNextPageURL(resp)
+	uri, err := getNextPageURLForRegistry(resp, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -17,6 +17,7 @@ package remote
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -85,7 +86,7 @@ func (f *fetcher) listPage(ctx context.Context, repo name.Repository, next strin
 		return nil, err
 	}
 
-	uri, err := getNextPageURL(resp)
+	uri, err := getNextPageURL(resp, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +100,9 @@ func (f *fetcher) listPage(ctx context.Context, repo name.Repository, next strin
 
 // getNextPageURL checks if there is a Link header in a http.Response which
 // contains a link to the next page. If yes it returns the url.URL of the next
-// page otherwise it returns nil.
-func getNextPageURL(resp *http.Response) (*url.URL, error) {
+// page otherwise it returns nil. It validates that the resolved URL points
+// to the same registry to prevent SSRF attacks.
+func getNextPageURL(resp *http.Response, repo name.Repository) (*url.URL, error) {
 	link := resp.Header.Get("Link")
 	if link == "" {
 		return nil, nil
@@ -124,7 +126,29 @@ func getNextPageURL(resp *http.Response) (*url.URL, error) {
 		return nil, nil
 	}
 	linkURL = resp.Request.URL.ResolveReference(linkURL)
+
+	// Validate that the pagination URL points to the same registry to prevent SSRF.
+	if err := validatePaginationURL(linkURL, repo); err != nil {
+		return nil, err
+	}
+
 	return linkURL, nil
+}
+
+// validatePaginationURL checks that a pagination URL is safe to follow.
+func validatePaginationURL(u *url.URL, repo name.Repository) error {
+	return validatePaginationURLHost(u, repo.Scheme(), repo.RegistryStr())
+}
+
+// validatePaginationURLHost checks that a pagination URL is safe to follow.
+func validatePaginationURLHost(u *url.URL, scheme, host string) error {
+	if u.Scheme != scheme {
+		return fmt.Errorf("pagination URL scheme %q does not match registry scheme %q", u.Scheme, scheme)
+	}
+	if u.Host != host {
+		return errors.New("pagination URL host does not match registry host: potential SSRF attack")
+	}
+	return nil
 }
 
 type Lister struct {
@@ -149,4 +173,38 @@ func (l *Lister) Next(ctx context.Context) (*Tags, error) {
 
 func (l *Lister) HasNext() bool {
 	return l.page != nil && (!l.needMore || l.page.Next != "")
+}
+
+// getNextPageURLForRegistry is like getNextPageURL but for name.Registry.
+func getNextPageURLForRegistry(resp *http.Response, reg name.Registry) (*url.URL, error) {
+	link := resp.Header.Get("Link")
+	if link == "" {
+		return nil, nil
+	}
+
+	if link[0] != '<' {
+		return nil, fmt.Errorf("failed to parse link header: missing '<' in: %s", link)
+	}
+
+	end := strings.Index(link, ">")
+	if end == -1 {
+		return nil, fmt.Errorf("failed to parse link header: missing '>' in: %s", link)
+	}
+	link = link[1:end]
+
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Request == nil || resp.Request.URL == nil {
+		return nil, nil
+	}
+	linkURL = resp.Request.URL.ResolveReference(linkURL)
+
+	// Validate that the pagination URL points to the same registry to prevent SSRF.
+	if err := validatePaginationURLHost(linkURL, reg.Scheme(), reg.RegistryStr()); err != nil {
+		return nil, err
+	}
+
+	return linkURL, nil
 }

--- a/pkg/v1/remote/list.go
+++ b/pkg/v1/remote/list.go
@@ -117,6 +117,9 @@ func getNextPageURL(resp *http.Response, repo name.Repository) (*url.URL, error)
 		return nil, fmt.Errorf("failed to parse link header: missing '>' in: %s", link)
 	}
 	link = link[1:end]
+	if link == "" {
+		return nil, nil
+	}
 
 	linkURL, err := url.Parse(link)
 	if err != nil {
@@ -191,6 +194,9 @@ func getNextPageURLForRegistry(resp *http.Response, reg name.Registry) (*url.URL
 		return nil, fmt.Errorf("failed to parse link header: missing '>' in: %s", link)
 	}
 	link = link[1:end]
+	if link == "" {
+		return nil, nil
+	}
 
 	linkURL, err := url.Parse(link)
 	if err != nil {

--- a/pkg/v1/remote/list_test.go
+++ b/pkg/v1/remote/list_test.go
@@ -140,11 +140,12 @@ func TestGetNextPageURL(t *testing.T) {
 		"",
 		"<",
 		"><",
+		"<>",
 		fmt.Sprintf("<%c>", 0x7f), // makes url.Parse fail
 	} {
 		u, err := getNextPageURL(makeResp(hdr), repo)
 		if err == nil && u != nil {
-			t.Errorf("Expected err for %q, got %+v", hdr, u)
+			t.Errorf("Expected err or nil URL for %q, got %+v", hdr, u)
 		}
 	}
 
@@ -170,5 +171,28 @@ func TestGetNextPageURL(t *testing.T) {
 	}
 	if u.Host != "example.com" {
 		t.Errorf("expected host to match request, got %s", u.Host)
+	}
+}
+
+func TestGetNextPageURL_SSRF(t *testing.T) {
+	repo, _ := name.NewRepository("registry.example.com/myrepo")
+
+	// Malicious registry returns Link header pointing to cloud metadata
+	malicious := &http.Response{
+		Header: http.Header{
+			"Link": []string{"<http://169.254.169.254/latest/meta-data/>;rel=\"next\""},
+		},
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "registry.example.com",
+				Path:   "/v2/myrepo/tags/list",
+			},
+		},
+	}
+
+	_, err := getNextPageURL(malicious, repo)
+	if err == nil {
+		t.Error("getNextPageURL should reject Link header pointing to cloud metadata endpoint")
 	}
 }

--- a/pkg/v1/remote/list_test.go
+++ b/pkg/v1/remote/list_test.go
@@ -121,39 +121,54 @@ func makeResp(hdr string) *http.Response {
 		Header: http.Header{
 			"Link": []string{hdr},
 		},
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+		},
 	}
 }
 
 func TestGetNextPageURL(t *testing.T) {
+	repo, err := name.NewRepository("example.com/myrepo")
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
+
 	for _, hdr := range []string{
 		"",
 		"<",
 		"><",
-		"<>",
 		fmt.Sprintf("<%c>", 0x7f), // makes url.Parse fail
 	} {
-		u, err := getNextPageURL(makeResp(hdr))
+		u, err := getNextPageURL(makeResp(hdr), repo)
 		if err == nil && u != nil {
-			t.Errorf("Expected err, got %+v", u)
+			t.Errorf("Expected err for %q, got %+v", hdr, u)
 		}
 	}
 
 	good := &http.Response{
 		Header: http.Header{
-			"Link": []string{"<example.com>"},
+			"Link": []string{"</v2/myrepo/tags/list?n=100>"},
 		},
 		Request: &http.Request{
 			URL: &url.URL{
 				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/v2/myrepo/tags/list",
 			},
 		},
 	}
-	u, err := getNextPageURL(good)
+	u, err := getNextPageURL(good, repo)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if u.Scheme != "https" {
 		t.Errorf("expected scheme to match request, got %s", u.Scheme)
+	}
+	if u.Host != "example.com" {
+		t.Errorf("expected host to match request, got %s", u.Host)
 	}
 }


### PR DESCRIPTION
Prevents SSRF attacks via malicious pagination Link headers in registry responses.

When listing tags or repositories, the library follows `Link` header URLs for pagination. A malicious registry can return a Link header pointing to internal services (e.g., cloud metadata at `169.254.169.254`), causing the client to make unintended requests.

This PR validates pagination URLs before following them:
- Scheme must match the registry's scheme (prevents HTTP downgrade)
- Host must match the registry's host (prevents redirect to arbitrary servers)

Fixes `google.List()`, `remote.List()`, and `remote.Catalog()`.