### PR TITLE
name: improve error when parsing a reference with a URL scheme

### DIFF
--- a/pkg/name/ref.go
+++ b/pkg/name/ref.go
@@ -16,6 +16,7 @@ package name
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Reference defines the interface that consumers use when they can
@@ -39,6 +40,11 @@ type Reference interface {
 // ParseReference parses the string as a reference, either by tag or digest.
 // References that include both a tag and digest parse as Digest references.
 func ParseReference(s string, opts ...Option) (Reference, error) {
+	// Image references never contain a URL scheme, so tell the user to
+	// strip it instead of returning a confusing parse error.
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return nil, newErrBadName("image reference must not contain a URL scheme (http:// or https://): %s; to connect to a registry over plain HTTP, use name.Insecure", s)
+	}
 	if t, err := NewTag(s, opts...); err == nil {
 		return t, nil
 	}

--- a/pkg/name/ref_test.go
+++ b/pkg/name/ref_test.go
@@ -15,6 +15,7 @@
 package name
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,24 @@ func TestParseReference(t *testing.T) {
 	for _, name := range badTagNames {
 		if _, err := ParseReference(name, WeakValidation); err == nil {
 			t.Errorf("ParseReference(%q); expected error, got none", name)
+		}
+	}
+}
+
+func TestParseReferenceURLScheme(t *testing.T) {
+	for _, s := range []string{
+		"https://gcr.io/foo/bar",
+		"http://localhost:5000/foo",
+	} {
+		for _, opts := range [][]Option{nil, {WeakValidation}, {StrictValidation}} {
+			_, err := ParseReference(s, opts...)
+			if err == nil {
+				t.Errorf("ParseReference(%q, %v); expected error, got none", s, opts)
+				continue
+			}
+			if !strings.Contains(err.Error(), "URL scheme") {
+				t.Errorf("ParseReference(%q, %v); error %q should mention the URL scheme", s, opts, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #779

Parsing `https://gcr.io/foo/bar` currently either fails with the generic `could not parse reference: ...` or, with weak validation, silently "succeeds" by treating `https:` as the registry host, which can never work.

As jonjohnsonjr said in #779: "I'd merge a PR that just makes this error message better for now" — so this doesn't attempt any scheme stripping. `ParseReference` now detects an `http://`/`https://` prefix up front (covering both the weak and strict paths) and returns:

`image reference must not contain a URL scheme (http:// or https://): <input>; to connect to a registry over plain HTTP, use name.Insecure`

Added a test covering both prefixes across default/weak/strict validation.
