### PR TITLE
mutate: let Time and Canonical take tarball.LayerOption

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-containerregistry/internal/gzip"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/match"
@@ -469,7 +468,8 @@ func hasWindowsDrivePrefix(name string) bool {
 }
 
 // Time sets all timestamps in an image to the given timestamp.
-func Time(img v1.Image, t time.Time) (v1.Image, error) {
+// Layers are rewritten as dockerv2+gzip unless opts say otherwise.
+func Time(img v1.Image, t time.Time, opts ...tarball.LayerOption) (v1.Image, error) {
 	newImage := empty.Image
 
 	layers, err := img.Layers()
@@ -485,7 +485,7 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 	addendums := make([]Addendum, max(len(ocf.History), len(layers)))
 	var historyIdx, addendumIdx int
 	for layerIdx := 0; layerIdx < len(layers); addendumIdx, layerIdx = addendumIdx+1, layerIdx+1 {
-		newLayer, err := layerTime(layers[layerIdx], t)
+		newLayer, err := layerTime(layers[layerIdx], t, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("setting layer times: %w", err)
 		}
@@ -547,7 +547,7 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 	return ConfigFile(newImage, cfg)
 }
 
-func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
+func layerTime(layer v1.Layer, t time.Time, opts ...tarball.LayerOption) (v1.Layer, error) {
 	layerReader, err := layer.Uncompressed()
 	if err != nil {
 		return nil, fmt.Errorf("getting layer: %w", err)
@@ -598,11 +598,10 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 	}
 
 	b := w.Bytes()
-	// gzip the contents, then create the layer
 	opener := func() (io.ReadCloser, error) {
-		return gzip.ReadCloser(io.NopCloser(bytes.NewReader(b))), nil
+		return io.NopCloser(bytes.NewReader(b)), nil
 	}
-	layer, err = tarball.LayerFromOpener(opener)
+	layer, err = tarball.LayerFromOpener(opener, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating layer: %w", err)
 	}
@@ -612,10 +611,10 @@ func layerTime(layer v1.Layer, t time.Time) (v1.Layer, error) {
 
 // Canonical is a helper function to combine Time and configFile
 // to remove any randomness during a docker build.
-func Canonical(img v1.Image) (v1.Image, error) {
+func Canonical(img v1.Image, opts ...tarball.LayerOption) (v1.Image, error) {
 	// Set all timestamps to 0
 	created := time.Time{}
-	img, err := Time(img, created)
+	img, err := Time(img, created, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/internal/verify"
+	"github.com/google/go-containerregistry/pkg/compression"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/match"
@@ -1490,4 +1491,84 @@ func TestTimeVerifiesLayerDigest(t *testing.T) {
 			t.Fatalf("Time of honest layer failed: %v", err)
 		}
 	})
+}
+
+func canonicalSource(t *testing.T, layerMT types.MediaType, comp compression.Compression) v1.Image {
+	t.Helper()
+	b := makeTarBytes(t, "app/hello.txt", "hello world")
+	l, err := tarball.LayerFromOpener(
+		func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(b)), nil },
+		tarball.WithMediaType(layerMT), tarball.WithCompression(comp),
+	)
+	if err != nil {
+		t.Fatalf("LayerFromOpener: %v", err)
+	}
+	img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: l})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	return img
+}
+
+func canonicalLayer(t *testing.T, img v1.Image, opts ...tarball.LayerOption) (types.MediaType, []byte) {
+	t.Helper()
+	got, err := mutate.Canonical(img, opts...)
+	if err != nil {
+		t.Fatalf("Canonical: %v", err)
+	}
+	man, err := got.Manifest()
+	if err != nil {
+		t.Fatalf("Manifest: %v", err)
+	}
+	layers, err := got.Layers()
+	if err != nil {
+		t.Fatalf("Layers: %v", err)
+	}
+	rc, err := layers[0].Compressed()
+	if err != nil {
+		t.Fatalf("Compressed: %v", err)
+	}
+	defer rc.Close()
+	magic := make([]byte, 4)
+	if _, err := io.ReadFull(rc, magic); err != nil {
+		t.Fatalf("reading blob magic: %v", err)
+	}
+	return man.Layers[0].MediaType, magic
+}
+
+func TestCanonicalDefaultsToDockerGzip(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		layerMT types.MediaType
+		comp    compression.Compression
+	}{
+		{"docker gzip source", types.DockerLayer, compression.GZip},
+		{"oci gzip source", types.OCILayer, compression.GZip},
+		{"oci zstd source", types.OCILayerZStd, compression.ZStd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mt, magic := canonicalLayer(t, canonicalSource(t, tc.layerMT, tc.comp))
+			if mt != types.DockerLayer {
+				t.Errorf("layer media type = %q, want %q", mt, types.DockerLayer)
+			}
+			if magic[0] != 0x1f || magic[1] != 0x8b {
+				t.Errorf("blob magic = %x, want gzip", magic)
+			}
+		})
+	}
+}
+
+func TestCanonicalLayerOptions(t *testing.T) {
+	img := canonicalSource(t, types.DockerLayer, compression.GZip)
+
+	mt, magic := canonicalLayer(t, img,
+		tarball.WithMediaType(types.OCILayerZStd),
+		tarball.WithCompression(compression.ZStd),
+	)
+	if mt != types.OCILayerZStd {
+		t.Errorf("layer media type = %q, want %q", mt, types.OCILayerZStd)
+	}
+	if !bytes.Equal(magic, []byte{0x28, 0xb5, 0x2f, 0xfd}) {
+		t.Errorf("blob magic = %x, want zstd", magic)
+	}
 }


### PR DESCRIPTION
`Time` rebuilds the image onto `empty.Image` and re-tars every layer, so every layer gets compressed again. `layerTime` always gzips and calls `tarball.LayerFromOpener` with no options, so a rebuilt layer is always a `types.DockerLayer`. An OCI image comes back as docker schema2 and a zstd layer is silently downgraded to gzip. `Canonical` inherits both.

This threads `tarball.LayerOption` through to `LayerFromOpener` and hands the opener the uncompressed tar instead of pre-gzipping it. The layer is then compressed once, in the codec the caller asked for. Pair it with the existing `mutate.MediaType` and `mutate.ConfigMediaType` to bring the manifest and config along.

The options are variadic so existing call sites are unaffected, and with none passed the output is byte identical to before. I checked that across docker and oci, gzip and zstd, uncompressed, foreign and multi layer images. One incompatibility remains, `Time` and `Canonical` can no longer be assigned to a `func(v1.Image) (v1.Image, error)` variable.
