### PR TITLE
flatten: preserve config and layer media types when flattening

### DIFF
--- a/cmd/crane/cmd/flatten.go
+++ b/cmd/crane/cmd/flatten.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/spf13/cobra"
 )
 
@@ -229,14 +230,28 @@ func flattenImage(old v1.Image, repo name.Repository, use string, o crane.Option
 		return nil, fmt.Errorf("mutating config: %w", err)
 	}
 
+	mt, err := old.MediaType()
+	if err != nil {
+		return nil, fmt.Errorf("getting media type: %w", err)
+	}
+
+	layerType := types.DockerLayer
+	if mt == types.OCIManifestSchema1 {
+		layerType = types.OCILayer
+	}
+
 	// TODO: Make compression configurable?
-	layer := stream.NewLayer(mutate.Extract(old), stream.WithCompressionLevel(gzip.BestCompression))
+	layer := stream.NewLayer(mutate.Extract(old),
+		stream.WithCompressionLevel(gzip.BestCompression),
+		stream.WithMediaType(layerType),
+	)
 	if err := remote.WriteLayer(repo, layer, o.Remote...); err != nil {
 		return nil, fmt.Errorf("uploading layer: %w", err)
 	}
 
 	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: layer,
+		Layer:     layer,
+		MediaType: layerType,
 		History: v1.History{
 			Created:   cf.Created,
 			CreatedBy: fmt.Sprintf("%s flatten %s", use, digest),
@@ -257,11 +272,21 @@ func flattenImage(old v1.Image, repo name.Repository, use string, o crane.Option
 	// an OCI image index would reference Docker-typed image manifests, which
 	// confuses registries and tooling that assumes the index and its children
 	// share the same media-type convention.
-	mt, err := old.MediaType()
-	if err != nil {
-		return nil, fmt.Errorf("getting media type: %w", err)
-	}
 	img = mutate.MediaType(img, mt)
+
+	configType := m.Config.MediaType
+	if configType == "" {
+		if mt == types.OCIManifestSchema1 {
+			configType = types.OCIConfigJSON
+		} else {
+			configType = types.DockerConfigJSON
+		}
+	} else if mt == types.OCIManifestSchema1 && configType == types.DockerConfigJSON {
+		configType = types.OCIConfigJSON
+	} else if mt == types.DockerManifestSchema2 && configType == types.OCIConfigJSON {
+		configType = types.DockerConfigJSON
+	}
+	img = mutate.ConfigMediaType(img, configType)
 
 	return img, nil
 }

--- a/cmd/crane/cmd/flatten_test.go
+++ b/cmd/crane/cmd/flatten_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -47,11 +48,19 @@ func TestFlattenImagePreservesMediaType(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			wantConfigType := types.DockerConfigJSON
+			wantLayerType := types.DockerLayer
+			if mt == types.OCIManifestSchema1 {
+				wantConfigType = types.OCIConfigJSON
+				wantLayerType = types.OCILayer
+			}
+
 			img, err := random.Image(1024, 2)
 			if err != nil {
 				t.Fatalf("random.Image: %v", err)
 			}
 			img = mutate.MediaType(img, mt)
+			img = mutate.ConfigMediaType(img, wantConfigType)
 
 			flat, err := flattenImage(img, repo, "crane", crane.GetOptions())
 			if err != nil {
@@ -70,6 +79,97 @@ func TestFlattenImagePreservesMediaType(t *testing.T) {
 			if got != mt {
 				t.Errorf("flattened media type = %q, want %q", got, mt)
 			}
+
+			m, err := flatImg.Manifest()
+			if err != nil {
+				t.Fatalf("Manifest: %v", err)
+			}
+			if m.Config.MediaType != wantConfigType {
+				t.Errorf("config media type = %q, want %q", m.Config.MediaType, wantConfigType)
+			}
+			if len(m.Layers) != 1 {
+				t.Fatalf("got %d layers, want 1", len(m.Layers))
+			}
+			if m.Layers[0].MediaType != wantLayerType {
+				t.Errorf("layer media type = %q, want %q", m.Layers[0].MediaType, wantLayerType)
+			}
 		})
+	}
+}
+
+func TestFlattenIndexPreservesMediaType(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := name.NewRepository(fmt.Sprintf("%s/test/flatten-index", u.Host))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	img = mutate.MediaType(img, types.OCIManifestSchema1)
+	img = mutate.ConfigMediaType(img, types.OCIConfigJSON)
+
+	idx := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
+		Add: img,
+		Descriptor: v1.Descriptor{
+			Platform: &v1.Platform{OS: "linux", Architecture: "amd64"},
+		},
+	})
+	idx = mutate.IndexMediaType(idx, types.OCIImageIndex)
+
+	flat, err := flattenIndex(idx, repo, "crane", crane.GetOptions())
+	if err != nil {
+		t.Fatalf("flattenIndex: %v", err)
+	}
+
+	flatIdx, ok := flat.(v1.ImageIndex)
+	if !ok {
+		t.Fatalf("flattenIndex returned %T, want v1.ImageIndex", flat)
+	}
+
+	gotMT, err := flatIdx.MediaType()
+	if err != nil {
+		t.Fatalf("MediaType: %v", err)
+	}
+	if gotMT != types.OCIImageIndex {
+		t.Errorf("flattened index media type = %q, want %q", gotMT, types.OCIImageIndex)
+	}
+
+	im, err := flatIdx.IndexManifest()
+	if err != nil {
+		t.Fatalf("IndexManifest: %v", err)
+	}
+	if len(im.Manifests) != 1 {
+		t.Fatalf("got %d manifests, want 1", len(im.Manifests))
+	}
+	desc := im.Manifests[0]
+	if desc.MediaType != types.OCIManifestSchema1 {
+		t.Errorf("child descriptor media type = %q, want %q", desc.MediaType, types.OCIManifestSchema1)
+	}
+	if desc.ArtifactType == string(types.DockerConfigJSON) {
+		t.Errorf("child descriptor artifactType should not be Docker config JSON")
+	}
+
+	child, err := flatIdx.Image(desc.Digest)
+	if err != nil {
+		t.Fatalf("getting child image: %v", err)
+	}
+	childMf, err := child.Manifest()
+	if err != nil {
+		t.Fatalf("child Manifest: %v", err)
+	}
+	if childMf.Config.MediaType != types.OCIConfigJSON {
+		t.Errorf("child config media type = %q, want %q", childMf.Config.MediaType, types.OCIConfigJSON)
+	}
+	if len(childMf.Layers) != 1 || childMf.Layers[0].MediaType != types.OCILayer {
+		t.Errorf("child layers = %v, want 1 layer of type %q", childMf.Layers, types.OCILayer)
 	}
 }


### PR DESCRIPTION
Fixes #2433

#2267 introduced preserving the manifest media type, but was overridden by the default image type of empty.Image. As a result, flattening an OCI image produced a mixed manifest, e.g.:
* Manifest `mediaType: application/vnd.oci.image.manifest.v1+json` (OCI)
* Config `mediaType: application/vnd.docker.container.image.v1+json` (Docker)
* Layer `mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip` (Docker)

### Changes

* Preserve layer media type and config media type for OCI manifests (via `stream.WithMediaType`)
* Expand TestFlattenImagePreservesMediaType to assert that m.Config.MediaType and m.Layers[0].MediaType match the expected media type family.
* Add TestFlattenIndexPreservesMediaType to verify that flattening an OCI index does not emit Docker artifact types on index descriptors and preserves child image media types.

### Verification

`go test -v ./...`