### PR TITLE
remote: retry failed Puller and Pusher initialization

### DIFF
--- a/pkg/v1/remote/puller.go
+++ b/pkg/v1/remote/puller.go
@@ -76,7 +76,11 @@ func (p *Puller) fetcher(ctx context.Context, target resource) (*fetcher, error)
 		o:      p.o,
 	})
 	rr := v.(*reader)
-	return rr.f, rr.init(ctx)
+	if err := rr.init(ctx); err != nil {
+		p.readers.CompareAndDelete(target, rr)
+		return nil, err
+	}
+	return rr.f, nil
 }
 
 // Head is like remote.Head, but avoids re-authenticating when possible.

--- a/pkg/v1/remote/puller_pusher_test.go
+++ b/pkg/v1/remote/puller_pusher_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/v1/remote/puller_pusher_test.go
+++ b/pkg/v1/remote/puller_pusher_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+)
+
+func TestPullerRetriesFailedInitialization(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	ref := registryReference(t, s.URL)
+	if err := Write(ref, empty.Image); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+
+	puller, err := NewPuller()
+	if err != nil {
+		t.Fatalf("NewPuller() = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := puller.Head(ctx, ref); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Head() = %v, want context.Canceled", err)
+	}
+
+	if _, err := puller.Head(context.Background(), ref); err != nil {
+		t.Fatalf("Head() after canceled initialization = %v", err)
+	}
+}
+
+func TestPusherRetriesFailedInitialization(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	ref := registryReference(t, s.URL)
+	pusher, err := NewPusher()
+	if err != nil {
+		t.Fatalf("NewPusher() = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := pusher.Push(ctx, ref, empty.Image); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Push() = %v, want context.Canceled", err)
+	}
+
+	if err := pusher.Push(context.Background(), ref, empty.Image); err != nil {
+		t.Fatalf("Push() after canceled initialization = %v", err)
+	}
+}
+
+func registryReference(t *testing.T, registryURL string) name.Reference {
+	t.Helper()
+	u, err := url.Parse(registryURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) = %v", registryURL, err)
+	}
+	ref, err := name.NewTag(fmt.Sprintf("%s/retry/init:latest", u.Host))
+	if err != nil {
+		t.Fatalf("name.NewTag() = %v", err)
+	}
+	return ref
+}

--- a/pkg/v1/remote/pusher.go
+++ b/pkg/v1/remote/pusher.go
@@ -122,7 +122,11 @@ func (p *Pusher) writer(ctx context.Context, repo name.Repository, o *options) (
 		o:    o,
 	})
 	rw := v.(*repoWriter)
-	return rw, rw.init(ctx)
+	if err := rw.init(ctx); err != nil {
+		p.writers.CompareAndDelete(repo, rw)
+		return nil, err
+	}
+	return rw, nil
 }
 
 func (p *Pusher) Put(ctx context.Context, ref name.Reference, t Taggable) error {


### PR DESCRIPTION
A failed Puller or Pusher initialization is retained by sync.Once, so a transient context, authentication, or transport error poisons the reusable client.

Delete only the failed cached reader or writer with CompareAndDelete, allowing the next request to initialize it again without removing a concurrent replacement. This adds retry regressions for both paths.

Fixes #2060

Tests:
- ./hack/presubmit.sh
- go test -race ./pkg/v1/remote -count=1