### PR TITLE
fix: remove '.' from unsafe path prefixes

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -437,7 +437,7 @@ func inWhiteoutDir(fileMap map[string]bool, file string) bool {
 
 func unsafeArchivePath(name string) bool {
 	clean := cleanArchivePath(name)
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+	if clean == ".." || strings.HasPrefix(clean, "../") {
 		return true
 	}
 	if strings.HasPrefix(name, "\\") {

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -876,23 +876,33 @@ func TestExtractSymlinkFiltering(t *testing.T) {
 }
 
 func TestExtractRejectsUnsafeArchivePaths(t *testing.T) {
-	for _, name := range []string{
-		"../tmp/evil",
-		`..\..\tmp\evil`,
-		`\tmp\evil`,
-		`C:\tmp\evil`,
-		"C:/tmp/evil",
-		`C:..\evil`,
-	} {
-		t.Run(name, func(t *testing.T) {
-			img := imageFromTarBytes(t, makeTarBytes(t, name, "bad"))
+	entries := []struct {
+		path    string
+		wantErr bool
+	}{
+		{path: ".", wantErr: false},
+		{path: "tmp/safe", wantErr: false},
+		{path: "../tmp/evil", wantErr: true},
+		{path: `..\..\tmp\evil`, wantErr: true},
+		{path: `\tmp\evil`, wantErr: true},
+		{path: `C:\tmp\evil`, wantErr: true},
+		{path: "C:/tmp/evil", wantErr: true},
+		{path: `C:..\evil`, wantErr: true},
+	}
+	for _, tc := range entries {
+		t.Run(tc.path, func(t *testing.T) {
+			img := imageFromTarBytes(t, makeTarBytes(t, tc.path, "data"))
 
 			_, err := io.Copy(io.Discard, mutate.Extract(img))
-			if err == nil {
-				t.Fatal("Extract accepted an unsafe archive path")
-			}
-			if !strings.Contains(err.Error(), "unsafe tar path") {
-				t.Fatalf("Extract error = %v, want unsafe tar path error", err)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("Extract accepted an unsafe archive path")
+				}
+				if !strings.Contains(err.Error(), "unsafe tar path") {
+					t.Errorf("Extract error = %v, want unsafe tar path error", err)
+				}
+			} else if err != nil {
+				t.Errorf("Extract error = %v, want nil", err)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #2399