### PR TITLE
transport: do not re-attach bearer token after cross-host redirect

### DIFF
--- a/pkg/v1/remote/transport/bearer.go
+++ b/pkg/v1/remote/transport/bearer.go
@@ -247,11 +247,18 @@ func (bt *bearerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 		if err = bt.refresh(in.Context()); err != nil {
 			return nil, err
 		}
-		// Apply the freshly fetched token directly rather than calling
-		// sendRequest(), which only sets Authorization when in.URL.Host
-		// matches bt.registry. When the request followed a cross-host
-		// redirect the hosts differ and sendRequest() would omit the
-		// header, causing an unnecessary second 401.
+		// Re-attach the freshly fetched token, but only when the request is
+		// still talking to the registry we authenticated against. matchesHost
+		// guards against forwarding the Authorization header across an
+		// http.Client-level redirect to a different host: a malicious or
+		// compromised registry can 302 the request to an attacker-controlled
+		// host, answer the follow-up with a Bearer challenge, and harvest the
+		// token if we re-attach it unconditionally. For a cross-host request
+		// fall back to sendRequest(), which omits the credential, rather than
+		// leaking it to a host we never logged in to.
+		if !matchesHost(bt.registry.RegistryStr(), in, bt.scheme) {
+			return sendRequest()
+		}
 		bt.mx.RLock()
 		tok := bt.bearer.RegistryToken
 		bt.mx.RUnlock()

--- a/pkg/v1/remote/transport/bearer_test.go
+++ b/pkg/v1/remote/transport/bearer_test.go
@@ -698,41 +698,36 @@ func TestValidateRealmURLSameHost(t *testing.T) {
 	}
 }
 
