### PR TITLE
Support pulling images by sha512 digest

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,8 @@ linters:
           deny:
             - pkg: crypto/sha256
               desc: use crypto.SHA256 instead
+            - pkg: crypto/sha512
+              desc: use crypto.SHA512 instead
     gosec:
       excludes:
         - G117 # Exported sensitive fields

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -17,7 +17,6 @@
 package verify
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -107,10 +106,16 @@ func Descriptor(d v1.Descriptor) error {
 		return errors.New("error verifying descriptor; Data == nil")
 	}
 
-	h, sz, err := v1.SHA256(bytes.NewReader(d.Data))
+	hasher, err := v1.Hasher(d.Digest.Algorithm)
 	if err != nil {
 		return err
 	}
+	hasher.Write(d.Data)
+	h := v1.Hash{
+		Algorithm: d.Digest.Algorithm,
+		Hex:       hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))),
+	}
+	sz := int64(len(d.Data))
 	if h != d.Digest {
 		return fmt.Errorf("error verifying Digest; got %q, want %q", h, d.Digest)
 	}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -109,9 +109,18 @@ func TestDescriptor(t *testing.T) {
 	}{{
 		err: errors.New("error verifying descriptor; Data == nil"),
 	}, {
-		err: errors.New(`error verifying Digest; got "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", want ":"`),
+		err: errors.New(`unsupported hash: ""`),
 		desc: v1.Descriptor{
 			Data: []byte("abc"),
+		},
+	}, {
+		err: errors.New(`error verifying Digest; got "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", want "sha256:baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d"`),
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Digest: v1.Hash{
+				Algorithm: "sha256",
+				Hex:       "baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d",
+			},
 		},
 	}, {
 		err: errors.New("error verifying Size; got 3, want 0"),
@@ -129,6 +138,15 @@ func TestDescriptor(t *testing.T) {
 			Digest: v1.Hash{
 				Algorithm: "sha256",
 				Hex:       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			},
+		},
+	}, {
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Size: 3,
+			Digest: v1.Hash{
+				Algorithm: "sha512",
+				Hex:       "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
 			},
 		},
 	}} {

--- a/pkg/name/digest.go
+++ b/pkg/name/digest.go
@@ -17,6 +17,8 @@ package name
 import (
 	// nolint: depguard
 	_ "crypto/sha256" // Recommended by go-digest.
+	// nolint: depguard
+	_ "crypto/sha512" // Needed for sha512 digests.
 	"encoding"
 	"encoding/json"
 	"strings"
@@ -107,13 +109,8 @@ func NewDigest(name string, opts ...Option) (Digest, error) {
 	}
 	base := parts[0]
 	dig := parts[1]
-	prefix := digest.Canonical.String() + ":"
-	if !strings.HasPrefix(dig, prefix) {
-		return Digest{}, newErrBadName("unsupported digest algorithm: %s", dig)
-	}
-	hex := strings.TrimPrefix(dig, prefix)
-	if err := digest.Canonical.Validate(hex); err != nil {
-		return Digest{}, err
+	if err := digest.Digest(dig).Validate(); err != nil {
+		return Digest{}, newErrBadName("%s: %s", err, dig)
 	}
 
 	tag, err := NewTag(base, opts...)

--- a/pkg/name/digest_test.go
+++ b/pkg/name/digest_test.go
@@ -24,11 +24,14 @@ import (
 
 const validDigest = "sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"
 
+var validSHA512Digest = "sha512:" + strings.Repeat("deadb33f", 16)
+
 var goodStrictValidationDigestNames = []string{
 	"gcr.io/g-convoy/hello-world@" + validDigest,
 	"gcr.io/google.com/project-id/hello-world@" + validDigest,
 	"us.gcr.io/project-id/sub-repo@" + validDigest,
 	"example.text/foo/bar@" + validDigest,
+	"example.text/foo/bar@" + validSHA512Digest,
 }
 
 var goodStrictValidationTagDigestNames = []string{
@@ -40,6 +43,7 @@ var goodStrictValidationTagDigestNames = []string{
 var goodWeakValidationDigestNames = []string{
 	"namespace/pathcomponent/image@" + validDigest,
 	"library/ubuntu@" + validDigest,
+	"library/ubuntu@" + validSHA512Digest,
 }
 
 var goodWeakValidationTagDigestNames = []string{
@@ -50,6 +54,8 @@ var goodWeakValidationTagDigestNames = []string{
 var badDigestNames = []string{
 	"gcr.io/project-id/unknown-alg@unknown:abc123",
 	"gcr.io/project-id/wrong-length@sha256:d34db33fd34db33f",
+	"gcr.io/project-id/wrong-length@sha512:d34db33fd34db33f",
+	"gcr.io/project-id/unregistered-alg@md5:" + strings.Repeat("d", 32),
 	"gcr.io/project-id/missing-digest@",
 	// https://github.com/google/go-containerregistry/issues/1394
 	"repo@sha256:" + strings.Repeat(":", 64),

--- a/pkg/v1/hash.go
+++ b/pkg/v1/hash.go
@@ -16,6 +16,10 @@ package v1
 
 import (
 	"crypto"
+	// nolint: depguard
+	_ "crypto/sha256" // Registered for Hasher.
+	// nolint: depguard
+	_ "crypto/sha512" // Registered for Hasher.
 	"encoding"
 	"encoding/hex"
 	"encoding/json"
@@ -78,6 +82,8 @@ func Hasher(name string) (hash.Hash, error) {
 	switch name {
 	case "sha256":
 		return crypto.SHA256.New(), nil
+	case "sha512":
+		return crypto.SHA512.New(), nil
 	default:
 		return nil, fmt.Errorf("unsupported hash: %q", name)
 	}

--- a/pkg/v1/hash_test.go
+++ b/pkg/v1/hash_test.go
@@ -25,6 +25,7 @@ func TestGoodHashes(t *testing.T) {
 	good := []string{
 		"sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}
 
 	for _, s := range good {
@@ -49,6 +50,8 @@ func TestBadHashes(t *testing.T) {
 	bad := []string{
 		// Too short
 		"sha256:deadbeef",
+		// Wrong length for the algorithm
+		"sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		// Bad character
 		"sha256:o123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		// Too many separators

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -17,6 +17,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -174,10 +175,26 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 		return nil, nil, err
 	}
 
-	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
+	// Hash with the algorithm of the reference when pulling by digest.
+	dgst, byDigest := ref.(name.Digest)
+	algo := "sha256"
+	if byDigest {
+		h, err := v1.NewHash(dgst.DigestStr())
+		if err != nil {
+			return nil, nil, err
+		}
+		algo = h.Algorithm
+	}
+	hasher, err := v1.Hasher(algo)
 	if err != nil {
 		return nil, nil, err
 	}
+	hasher.Write(manifest)
+	digest := v1.Hash{
+		Algorithm: algo,
+		Hex:       hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))),
+	}
+	size := int64(len(manifest))
 
 	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
 	contentDigest, err := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
@@ -188,7 +205,7 @@ func (f *fetcher) fetchManifest(ctx context.Context, ref name.Reference, accepta
 	}
 
 	// Validate the digest matches what we asked for, if pulling by digest.
-	if dgst, ok := ref.(name.Digest); ok {
+	if byDigest {
 		if digest.String() != dgst.DigestStr() {
 			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), ref)
 		}

--- a/pkg/v1/remote/image_test.go
+++ b/pkg/v1/remote/image_test.go
@@ -106,6 +106,17 @@ func TestMediaType(t *testing.T) {
 	}
 }
 
+// mustDigestWith computes a digest string of b with the named algorithm.
+func mustDigestWith(t *testing.T, algo string, b []byte) string {
+	t.Helper()
+	hasher, err := v1.Hasher(algo)
+	if err != nil {
+		t.Fatalf("v1.Hasher(%q) = %v", algo, err)
+	}
+	hasher.Write(b)
+	return fmt.Sprintf("%s:%x", algo, hasher.Sum(nil))
+}
+
 func TestRawManifestDigests(t *testing.T) {
 	img := randomImage(t)
 	expectedRepo := "foo/bar"
@@ -147,6 +158,18 @@ func TestRawManifestDigests(t *testing.T) {
 		responseBody:  mustRawManifest(t, img),
 		contentDigest: bogusDigest,
 		wantErr:       false,
+	}, {
+		name:          "normal pull, by sha512 digest",
+		ref:           mustDigestWith(t, "sha512", mustRawManifest(t, img)),
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       false,
+	}, {
+		name:          "wrong body, by sha512 digest",
+		ref:           mustDigestWith(t, "sha512", []byte("not the manifest")),
+		responseBody:  mustRawManifest(t, img),
+		contentDigest: mustDigest(t, img).String(),
+		wantErr:       true,
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
The image spec registers sha512 alongside sha256 ([registered algorithms](https://github.com/opencontainers/image-spec/blob/v1.1.1/descriptor.md#registered-algorithms)), but a reference or descriptor carrying a sha512 digest is rejected at parse time. This change makes pulling by a sha512 digest work: parsing, manifest hashing, and data verification use the digest's algorithm instead of assuming sha256.

Producing sha512 images is out of scope — `Digest()` and `ConfigName()` of a pulled image still report sha256.
