### PR TITLE
crane mutate: preserve cmd when setting entrypoint

### DIFF
--- a/cmd/crane/cmd/mutate.go
+++ b/cmd/crane/cmd/mutate.go
@@ -103,8 +103,7 @@ func NewCmdMutate(options *[]crane.Option) *cobra.Command {
 
 			// Set entrypoint.
 			if len(entrypoint) > 0 {
-				cfg.Config.Entrypoint = entrypoint
-				cfg.Config.Cmd = nil // This matches Docker's behavior.
+				setEntrypoint(cfg, entrypoint)
 			}
 
 			// Set cmd.
@@ -209,6 +208,10 @@ func validateKeyVals(kvPairs map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func setEntrypoint(cfg *v1.ConfigFile, entrypoint []string) {
+	cfg.Config.Entrypoint = entrypoint
 }
 
 // setEnvVars override envvars in a config

--- a/cmd/crane/cmd/mutate_test.go
+++ b/cmd/crane/cmd/mutate_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestSetEntrypointPreservesCmd(t *testing.T) {
+	cfg := &v1.ConfigFile{}
+	cfg.Config.Cmd = []string{"--listen=:8080"}
+
+	setEntrypoint(cfg, []string{"server"})
+
+	if got, want := cfg.Config.Entrypoint, []string{"server"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Entrypoint = %v, want %v", got, want)
+	}
+	if got, want := cfg.Config.Cmd, []string{"--listen=:8080"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Cmd = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #2041

`crane mutate --entrypoint` should preserve an existing image `Cmd`. Setting an image entrypoint does not discard its default arguments; only an explicitly supplied `--cmd` should replace them.

Add regression coverage for preserving `Cmd` while setting `Entrypoint`.

Tests:
- `go test ./cmd/crane/cmd -run ^TestSetEntrypointPreservesCmd -count=1`
- `go test ./cmd/crane/cmd ./pkg/v1/mutate`
- `./hack/presubmit.sh` *(blocked by pre-existing `pkg/name/internal` build-constraint failure and missing `registry` command in `cmd/crane/rebase_test.sh`)*