### PR TITLE
Allow single-character repository paths

### DIFF
--- a/pkg/name/repository.go
+++ b/pkg/name/repository.go
@@ -72,7 +72,7 @@ func (r Repository) Scope(action string) string {
 }
 
 func checkRepository(repository string) error {
-	return checkElement("repository", repository, repositoryChars, 2, 255)
+	return checkElement("repository", repository, repositoryChars, 1, 255)
 }
 
 // NewRepository returns a new Repository representing the given name, according to the given strictness.

--- a/pkg/name/repository_test.go
+++ b/pkg/name/repository_test.go
@@ -27,12 +27,19 @@ var goodStrictValidationRepositoryNames = []string{
 	"example.text/foo/bar",
 	"mirror.gcr.io/ubuntu",
 	"index.docker.io/library/ubuntu",
+	// A path component may be a single character:
+	// path-component := alpha-numeric [separator alpha-numeric]*
+	// alpha-numeric  := /[a-z0-9]+/
+	"example.com/a",
+	"example.com/a/b",
 }
 
 var goodWeakValidationRepositoryNames = []string{
 	"namespace/pathcomponent/image",
 	"library/ubuntu",
 	"ubuntu",
+	"a",
+	"0",
 }
 
 var badRepositoryNames = []string{


### PR DESCRIPTION
`checkRepository` requires at least two characters, so a repository whose path is a single character cannot be parsed — even though the spec allows it and registries serve it.

### The reference is valid, and everything else accepts it

The [distribution spec's](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) grammar for a repository name is

```
[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*
```

`[a-z0-9]+` is one *or more*, so `a` is a valid path component. `distribution/reference` parses `example.com/a` into domain `example.com`, path `a`.

Against a local `registry:2` with an image pushed by docker as `127.0.0.1:5555/a:v1`:

```console
$ curl -s http://127.0.0.1:5555/v2/_catalog
{"repositories":["a"]}
$ curl -s http://127.0.0.1:5555/v2/a/tags/list
{"name":"a","tags":["v1"]}

$ crane ls 127.0.0.1:5555/a
Error: parsing repo "127.0.0.1:5555/a": repository must be between 2 and 255 characters in length: a
$ crane digest 127.0.0.1:5555/a:v1
Error: parsing reference "127.0.0.1:5555/a:v1": could not parse reference: 127.0.0.1:5555/a:v1
```

`docker push` and `docker pull` both round-trip that name; only this library refuses it, and it refuses at parse time, so every consumer — crane, ko, kaniko, cosign, skaffold — is cut off from the image.

With this change:

```console
$ crane ls 127.0.0.1:5555/a
v1
$ crane digest 127.0.0.1:5555/a:v1
sha256:45e09956dc667c5eff3583c9d94830261fb1ca0be10a0a7db36266edf5de9e1d
```

which is the digest `docker push` reported for the same image.

### Why the minimum isn't load-bearing

It reads like a guard against degenerate names, but it isn't one — the current release accepts all of these:

```
--        ..        __        //        -.
example.com/--      example.com/..      example.com///
```

So two-character garbage passes today; the floor only excluded the single-character subset of exactly the same class, and took every valid single-character repository with it. Character-level validation is unchanged by this PR, and the existing `TODO(dekkagaijin): use the docker/distribution regexes for validation` still describes the way to tighten the whole class properly. `checkTag` already uses a minimum of 1; the repository was the only element with a 2.

### What changes, exactly

I ran 10,133 generated references — hosts (none, docker.io, localhost, ports, IPv6, uppercase), paths (1…256 chars, separators, mixed case), and suffixes (tags, digests, both) — through `ParseReference` before and after:

| | |
|---|---|
| inputs | 10,133 |
| results that change | 225 |
| direction | every one of them `error` → parses; nothing that parsed before stops parsing |
| single-character alphanumeric repositories (the point of the change) | 216 |
| single-character `-`, `.`, `_`, `/` | 9 |

The 9 are the degenerate class quoted above, now consistent with their two-character forms rather than singled out by length. Nothing else moves.

### Tests

`example.com/a`, `example.com/a/b`, `a` and `0` are added to the existing fixtures. They are not vacuous — with the `2` restored, the suite fails:

```
--- FAIL: TestNewRepositoryStrictValidation
    repository_test.go:56: `example.com/a` should be a valid Repository name,
        got error: repository must be between 2 and 255 characters in length: a
--- FAIL: TestNewRepository
    repository_test.go:74: `example.com/a` should be a valid repository name, ...
```

`go test ./...` is green across all 37 packages.
