### PR TITLE
validate: check artifact manifests structurally instead of as images

### DIFF
--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -56,6 +56,9 @@ func computeDescriptor(ia IndexAddendum) (*v1.Descriptor, error) {
 	if ia.Data != nil {
 		desc.Data = ia.Data
 	}
+	if ia.ArtifactType != "" {
+		desc.ArtifactType = ia.ArtifactType
+	}
 
 	return desc, nil
 }

--- a/pkg/v1/validate/artifact.go
+++ b/pkg/v1/validate/artifact.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// isArtifact reports whether img is an artifact manifest rather than an
+// image, e.g. a BuildKit SBOM/provenance attestation, which uses the OCI
+// empty descriptor ({}) as its config.
+func isArtifact(img v1.Image) (bool, error) {
+	m, err := img.Manifest()
+	if err != nil {
+		return false, err
+	}
+	if m.ArtifactType != "" {
+		return true, nil
+	}
+	return m.Config.MediaType != "" && !m.Config.MediaType.IsConfig(), nil
+}
+
+// validateArtifact checks the structural integrity of an artifact manifest:
+// the manifest, config blob, and layer blobs must exist and match their
+// declared digests and sizes. Image invariants (rootfs type, diff_ids,
+// platform) do not apply to artifacts and are not checked.
+func validateArtifact(img v1.Image, opt ...Option) error {
+	errs := []string{}
+	if err := validateManifest(img); err != nil {
+		errs = append(errs, fmt.Sprintf("validating manifest: %v", err))
+	}
+
+	if err := validateArtifactConfig(img); err != nil {
+		errs = append(errs, fmt.Sprintf("validating config: %v", err))
+	}
+
+	if err := validateArtifactLayers(img, opt...); err != nil {
+		errs = append(errs, fmt.Sprintf("validating layers: %v", err))
+	}
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n\n"))
+	}
+	return nil
+}
+
+func validateArtifactConfig(img v1.Image) error {
+	rc, err := img.RawConfigFile()
+	if err != nil {
+		return err
+	}
+
+	hash, size, err := v1.SHA256(bytes.NewReader(rc))
+	if err != nil {
+		return err
+	}
+
+	m, err := img.Manifest()
+	if err != nil {
+		return err
+	}
+
+	errs := []string{}
+	if m.Config.Digest != hash {
+		errs = append(errs, fmt.Sprintf("mismatched config digest: Manifest.Config.Digest=%s, SHA256(RawConfigFile())=%s", m.Config.Digest, hash))
+	}
+
+	if m.Config.Size != size {
+		errs = append(errs, fmt.Sprintf("mismatched config size: Manifest.Config.Size=%d, len(RawConfigFile())=%d", m.Config.Size, size))
+	}
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func validateArtifactLayers(img v1.Image, opt ...Option) error {
+	o := makeOptions(opt...)
+
+	layers, err := img.Layers()
+	if err != nil {
+		return err
+	}
+
+	if o.fast {
+		return layersExist(layers)
+	}
+
+	m, err := img.Manifest()
+	if err != nil {
+		return err
+	}
+
+	errs := []string{}
+	for i, layer := range layers {
+		rc, err := layer.Compressed()
+		if err != nil {
+			return err
+		}
+		digest, size, err := v1.SHA256(rc)
+		rc.Close()
+		if err != nil {
+			return err
+		}
+
+		if m.Layers[i].Digest != digest {
+			errs = append(errs, fmt.Sprintf("mismatched layer[%d] digest: Manifest.Layers[%d].Digest=%s, SHA256(Compressed())=%s", i, i, m.Layers[i].Digest, digest))
+		}
+
+		if m.Layers[i].Size != size {
+			errs = append(errs, fmt.Sprintf("mismatched layer[%d] size: Manifest.Layers[%d].Size=%d, len(Compressed())=%d", i, i, m.Layers[i].Size, size))
+		}
+	}
+
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
+}

--- a/pkg/v1/validate/image.go
+++ b/pkg/v1/validate/image.go
@@ -114,10 +114,12 @@ func validateLayers(img v1.Image, opt ...Option) error {
 		return layersExist(layers)
 	}
 
-	digests := []v1.Hash{}
-	diffids := []v1.Hash{}
-	udiffids := []v1.Hash{}
-	sizes := []int64{}
+	// Indexed by position in layers so that skipped (non-layer) entries do
+	// not shift later layers onto the wrong index.
+	digests := make([]v1.Hash, len(layers))
+	diffids := make([]v1.Hash, len(layers))
+	udiffids := make([]v1.Hash, len(layers))
+	sizes := make([]int64, len(layers))
 	for i, layer := range layers {
 		if mt, err := layer.MediaType(); err != nil {
 			return fmt.Errorf("getting mediaType[%d]: %w", i, err)
@@ -141,10 +143,10 @@ func validateLayers(img v1.Image, opt ...Option) error {
 		}
 		// Compute all of these first before we call Config() and Manifest() to allow
 		// for lazy access e.g. for stream.Layer.
-		digests = append(digests, cl.digest)
-		diffids = append(diffids, cl.diffid)
-		udiffids = append(udiffids, cl.uncompressedDiffid)
-		sizes = append(sizes, cl.size)
+		digests[i] = cl.digest
+		diffids[i] = cl.diffid
+		udiffids[i] = cl.uncompressedDiffid
+		sizes[i] = cl.size
 	}
 
 	cf, err := img.ConfigFile()
@@ -204,7 +206,9 @@ func validateLayers(img v1.Image, opt ...Option) error {
 			errs = append(errs, fmt.Sprintf("mismatched layer[%d] diffid: DiffID()=%s, SHA256(Uncompressed())=%s", i, diffid, udiffids[i]))
 		}
 
-		if cf.RootFS.DiffIDs[i] != diffids[i] {
+		if i >= len(cf.RootFS.DiffIDs) {
+			errs = append(errs, fmt.Sprintf("missing layer[%d] diffid: len(ConfigFile.RootFS.DiffIDs)=%d", i, len(cf.RootFS.DiffIDs)))
+		} else if cf.RootFS.DiffIDs[i] != diffids[i] {
 			errs = append(errs, fmt.Sprintf("mismatched layer[%d] diffid: ConfigFile.RootFS.DiffIDs[%d]=%s, SHA256(Gunzip(Compressed()))=%s", i, i, cf.RootFS.DiffIDs[i], diffids[i]))
 		}
 

--- a/pkg/v1/validate/index.go
+++ b/pkg/v1/validate/index.go
@@ -73,6 +73,24 @@ func validateChildren(idx v1.ImageIndex, opt ...Option) error {
 			if err != nil {
 				return err
 			}
+			artifact := desc.ArtifactType != ""
+			if !artifact {
+				if artifact, err = isArtifact(img); err != nil {
+					return err
+				}
+			}
+			if artifact {
+				// Artifact manifests (e.g. BuildKit attestations) are not
+				// images and cannot satisfy image invariants; validate their
+				// structure instead.
+				if err := validateArtifact(img, opt...); err != nil {
+					errs = append(errs, fmt.Sprintf("failed to validate artifact Manifests[%d](%s): %v", i, desc.Digest, err))
+				}
+				if err := validateMediaType(img, desc.MediaType); err != nil {
+					errs = append(errs, fmt.Sprintf("failed to validate artifact MediaType[%d](%s): %v", i, desc.Digest, err))
+				}
+				continue
+			}
 			if err := Image(img, opt...); err != nil {
 				errs = append(errs, fmt.Sprintf("failed to validate image Manifests[%d](%s): %v", i, desc.Digest, err))
 			}

--- a/pkg/v1/validate/index_test.go
+++ b/pkg/v1/validate/index_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+// attestation mimics a BuildKit attestation manifest: a manifest whose
+// config is not an image config and whose layers are not image layers.
+func attestation(t *testing.T) v1.Image {
+	t.Helper()
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mutate.ConfigMediaType(img, "application/vnd.oci.empty.v1+json")
+}
+
+func attestationAddendum(img v1.Image) mutate.IndexAddendum {
+	return mutate.IndexAddendum{
+		Add: img,
+		Descriptor: v1.Descriptor{
+			Annotations: map[string]string{
+				"vnd.docker.reference.type": "attestation-manifest",
+			},
+			Platform: &v1.Platform{
+				Architecture: "unknown",
+				OS:           "unknown",
+			},
+		},
+	}
+}
+
+func TestIndexAcceptsArtifactManifests(t *testing.T) {
+	base, err := random.Index(1024, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := mutate.AppendManifests(base, attestationAddendum(attestation(t)))
+	if err := Index(idx); err != nil {
+		t.Errorf("Index() = %v, want nil", err)
+	}
+	if err := Index(idx, Fast); err != nil {
+		t.Errorf("Index(Fast) = %v, want nil", err)
+	}
+}
+
+func TestIndexAcceptsArtifactManifestsByDescriptorArtifactType(t *testing.T) {
+	base, err := random.Index(1024, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An artifact that keeps an image config media type but declares an
+	// artifactType on its index descriptor; its config would fail image
+	// invariants.
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err = mutate.ConfigFile(img, &v1.ConfigFile{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := mutate.AppendManifests(base, mutate.IndexAddendum{
+		Add: img,
+		Descriptor: v1.Descriptor{
+			ArtifactType: "application/vnd.example.artifact",
+		},
+	})
+	if err := Index(idx); err != nil {
+		t.Errorf("Index() = %v, want nil", err)
+	}
+}
+
+type tamperedConfig struct {
+	v1.Image
+}
+
+func (i tamperedConfig) RawConfigFile() ([]byte, error) {
+	return []byte(`{"tampered":true}`), nil
+}
+
+func TestIndexRejectsCorruptArtifactManifests(t *testing.T) {
+	base, err := random.Index(1024, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := mutate.AppendManifests(base, attestationAddendum(tamperedConfig{attestation(t)}))
+	err = Index(idx)
+	if err == nil {
+		t.Fatal("Index() = nil, want error for artifact with corrupt config")
+	}
+	if !strings.Contains(err.Error(), "mismatched config digest") {
+		t.Errorf("Index() = %v, want mismatched config digest", err)
+	}
+}
+
+func TestImageErrorsOnMissingDiffIDs(t *testing.T) {
+	img, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err = mutate.ConfigFile(img, &v1.ConfigFile{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Image(img)
+	if err == nil {
+		t.Fatal("Image() = nil, want error for config without diff_ids")
+	}
+	if !strings.Contains(err.Error(), "missing layer[0] diffid") {
+		t.Errorf("Image() = %v, want missing layer[0] diffid", err)
+	}
+}


### PR DESCRIPTION
`crane validate` fails on any multi-arch image published by BuildKit with provenance/SBOM attestations enabled:

```
$ crane validate --fast --remote docker.io/arizephoenix/phoenix:version-20.2.0-nonroot
Error: validating children: failed to validate image Manifests[2](sha256:158c42…):
validating config: invalid ConfigFile.RootFS.Type: "" != "layers"
```

BuildKit attaches attestation manifests to the image index, and recent versions give them the OCI empty descriptor (`{}`) as their config. `validate.Index` validates every `OCIManifestSchema1`/`DockerManifestSchema2` child as a container image, so the attestation's config fails the `ConfigFile.RootFS.Type == "layers"` invariant and validation of an otherwise well-formed image reports failure.

Rather than skipping these children, this change validates them as what they are. A child is treated as an artifact manifest when its index descriptor or manifest declares an `artifactType`, or its config media type is not an image config (`!IsConfig()`). Artifact children get structural validation — manifest digest/size/content consistency, config blob existence and digest/size match, layer blob existence (`Fast`) or digest/size verification (full) — while image-only invariants (rootfs type, diff_ids, platform) are not applied. A registry copy with a missing or corrupt attestation blob still fails validation.

Also fixes two bounds bugs in `validateLayers`, found while testing with attestation-shaped images:

- the computed-layer slices are appended only for `IsLayer()` media types but indexed by overall layer position, so an image with a leading non-layer blob panics or compares the wrong layers;
- `cf.RootFS.DiffIDs[i]` panics with index out of range when the config declares fewer diff_ids than the image has layers (previously reachable via any image whose config is missing rootfs data — now reported as a validation error).

Testing the descriptor-level `artifactType` path surfaced that `mutate.AppendManifests` silently dropped `IndexAddendum.ArtifactType`; it now propagates like the other descriptor overrides.

Tests cover: an index with a BuildKit-style attestation child validates clean (full and `Fast`); a child detected only via its descriptor `artifactType` validates clean; a child with a tampered config blob fails on config digest; an image with layers but no diff_ids returns an error instead of panicking.

Verified against a real BuildKit-published image: `crane validate --fast --remote docker.io/arizephoenix/phoenix:version-20.2.0-nonroot@sha256:b20fc0…` now reports `PASS`.
