### PR TITLE
remote: copy manifest annotations to referrers fallback tag descriptors

### DIFF
--- a/pkg/registry/manifest.go
+++ b/pkg/registry/manifest.go
@@ -426,6 +426,7 @@ func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request)
 			Config struct {
 				MediaType string `json:"mediaType"`
 			} `json:"config"`
+			Annotations map[string]string `json:"annotations"`
 		}
 		json.Unmarshal(manifest.blob, &imageAsArtifact)
 		im.Manifests = append(im.Manifests, v1.Descriptor{
@@ -433,6 +434,7 @@ func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request)
 			Size:         int64(len(manifest.blob)),
 			Digest:       h,
 			ArtifactType: imageAsArtifact.Config.MediaType,
+			Annotations:  imageAsArtifact.Annotations,
 		})
 	}
 	msg, _ := json.Marshal(&im)

--- a/pkg/v1/remote/referrers_test.go
+++ b/pkg/v1/remote/referrers_test.go
@@ -61,6 +61,9 @@ func TestReferrers(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		annotations := map[string]string{
+			"org.example.testing123": "testing456",
+		}
 		descriptor := func(img v1.Image) v1.Descriptor {
 			d, err := img.Digest()
 			if err != nil {
@@ -79,6 +82,7 @@ func TestReferrers(t *testing.T) {
 				Size:         sz,
 				MediaType:    mt,
 				ArtifactType: "application/testing123",
+				Annotations:  annotations,
 			}
 		}
 
@@ -93,6 +97,7 @@ func TestReferrers(t *testing.T) {
 			t.Fatal(err)
 		}
 		rootImg = mutate.ConfigMediaType(rootImg, types.MediaType("application/testing123"))
+		rootImg = mutate.Annotations(rootImg, annotations).(v1.Image)
 		if err := remote.Write(rootRef, rootImg); err != nil {
 			t.Fatal(err)
 		}
@@ -123,6 +128,7 @@ func TestReferrers(t *testing.T) {
 			t.Fatal(err)
 		}
 		leafImg = mutate.ConfigMediaType(leafImg, types.MediaType("application/testing123"))
+		leafImg = mutate.Annotations(leafImg, annotations).(v1.Image)
 		leafImg = mutate.Subject(leafImg, rootDesc).(v1.Image)
 		if err := remote.Write(leafRef, leafImg); err != nil {
 			t.Fatal(err)

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -608,9 +608,10 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		return err
 	}
 	var mf struct {
-		MediaType    types.MediaType `json:"mediaType"`
-		Subject      *v1.Descriptor  `json:"subject,omitempty"`
-		ArtifactType string          `json:"artifactType,omitempty"`
+		MediaType    types.MediaType   `json:"mediaType"`
+		Subject      *v1.Descriptor    `json:"subject,omitempty"`
+		ArtifactType string            `json:"artifactType,omitempty"`
+		Annotations  map[string]string `json:"annotations,omitempty"`
 		Config       struct {
 			MediaType types.MediaType `json:"mediaType"`
 		} `json:"config"`
@@ -653,9 +654,10 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 				return err
 			}
 			desc := v1.Descriptor{
-				MediaType: mf.MediaType,
-				Digest:    h,
-				Size:      size,
+				MediaType:   mf.MediaType,
+				Digest:      h,
+				Size:        size,
+				Annotations: mf.Annotations,
 			}
 			if mf.ArtifactType != "" {
 				desc.ArtifactType = mf.ArtifactType


### PR DESCRIPTION
The distribution spec requires that "all annotations from the pushed manifest MUST be copied to this descriptor" when a client maintains the referrers fallback tag, but we only carried mediaType, digest, size, and (since #2269) artifactType. Consumers that filter referrers by annotation (cosign, oras, regctl) can't tell sigstore bundles apart without the dev.sigstore.bundle.* annotations, so they end up pulling every referrer.

This is the write-side counterpart of #2269, which fixed artifactType hoisting in this path and annotations on the read side. Give the fake registry's referrers endpoint the same treatment so both test legs (referrers API and fallback tag) assert identical descriptors.

Related: sigstore/cosign#4641.

Assisted by Claude Code.