### PR TITLE
build(deps): bump golang.org/x/crypto

### DIFF
--- a/cmd/krane/go.mod
+++ b/cmd/krane/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/pkg/authn/k8schain/go.mod
+++ b/pkg/authn/k8schain/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect


### PR DESCRIPTION
Fixes multiple CVEs

None of the listed CVEs affect `golang.org/x/net`. They all affect `golang.org/x/crypto` and are fixed in version `v0.52.0`.

| CVE | Module | Affected Versions | Fixed Version | Advisory |
|------|--------|-------------------|---------------|----------|
| CVE-2026-39827 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-39827 |
| CVE-2026-39828 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-39828 |
| CVE-2026-39829 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-39829 |
| CVE-2026-39830 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-39830 |
| CVE-2026-39831 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://pkg.go.dev/vuln/GO-2026-39831 |
| CVE-2026-39832 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://pkg.go.dev/vuln/GO-2026-39832 |
| CVE-2026-39833 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://pkg.go.dev/vuln/GO-2026-39833 |
| CVE-2026-39834 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-39834 |
| CVE-2026-39835 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://pkg.go.dev/vuln/GO-2026-39835 |
| CVE-2026-42508 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://advisories.gitlab.com/pkg/golang/golang.org/x/crypto/CVE-2026-42508/ |
| CVE-2026-46595 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-46595 |
| CVE-2026-46597 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://pkg.go.dev/vuln/GO-2026-46597 |
| CVE-2026-46598 | `golang.org/x/crypto` | `< 0.52.0` | `0.52.0` | https://nvd.nist.gov/vuln/detail/CVE-2026-46598 |