### PR TITLE
authn: do not overwrite AuthConfig.Auth when username and password are empty

### DIFF
--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -89,10 +89,6 @@ func (a *AuthConfig) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler
 func (a AuthConfig) MarshalJSON() ([]byte, error) {
 	shadow := (authConfig)(a)
-	// Only derive the auth field from the username and password when at least
-	// one of them is set. Otherwise an AuthConfig carrying only an already
-	// encoded Auth, or only a token, would have its auth field overwritten with
-	// the encoding of an empty username and password (":", i.e. "Og==").
 	if shadow.Username != "" || shadow.Password != "" {
 		shadow.Auth = encodeDockerConfigFieldAuth(shadow.Username, shadow.Password)
 	}

--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -89,7 +89,13 @@ func (a *AuthConfig) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler
 func (a AuthConfig) MarshalJSON() ([]byte, error) {
 	shadow := (authConfig)(a)
-	shadow.Auth = encodeDockerConfigFieldAuth(shadow.Username, shadow.Password)
+	// Only derive the auth field from the username and password when at least
+	// one of them is set. Otherwise an AuthConfig carrying only an already
+	// encoded Auth, or only a token, would have its auth field overwritten with
+	// the encoding of an empty username and password (":", i.e. "Og==").
+	if shadow.Username != "" || shadow.Password != "" {
+		shadow.Auth = encodeDockerConfigFieldAuth(shadow.Username, shadow.Password)
+	}
 	return json.Marshal(shadow)
 }
 

--- a/pkg/authn/authn_test.go
+++ b/pkg/authn/authn_test.go
@@ -46,6 +46,22 @@ func TestAuthConfigMarshalJSON(t *testing.T) {
 			RegistryToken: "reg",
 		},
 		json: `{"username":"user","password":"pass","auth":"dXNlcjpwYXNz","identitytoken":"id","registrytoken":"reg"}`,
+	}, {
+		// Without a username or a password there is nothing to derive the auth
+		// field from, so an already encoded auth must be preserved rather than
+		// overwritten with the encoding of an empty username and password.
+		name: "auth field preserved when username and password are empty",
+		config: AuthConfig{
+			Auth: "dXNlcjpwYXNz",
+		},
+		json: `{"auth":"dXNlcjpwYXNz"}`,
+	}, {
+		name: "no auth field is invented for a token only config",
+		config: AuthConfig{
+			IdentityToken: "id",
+			RegistryToken: "reg",
+		},
+		json: `{"identitytoken":"id","registrytoken":"reg"}`,
 	}}
 
 	for _, tc := range cases {

--- a/pkg/authn/authn_test.go
+++ b/pkg/authn/authn_test.go
@@ -47,9 +47,6 @@ func TestAuthConfigMarshalJSON(t *testing.T) {
 		},
 		json: `{"username":"user","password":"pass","auth":"dXNlcjpwYXNz","identitytoken":"id","registrytoken":"reg"}`,
 	}, {
-		// Without a username or a password there is nothing to derive the auth
-		// field from, so an already encoded auth must be preserved rather than
-		// overwritten with the encoding of an empty username and password.
 		name: "auth field preserved when username and password are empty",
 		config: AuthConfig{
 			Auth: "dXNlcjpwYXNz",


### PR DESCRIPTION
Fixes #1864.

### The bug

`AuthConfig.MarshalJSON` unconditionally recomputes the `auth` field:

```go
func (a AuthConfig) MarshalJSON() ([]byte, error) {
	shadow := (authConfig)(a)
	shadow.Auth = encodeDockerConfigFieldAuth(shadow.Username, shadow.Password)
	return json.Marshal(shadow)
}
```

When neither `Username` nor `Password` is set there is nothing to derive it from, so `auth` becomes the encoding of `":"`, which is `Og==`.

```go
AuthConfig{Auth: "dXNlcjpwYXNz"}    -> {"auth":"Og=="}
AuthConfig{RegistryToken: "bearer"} -> {"auth":"Og==","registrytoken":"bearer"}
AuthConfig{IdentityToken: "id"}     -> {"auth":"Og==","identitytoken":"id"}
```

The first case silently discards a valid credential: a config carrying only an already encoded `Auth` marshals to a useless one, and round-tripping it yields `Auth: "Og=="` with empty username and password. The second and third invent an `auth` field for configs that never had one.

This is the case reported in #1864, which was closed by the stale bot rather than resolved, with a follow-up noting it was still broken.

### The change

Derive `auth` only when a username or password is present, otherwise leave whatever the caller set:

```go
if shadow.Username != "" || shadow.Password != "" {
	shadow.Auth = encodeDockerConfigFieldAuth(shadow.Username, shadow.Password)
}
```

Configs carrying a username and password are unaffected, including the existing `auth field replaced` case where a stale `Auth` is deliberately overwritten.

### Testing

Two cases added to the existing `TestAuthConfigMarshalJSON` table: an auth-only config, and a token-only config. Without the change both fail:

```
--- FAIL: TestAuthConfigMarshalJSON/auth_field_preserved_when_username_and_password_are_empty
--- FAIL: TestAuthConfigMarshalJSON/no_auth_field_is_invented_for_a_token_only_config
```

With it, `TestAuthConfigMarshalJSON` and `TestAuthConfigUnmarshalJSON` pass in full. `TestPodmanConfig` fails identically before and after on my machine because it picks up a `REGISTRY_AUTH_FILE` from the environment; it is unrelated to this change.
