### PR TITLE
internal/gzip: fix goroutine leak in ReadCloserLevel

### DIFF
--- a/internal/gzip/zip.go
+++ b/internal/gzip/zip.go
@@ -51,32 +51,30 @@ func ReadCloserLevel(r io.ReadCloser, level int) io.ReadCloser {
 
 	// Returns err so we can pw.CloseWithError(err)
 	go func() error {
-		// TODO(go1.14): Just defer {pw,gw,r}.Close like you'd expect.
-		// Context: https://golang.org/issue/24283
+		// Always close the source reader when the goroutine exits,
+		// regardless of which error path is taken. This prevents
+		// resource leaks (e.g. pullLimiter token slots held by
+		// limitedReadCloser wrappers around r).
+		defer r.Close()
+
 		gw, err := gzip.NewWriterLevel(bw, level)
 		if err != nil {
 			return pw.CloseWithError(err)
 		}
+		defer gw.Close()
+		defer pw.Close()
 
 		if _, err := io.Copy(gw, r); err != nil {
-			defer r.Close()
-			defer gw.Close()
 			return pw.CloseWithError(err)
 		}
 
-		// Close gzip writer to Flush it and write gzip trailers.
 		if err := gw.Close(); err != nil {
 			return pw.CloseWithError(err)
 		}
 
-		// Flush bufio writer to ensure we write out everything.
 		if err := bw.Flush(); err != nil {
 			return pw.CloseWithError(err)
 		}
-
-		// We don't really care if these fail.
-		defer pw.Close()
-		defer r.Close()
 
 		return nil
 	}()


### PR DESCRIPTION
## Problem

`ReadCloserLevel` starts a goroutine that holds `r io.ReadCloser`. In several error paths (`gw.Close()`, `bw.Flush()`), the goroutine calls `pw.CloseWithError(err)` without ever calling `r.Close()`. When `r` wraps a `limitedReadCloser` (pullLimiter from #2271), the token slot is permanently leaked, eventually deadlocking under `layout.WriteImage`.

## Fix

Move `defer r.Close()` and `defer pw.Close()` to the top of the goroutine (resolving the existing `TODO(go1.14)` comment). Add `defer gw.Close()` after creation. This ensures resources are released on every exit path.

## Testing

`go build ./internal/gzip/` and `go test ./internal/gzip/` pass.

Fixes #2342