### PR TITLE
fix(release): honor declared Go toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['*']
 
 env:
-  GOTOOLCHAIN: local
+  GOTOOLCHAIN: auto
 
 jobs:
   goreleaser:
@@ -25,6 +25,14 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true # no-op if full version is specified
           cache: false
+      - name: Verify release Go version
+        run: |
+          expected="$(go mod edit -json | jq -r .Toolchain)"
+          actual="$(go env GOVERSION)"
+          if [[ "${actual}" != "${expected}" ]]; then
+            echo "Release Go version mismatch: got ${actual}, want ${expected}" >&2
+            exit 1
+          fi
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         id: run-goreleaser
         with:


### PR DESCRIPTION
## Summary

- let the release workflow activate the exact Go toolchain declared in `go.mod`
- stop before GoReleaser if the active Go version does not match that declaration
- keep `go 1.25.0` as the module's minimum supported version

## Problem

The v0.22.0 release binaries were built with Go 1.25.0 even though the module declares `toolchain go1.26.6`. This leaves release artifacts on an older standard library than intended and makes the repository's documented release-toolchain setting ineffective.

## Root cause

#2416 replaced the dedicated `.go-version` file with the `toolchain` directive, but the release workflow retained `GOTOOLCHAIN: local`. `actions/setup-go` selects the `go` directive from `go.mod` (the minimum version), while `GOTOOLCHAIN: local` prevents the Go command from activating the newer declared toolchain.

## Fix

Set `GOTOOLCHAIN` to `auto` for the release job so the Go command honors the pinned toolchain directive. Before GoReleaser runs, compare `go env GOVERSION` with the toolchain parsed by `go mod edit -json` and fail with an actionable mismatch if they differ.

## Security considerations

This affects the trusted tag-release workflow and the provenance-bearing binaries it publishes. The change does not alter workflow permissions, token handling, or application runtime behavior. Automatic selection is still pinned to the exact toolchain in `go.mod`, and the new check prevents a mismatched builder from publishing. Existing v0.22.0 artifacts are not changed; the fix applies to future releases.

## Validation

- Published reproduction: `go version -m crane` from the v0.22.0 Linux x86_64 archive reports `go1.25.0`.
- Regression check before the fix: `expected=go1.26.6 actual=go1.26.5` with the workflow's `GOTOOLCHAIN=local` behavior.
- Regression check after the fix: `workflow_GOTOOLCHAIN=auto expected=go1.26.6 actual=go1.26.6`.
- Release-equivalent `CGO_ENABLED=0 go build -trimpath ./cmd/crane/main.go`; `go version -m` reports `go1.26.6`.
- `PATH="$(go env GOPATH)/bin:$PATH" ./hack/presubmit.sh` — passed.
- `go test -coverprofile=/tmp/gcr-coverage-2430.txt -covermode=atomic -race ./...` — passed.
- `go build ./... && go test -run=^$ ./...` — passed.
- `actionlint -ignore SC2086 .github/workflows/release.yml` — passed. (`SC2086` findings predate this change elsewhere in the workflow.)
- `git diff --check` — passed.

## Compatibility

No library API, CLI behavior, module minimum Go version, artifact format, or supported platform changes. Only the Go version used to build future release binaries changes to the already-declared release toolchain.

Fixes #2430
