### PR TITLE
authn: read Podman auth from XDG config

### DIFF
--- a/pkg/authn/keychain.go
+++ b/pkg/authn/keychain.go
@@ -102,11 +102,19 @@ func (dk *defaultKeychain) ResolveContext(_ context.Context, target Resource) (A
 	if !foundDockerConfig && os.Getenv("DOCKER_CONFIG") != "" {
 		foundDockerConfig = fileExists(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json"))
 	}
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if configDir == "" && home != "" {
+		configDir = filepath.Join(home, ".config")
+	}
+	podmanAuth := filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json")
+	if (os.Getenv("XDG_RUNTIME_DIR") == "" || !fileExists(podmanAuth)) && configDir != "" {
+		podmanAuth = filepath.Join(configDir, "containers/auth.json")
+	}
 	// If either of those locations are found, load it using Docker's
 	// config.Load, which may fail if the config can't be parsed.
 	//
 	// If neither was found, look for Podman's auth at
-	// $REGISTRY_AUTH_FILE or $XDG_RUNTIME_DIR/containers/auth.json
+	// $REGISTRY_AUTH_FILE or containers/auth.json under XDG runtime/config dirs
 	// and attempt to load it as a Docker config.
 	//
 	// If neither are found, fallback to Anonymous.
@@ -126,7 +134,7 @@ func (dk *defaultKeychain) ResolveContext(_ context.Context, target Resource) (A
 		if err != nil {
 			return nil, err
 		}
-	} else if path := filepath.Clean(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json")); fileExists(path) {
+	} else if path := filepath.Clean(podmanAuth); fileExists(path) {
 		f, err := os.Open(path)
 		if err != nil {
 			return nil, err

--- a/pkg/authn/keychain_test.go
+++ b/pkg/authn/keychain_test.go
@@ -117,6 +117,11 @@ func TestPodmanConfig(t *testing.T) {
 	writeConfig(t, filepath.Join(p, "containers"), "auth.json",
 		fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`,
 			encode("XDG_RUNTIME_DIR-foo", "XDG_RUNTIME_DIR-bar")))
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	writeConfig(t, filepath.Join(configDir, "containers"), "auth.json",
+		fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`,
+			encode("XDG_CONFIG_HOME-foo", "XDG_CONFIG_HOME-bar")))
 	auth, err := DefaultKeychain.Resolve(testRegistry)
 	if err != nil {
 		t.Fatalf("Resolve() = %v", err)
@@ -195,6 +200,64 @@ func TestPodmanConfig(t *testing.T) {
 	want = &AuthConfig{
 		Username: "another-foo",
 		Password: "another-bar",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestPodmanConfigXDGConfigHome(t *testing.T) {
+	t.Setenv("DOCKER_CONFIG", "")
+	t.Setenv("REGISTRY_AUTH_FILE", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	writeConfig(t, filepath.Join(configDir, "containers"), "auth.json",
+		fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`,
+			encode("XDG_CONFIG_HOME-foo", "XDG_CONFIG_HOME-bar")))
+
+	auth, err := DefaultKeychain.Resolve(testRegistry)
+	if err != nil {
+		t.Fatalf("Resolve() = %v", err)
+	}
+	got, err := auth.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &AuthConfig{
+		Username: "XDG_CONFIG_HOME-foo",
+		Password: "XDG_CONFIG_HOME-bar",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestPodmanConfigHomeConfig(t *testing.T) {
+	t.Setenv("DOCKER_CONFIG", "")
+	t.Setenv("REGISTRY_AUTH_FILE", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeConfig(t, filepath.Join(home, ".config/containers"), "auth.json",
+		fmt.Sprintf(`{"auths": {"test.io": {"auth": %q}}}`,
+			encode("home-config-foo", "home-config-bar")))
+
+	auth, err := DefaultKeychain.Resolve(testRegistry)
+	if err != nil {
+		t.Fatalf("Resolve() = %v", err)
+	}
+	got, err := auth.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &AuthConfig{
+		Username: "home-config-foo",
+		Password: "home-config-bar",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %+v, want %+v", got, want)


### PR DESCRIPTION
## Summary

- read Podman credentials from `$XDG_CONFIG_HOME/containers/auth.json` when no runtime auth file exists
- fall back to `$HOME/.config/containers/auth.json` when `XDG_CONFIG_HOME` is unset
- preserve the existing precedence of runtime credentials over config credentials

Fixes #1516

## Testing

- `go test -mod=vendor ./pkg/authn -run '^TestPodmanConfig(XDGConfigHome|HomeConfig)?$' -count=1`
- `go test -race ./pkg/authn -count=1`
- `go test -race ./...`
- `./hack/presubmit.sh`
- `go run golang.org/x/tools/cmd/goimports@v0.48.0 -d pkg/authn/keychain.go pkg/authn/keychain_test.go`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run`
