### PR TITLE
mutate: don't reject the rootfs root ("./") as an unsafe tar path

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -316,6 +316,11 @@ func extractLayer(tarWriter *tar.Writer, fileMap, opaqueDirs map[string]bool, la
 		// Some tools prepend everything with "./", so if we don't Clean the
 		// name, we may have duplicate entries, which angers tar-split.
 		header.Name = path.Clean(header.Name)
+		// The rootfs root (a "./" or empty-name entry, both of which Clean to ".")
+		// is implicit; skip it rather than emit a redundant entry.
+		if header.Name == "." {
+			continue
+		}
 		if unsafeArchivePath(header.Name) {
 			return fmt.Errorf("unsafe tar path %q", header.Name)
 		}
@@ -437,7 +442,7 @@ func inWhiteoutDir(fileMap map[string]bool, file string) bool {
 
 func unsafeArchivePath(name string) bool {
 	clean := cleanArchivePath(name)
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+	if clean == ".." || strings.HasPrefix(clean, "../") {
 		return true
 	}
 	if strings.HasPrefix(name, "\\") {

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -898,6 +898,51 @@ func TestExtractRejectsUnsafeArchivePaths(t *testing.T) {
 	}
 }
 
+func TestExtractSkipsRootDirEntry(t *testing.T) {
+	// A layer whose entries include the rootfs root ("./") -- as gcr.io/distroless
+	// base images ship -- must extract cleanly, not be rejected as an unsafe path.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, hdr := range []*tar.Header{
+		{Name: "./", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "etc/hello", Typeflag: tar.TypeReg, Mode: 0o644, Size: 5},
+	} {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte("world")); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+
+	img := imageFromTarBytes(t, buf.Bytes())
+
+	names := map[string]bool{}
+	tr := tar.NewReader(mutate.Extract(img))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading extracted tar: %v", err)
+		}
+		names[hdr.Name] = true
+	}
+
+	if names["."] {
+		t.Error(`extracted tar contains a redundant root-dir entry "."`)
+	}
+	if !names["etc/hello"] {
+		t.Error("extracted tar is missing the real file etc/hello")
+	}
+}
+
 func TestCanonical(t *testing.T) {
 	source := sourceImage(t)
 	img, err := mutate.Canonical(source)


### PR DESCRIPTION
Extract rejected any layer entry whose path cleaned to "." as an "unsafe tar path". Unlike ".." / "../…", a "." entry does not escape the extraction root -- it *is* the root -- so rejecting it serves no security purpose. It does, however, break real images: gcr.io/distroless base images (and everything built on them) ship a standalone "./" layer entry, so Extract, crane export, and crane flatten all fail on them with `unsafe tar path "."`.

Drop "." from unsafeArchivePath (keeping ".." and "../"), and skip the redundant root entry in extractLayer instead of writing it, mirroring how whiteout and duplicate entries are already skipped. Empty-name entries, which also clean to ".", are skipped the same way.