### PR TITLE
krane: add OCI Container Registry (OCIR) keychain

### DIFF
--- a/cmd/krane/README.md
+++ b/cmd/krane/README.md
@@ -7,7 +7,7 @@ support for authenticating against registries using common credential helpers
 that find credentials from the environment.
 
 In particular this tool supports authenticating with common "workload identity"
-mechanisms on platforms such as GKE and EKS.
+mechanisms on platforms such as GKE, EKS and OKE.
 
 This additional keychain logic only kicks in if alternative authentication
 mechanisms have NOT been configured and `crane` would otherwise perform the

--- a/cmd/krane/go.mod
+++ b/cmd/krane/go.mod
@@ -14,7 +14,9 @@ replace github.com/google/go-containerregistry => ../../
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
+	github.com/docker/docker-credential-helpers v0.9.5
 	github.com/google/go-containerregistry v0.21.2
+	github.com/oracle/oci-go-sdk/v65 v65.124.1
 )
 
 require (
@@ -46,7 +48,7 @@ require (
 	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/cli v29.7.2+incompatible // indirect
-	github.com/docker/docker-credential-helpers v0.9.5 // indirect
+	github.com/gofrs/flock v0.10.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -55,8 +57,10 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/cmd/krane/go.sum
+++ b/cmd/krane/go.sum
@@ -74,6 +74,8 @@ github.com/docker/cli v29.7.2+incompatible h1:dlkwallR8XqfeVnA2ELEhdwvb4lsSwuB4I
 github.com/docker/cli v29.7.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
 github.com/docker/docker-credential-helpers v0.9.5/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
+github.com/gofrs/flock v0.10.0 h1:SHMXenfaB03KbroETaCMtbBg3Yn29v4w1r+tgy4ff4k=
+github.com/gofrs/flock v0.10.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -92,6 +94,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/oracle/oci-go-sdk/v65 v65.124.1 h1:Wuos4/Ru9PRI83ObOfAmaEu+m+LcmjG7f17c0p6YzwM=
+github.com/oracle/oci-go-sdk/v65 v65.124.1/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -99,6 +103,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -108,11 +114,15 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/cmd/krane/internal/ocir/ocir.go
+++ b/cmd/krane/internal/ocir/ocir.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ocir implements a Docker credential helper for OCI Container
+// Registry (OCIR).
+//
+// It exchanges an OCI-signed request for a short-lived registry token via
+// OCIR's /20180419/docker/token endpoint, resolving the signing principal
+// from OKE workload identity, instance principal, resource principal, or
+// the local OCI configuration, in that order.
+package ocir
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+)
+
+const (
+	// tokenUsername is the fixed username OCIR expects when the password is
+	// a short-lived registry token.
+	tokenUsername = "BEARER_TOKEN"
+
+	// tokenPath is the OCIR endpoint that exchanges an OCI-signed request
+	// for a short-lived registry token.
+	tokenPath = "/20180419/docker/token"
+
+	// registryDomain matches OCIR registry hosts, e.g. iad.ocir.io or
+	// us-ashburn-1.ocir.io.
+	registryDomain = ".ocir.io"
+
+	metadataBaseURLEnv     = "OCI_METADATA_BASE_URL"
+	defaultMetadataBaseURL = "http://169.254.169.254/opc/v2"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// Helper implements the Docker credentials.Helper interface for OCIR.
+//
+// Constructing a Helper performs no I/O; principals are resolved lazily on
+// Get. Requests for non-OCIR registries and requests made where no OCI
+// principal is available fail with credentials.NewErrCredentialsNotFound so
+// that other keychains can be tried.
+type Helper struct {
+	client *http.Client
+
+	// endpoint and providers exist so tests can point the helper at a fake
+	// token endpoint and a static signing principal.
+	endpoint  func(host string) string
+	providers func() []common.ConfigurationProvider
+}
+
+// NewHelper returns a credential helper for OCIR.
+func NewHelper() *Helper {
+	return &Helper{
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+var _ credentials.Helper = (*Helper)(nil)
+
+// Get returns a short-lived registry token for OCIR hosts.
+func (h *Helper) Get(serverURL string) (string, string, error) {
+	host := registryHost(serverURL)
+	if !strings.HasSuffix(host, registryDomain) {
+		return "", "", credentials.NewErrCredentialsNotFound()
+	}
+	providers := h.providers
+	if providers == nil {
+		providers = defaultProviders
+	}
+	for _, provider := range providers() {
+		token, err := h.fetchToken(host, provider)
+		if err != nil {
+			continue
+		}
+		return tokenUsername, token, nil
+	}
+	return "", "", credentials.NewErrCredentialsNotFound()
+}
+
+// Add is unsupported, since all issued credentials are temporary.
+func (h *Helper) Add(*credentials.Credentials) error { return errNotImplemented }
+
+// Delete is unsupported, since all issued credentials are temporary.
+func (h *Helper) Delete(string) error { return errNotImplemented }
+
+// List is unsupported, since all issued credentials are temporary.
+func (h *Helper) List() (map[string]string, error) { return nil, errNotImplemented }
+
+// fetchToken requests a short-lived registry token from the OCIR host,
+// signing the request with the given principal.
+func (h *Helper) fetchToken(host string, provider common.ConfigurationProvider) (string, error) {
+	endpoint := "https://" + host + tokenPath
+	if h.endpoint != nil {
+		endpoint = h.endpoint(host)
+	}
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	// The signer includes the date header in the signature but does not set it.
+	req.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+	if err := common.DefaultRequestSigner(provider).Sign(req); err != nil {
+		return "", err
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching OCIR token: unexpected status %d", resp.StatusCode)
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Token == "" {
+		return "", errors.New("fetching OCIR token: no token in response")
+	}
+	if anonymousToken(body.Token) {
+		return "", errors.New("fetching OCIR token: endpoint issued an anonymous token (request signature not accepted)")
+	}
+	return body.Token, nil
+}
+
+// anonymousToken reports whether the registry token was issued to the
+// anonymous principal. OCIR does not reject requests whose signature it
+// cannot validate; it silently issues an anonymous token instead, which
+// would mask credential problems here. Parsing is best-effort: tokens that
+// don't match the expected JWT shape are assumed to be principal tokens.
+func anonymousToken(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	// The sub claim is itself a JSON document, e.g.
+	// {"userId":"anon-...","tenantId":"anon-...","claims":[]}.
+	var claims struct {
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false
+	}
+	var sub struct {
+		UserID string `json:"userId"`
+	}
+	if err := json.Unmarshal([]byte(claims.Sub), &sub); err != nil {
+		return false
+	}
+	return strings.HasPrefix(sub.UserID, "anon-")
+}
+
+// registryHost extracts the bare registry hostname from a Docker credential
+// helper serverURL, which may be a bare host or include a scheme and path.
+func registryHost(serverURL string) string {
+	host := serverURL
+	if strings.Contains(host, "://") {
+		if u, err := url.Parse(host); err == nil && u.Host != "" {
+			return u.Hostname()
+		}
+	}
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	}
+	return host
+}
+
+// defaultProviders returns OCI configuration providers in priority order.
+// Constructors that report their environment is not present (e.g. not
+// running on OKE or an OCI instance) are skipped silently.
+func defaultProviders() []common.ConfigurationProvider {
+	var providers []common.ConfigurationProvider
+	if p, err := auth.OkeWorkloadIdentityConfigurationProvider(); err == nil {
+		providers = append(providers, p)
+	}
+	// InstancePrincipalConfigurationProvider retries against the instance
+	// metadata service with backoff for ~90s when it is unreachable, so
+	// probe reachability first to fail fast off OCI.
+	if metadataServiceReachable() {
+		if p, err := auth.InstancePrincipalConfigurationProvider(); err == nil {
+			providers = append(providers, p)
+		}
+	}
+	if p, err := auth.ResourcePrincipalConfigurationProvider(); err == nil {
+		providers = append(providers, p)
+	}
+	return append(providers, common.DefaultConfigProvider())
+}
+
+// metadataServiceReachable reports whether the OCI instance metadata service
+// accepts connections.
+func metadataServiceReachable() bool {
+	base := os.Getenv(metadataBaseURLEnv)
+	if base == "" {
+		base = defaultMetadataBaseURL
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return false
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(u.Hostname(), port), time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/cmd/krane/internal/ocir/ocir_test.go
+++ b/cmd/krane/internal/ocir/ocir_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocir
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+func testProvider(t *testing.T) common.ConfigurationProvider {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	pemKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return common.NewRawConfigurationProvider(
+		"ocid1.tenancy.oc1..testtenancy",
+		"ocid1.user.oc1..testuser",
+		"us-ashburn-1",
+		"aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+		string(pemKey),
+		nil)
+}
+
+func staticProviders(p ...common.ConfigurationProvider) func() []common.ConfigurationProvider {
+	return func() []common.ConfigurationProvider { return p }
+}
+
+// fakeJWT builds an unsigned JWT-shaped token whose sub claim carries the
+// given userId, mirroring OCIR's nested-JSON sub format.
+func fakeJWT(t *testing.T, userID string) string {
+	t.Helper()
+	sub, err := json.Marshal(map[string]any{"userId": userID, "tenantId": "tenant", "claims": []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]string{"sub": string(sub)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func TestGet(t *testing.T) {
+	var gotReq *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r.Clone(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"token":"test-jwt"}`))
+	}))
+	defer ts.Close()
+
+	h := &Helper{
+		client:    ts.Client(),
+		endpoint:  func(host string) string { return ts.URL + tokenPath },
+		providers: staticProviders(testProvider(t)),
+	}
+
+	username, password, err := h.Get("iad.ocir.io")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if username != "BEARER_TOKEN" {
+		t.Errorf("username: got %q, want %q", username, "BEARER_TOKEN")
+	}
+	if password != "test-jwt" {
+		t.Errorf("password: got %q, want %q", password, "test-jwt")
+	}
+
+	if gotReq == nil {
+		t.Fatal("token endpoint was not called")
+	}
+	if gotReq.Method != http.MethodGet {
+		t.Errorf("method: got %q, want GET", gotReq.Method)
+	}
+	if gotReq.URL.Path != tokenPath {
+		t.Errorf("path: got %q, want %q", gotReq.URL.Path, tokenPath)
+	}
+	if auth := gotReq.Header.Get("Authorization"); !strings.HasPrefix(auth, "Signature ") {
+		t.Errorf("Authorization: got %q, want OCI request signature", auth)
+	}
+	if gotReq.Header.Get("Date") == "" {
+		t.Error("Date header not set on signed request")
+	}
+}
+
+func TestGetNonOCIRHost(t *testing.T) {
+	// The host check must reject non-OCIR registries before any principal
+	// resolution or network access happens, so exercise the default Helper.
+	h := NewHelper()
+	for _, serverURL := range []string{
+		"index.docker.io",
+		"gcr.io",
+		"https://registry.example.com/v2/",
+		"ocir.io",
+		"evil-ocir.io",
+		"iad.ocir.io.example.com",
+	} {
+		_, _, err := h.Get(serverURL)
+		if !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("Get(%q): got %v, want ErrCredentialsNotFound", serverURL, err)
+		}
+	}
+}
+
+func TestGetNoPrincipal(t *testing.T) {
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer ts.Close()
+
+	// No providers at all.
+	h := &Helper{
+		client:    ts.Client(),
+		endpoint:  func(host string) string { return ts.URL + tokenPath },
+		providers: staticProviders(),
+	}
+	if _, _, err := h.Get("iad.ocir.io"); !credentials.IsErrCredentialsNotFound(err) {
+		t.Errorf("Get with no providers: got %v, want ErrCredentialsNotFound", err)
+	}
+
+	// A provider that cannot produce a signing key, like
+	// common.DefaultConfigProvider without any OCI configuration.
+	h.providers = staticProviders(common.NewRawConfigurationProvider("", "", "", "", "", nil))
+	if _, _, err := h.Get("iad.ocir.io"); !credentials.IsErrCredentialsNotFound(err) {
+		t.Errorf("Get with unusable provider: got %v, want ErrCredentialsNotFound", err)
+	}
+
+	if called {
+		t.Error("token endpoint was called without a usable principal")
+	}
+}
+
+func TestGetTokenEndpointErrors(t *testing.T) {
+	anonJWT := fakeJWT(t, "anon-f82f6dd96e37fdb72ad")
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"unauthorized", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}},
+		{"empty token", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{}`))
+		}},
+		{"malformed body", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`not json`))
+		}},
+		{"anonymous token", func(w http.ResponseWriter, r *http.Request) {
+			// OCIR returns 200 with an anonymous token instead of
+			// rejecting an invalid request signature.
+			body, _ := json.Marshal(map[string]string{"token": anonJWT})
+			w.Write(body)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(tc.handler)
+			defer ts.Close()
+			h := &Helper{
+				client:    ts.Client(),
+				endpoint:  func(host string) string { return ts.URL + tokenPath },
+				providers: staticProviders(testProvider(t)),
+			}
+			if _, _, err := h.Get("iad.ocir.io"); !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("Get: got %v, want ErrCredentialsNotFound", err)
+			}
+		})
+	}
+}
+
+func TestGetPrincipalToken(t *testing.T) {
+	// A token issued to a real principal must be accepted.
+	userJWT := fakeJWT(t, "ocid1.user.oc1..sometestuser")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := json.Marshal(map[string]string{"token": userJWT})
+		w.Write(body)
+	}))
+	defer ts.Close()
+	h := &Helper{
+		client:    ts.Client(),
+		endpoint:  func(host string) string { return ts.URL + tokenPath },
+		providers: staticProviders(testProvider(t)),
+	}
+	_, password, err := h.Get("iad.ocir.io")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if password != userJWT {
+		t.Errorf("password: got %q, want %q", password, userJWT)
+	}
+}
+
+func TestAnonymousToken(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"anonymous", fakeJWT(t, "anon-f82f6dd96e37fdb72ad"), true},
+		{"real user", fakeJWT(t, "ocid1.user.oc1..sometestuser"), false},
+		// Fail open on anything that doesn't match the expected shape.
+		{"not a JWT", "opaque-token", false},
+		{"bad base64", "a.!!!.c", false},
+		{"non-JSON payload", "a." + base64.RawURLEncoding.EncodeToString([]byte("hi")) + ".c", false},
+		{"non-JSON sub", "a." + base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"plain-string"}`)) + ".c", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anonymousToken(tc.token); got != tc.want {
+				t.Errorf("anonymousToken: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegistryHost(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"iad.ocir.io", "iad.ocir.io"},
+		{"us-ashburn-1.ocir.io", "us-ashburn-1.ocir.io"},
+		{"https://iad.ocir.io", "iad.ocir.io"},
+		{"https://iad.ocir.io/v2/", "iad.ocir.io"},
+		{"iad.ocir.io:443", "iad.ocir.io"},
+		{"iad.ocir.io/some/repo", "iad.ocir.io"},
+		{"index.docker.io", "index.docker.io"},
+	} {
+		if got := registryHost(tc.in); got != tc.want {
+			t.Errorf("registryHost(%q): got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/krane/main.go
+++ b/cmd/krane/main.go
@@ -23,6 +23,7 @@ import (
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
 	"github.com/google/go-containerregistry/cmd/crane/cmd"
+	"github.com/google/go-containerregistry/cmd/krane/internal/ocir"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/github"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -33,6 +34,7 @@ import (
 var (
 	amazonKeychain authn.Keychain = authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard)))
 	azureKeychain  authn.Keychain = authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper())
+	oracleKeychain authn.Keychain = authn.NewKeychainFromHelper(ocir.NewHelper())
 )
 
 func init() {
@@ -55,6 +57,7 @@ func main() {
 		github.Keychain,
 		amazonKeychain,
 		azureKeychain,
+		oracleKeychain,
 	)
 
 	// Same as crane, but override usage and keychain.


### PR DESCRIPTION
## Summary

Adds an OCIR (`*.ocir.io`) keychain to krane, following the ECR/ACR pattern from #1250: a Docker credential helper wrapped with `authn.NewKeychainFromHelper`.

OKE workload identity, instance principals, resource principals and `~/.oci/config` then work without `docker login`, matching what krane already provides on GKE/EKS.

OCIR issues short-lived (~1h) registry tokens for OCI-signed requests to `GET https://<region>.ocir.io/20180419/docker/token`, used with the fixed username `BEARER_TOKEN` ([reference](https://www.ateam-oracle.com/authentication-mechanisms-for-oci-container-registry-ocir)).

Everything resolves lazily and only for `*.ocir.io` hosts; anything else falls through unchanged.

Unlike ECR/ACR there is no importable credential helper for OCIR, so the helper lives in `cmd/krane/internal/ocir`, keeping the oci-go-sdk dependency confined to the krane module.

## Test

- [x] `./hack/presubmit.sh` passes.
- [x] `cd ./cmd/krane && go test ./...` passes.
- [x]  Verified against a live region (`ap-tokyo-1.ocir.io`): `krane auth get` returns a `BEARER_TOKEN` credential, and `krane ls` / `krane digest` / `krane manifest` succeed on a private repo with no `docker login`
- [ ] Not tested live: instance principal / OKE workload identity paths (need an OCI instance / OKE cluster; the flow is identical per Oracle's docs).