-// TestBearerTokenAppliedAfterCrossHostRedirect is a regression test for
-// https://github.com/google/go-containerregistry/issues/2333.
-//
-// When an HTTP redirect sends the request to a host that differs from
-// bt.registry, the sendRequest() closure omits the Authorization header
-// (its matchesHost guard returns false). Previously, the post-401 retry
-// also went through sendRequest(), so the freshly refreshed token was
-// never applied and the request failed with a second 401.
-//
-// The fix skips sendRequest() after a successful refresh and sets the
-// Authorization header directly before retrying.
-func TestBearerTokenAppliedAfterCrossHostRedirect(t *testing.T) {
+// TestBearerTokenReappliedOnSameHostChallenge is the regression test for
+// https://github.com/google/go-containerregistry/issues/2333: when the
+// registry we authenticated against answers with a 401 Bearer challenge
+// (e.g. token expiry mid-session), the freshly refreshed token must be
+// applied to the retry so it succeeds rather than failing with a second 401.
+func TestBearerTokenReappliedOnSameHostChallenge(t *testing.T) {
 	const (
 		staleToken = "stale-token"
 		freshToken = "fresh-token"
 	)
 
 	attempts := 0
-	// registryServer simulates a registry reachable after a cross-host redirect.
-	// Its host intentionally differs from bt.registry ("registry.example.com").
 	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
 		if r.Header.Get("Authorization") == "Bearer "+freshToken {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		w.Header().Set("WWW-Authenticate", `Bearer realm="https://token.example.com/token",service="registry.example.com"`)
+		w.Header().Set("WWW-Authenticate", `Bearer realm="https://token.example.com/token",service="registry"`)
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer registryServer.Close()
 
-	// bt.registry is "registry.example.com", which does NOT match registryServer's host.
-	// This replicates what bearerTransport sees after an http.Client-level redirect:
-	// in.URL.Host is the redirected host, not bt.registry.
-	registry, err := name.NewRegistry("registry.example.com", name.WeakValidation)
+	// bt.registry IS the server's host, so matchesHost is true: this is the
+	// registry we authenticated against, and re-attaching the token is safe.
+	u, err := url.Parse(registryServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := name.NewRegistry(u.Host, name.WeakValidation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -746,7 +741,7 @@ func TestBearerTokenAppliedAfterCrossHostRedirect(t *testing.T) {
 		registry: registry,
 		realm:    "https://token.example.com/token",
 		scopes:   []string{"repo:example/image:pull"},
-		service:  "registry.example.com",
+		service:  "registry",
 		scheme:   "http",
 	}
 
@@ -757,12 +752,64 @@ func TestBearerTokenAppliedAfterCrossHostRedirect(t *testing.T) {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		t.Errorf("got status %d, want %d: fresh bearer token was not applied on cross-host retry", res.StatusCode, http.StatusOK)
+		t.Errorf("got status %d, want %d: fresh bearer token was not applied on same-host retry", res.StatusCode, http.StatusOK)
 	}
 	if got := bt.bearer.RegistryToken; got != freshToken {
 		t.Errorf("bearer.RegistryToken = %q, want %q", got, freshToken)
 	}
 	if attempts != 2 {
 		t.Errorf("registry received %d request(s), want 2 (401 then 200)", attempts)
+	}
+}
+
+// TestBearerTokenNotLeakedOnCrossHostChallenge verifies that when a request
+// has been redirected to a host that differs from the registry we logged in
+// to, the refreshed token is NOT re-attached. A malicious or compromised
+// registry must not be able to 302 the request to an attacker host, answer
+// with a Bearer challenge, and harvest the operator's registry credential.
+func TestBearerTokenNotLeakedOnCrossHostChallenge(t *testing.T) {
+	const (
+		staleToken = "stale-token"
+		freshToken = "fresh-token"
+	)
+
+	var gotAuth string
+	// attackerServer is NOT bt.registry. It issues a Bearer challenge and
+	// records any Authorization header it receives.
+	attackerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a := r.Header.Get("Authorization"); a != "" {
+			gotAuth = a
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer realm="https://token.example.com/token",service="attacker"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer attackerServer.Close()
+
+	registry, err := name.NewRegistry("registry.example.com", name.WeakValidation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bt := &bearerTransport{
+		inner:    http.DefaultTransport,
+		bearer:   authn.AuthConfig{RegistryToken: staleToken},
+		basic:    &authn.Bearer{Token: freshToken},
+		registry: registry, // does NOT match attackerServer's host
+		realm:    "https://token.example.com/token",
+		scopes:   []string{"repo:example/image:pull"},
+		service:  "registry.example.com",
+		scheme:   "http",
+	}
+
+	res, err := (&http.Client{Transport: bt}).Get(attackerServer.URL + "/v2/example/image/manifests/latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer res.Body.Close()
+
+	if gotAuth != "" {
+		t.Fatalf("credential leaked to cross-host challenger: Authorization=%q", gotAuth)
 	}
 }


### PR DESCRIPTION
## Summary

`bearerTransport.RoundTrip` re-attaches the registry bearer token on its post-401 retry without checking that the request is still talking to the registry we authenticated against.

PR #2337 replaced the post-`bt.refresh()` `return sendRequest()` with an unconditional `in.Header.Set("Authorization", ...)` + `bt.inner.RoundTrip(in)`, intentionally bypassing the `matchesHost` guard. That guard exists to keep the `Authorization` header from being forwarded across an `http.Client`-level redirect to a different host.

With the guard bypassed, the credential leaks across a cross-host redirect:

1. A pull is issued against a registry; the transport seeds a bearer token from the trusted realm.
2. The registry answers the manifest/blob GET with a `302` to a *different* host. `checkRedirectSSRF` (pkg/v1/remote/fetcher.go) allows it for any public host or DNS name (it only blocks private/link-local IP literals).
3. `RoundTrip` re-runs for the redirected host. The first `sendRequest()` correctly omits `Authorization` (host mismatch). The redirected host replies `401` with a Bearer challenge.
4. `RoundTrip` refreshes the token from the trusted realm and, after #2337, sets `Authorization: Bearer <token>` unconditionally and sends it to the redirected host.

A registry the client did not authenticate against (a malicious/compromised peer, or a MITM on insecure transport) thus receives the operator's registry token.

## Fix

Gate the re-attach on `matchesHost`: only apply the refreshed token when the request is still on the registry host we logged in to; otherwise fall back to `sendRequest()` (which omits the credential). This preserves the #2333 behavior for same-host 401 retries (e.g. token expiry mid-session) and closes the cross-host credential leak.

## Changes

- `pkg/v1/remote/transport/bearer.go` — guard the post-refresh re-attach with `matchesHost`.
- `pkg/v1/remote/transport/bearer_test.go` — `TestBearerTokenReappliedOnSameHostChallenge` (the #2333 same-host retry still works) and `TestBearerTokenNotLeakedOnCrossHostChallenge` (token is not sent to a cross-host challenger).

## Test plan

- [x] `go test ./pkg/v1/remote/...` passes (existing tests + both new tests).
- [x] Reverting the guard makes `TestBearerTokenNotLeakedOnCrossHostChallenge` fail (the credential is forwarded), confirming the test catches the regression.