### PR TITLE
transport: apply CheckRedirectSSRF to pingSingle

### DIFF
--- a/internal/ipaddr/ipaddr.go
+++ b/internal/ipaddr/ipaddr.go
@@ -15,10 +15,36 @@
 package ipaddr
 
 import (
+	"fmt"
+	"net/http"
 	"net/netip"
 	"strconv"
 	"strings"
 )
+
+// CheckRedirectSSRF rejects HTTP redirects that cross from a public host to a
+// private or link-local IP literal. This prevents a malicious registry from
+// issuing a 302 to a cloud instance metadata service (e.g. 169.254.169.254)
+// or another internal network address.
+//
+// Same-host redirects and redirects to non-IP hostnames (including DNS names
+// that may resolve to private addresses) are allowed. The first redirect in
+// the chain uses the original request URL as the "origin host" via
+// req.Response.Request, falling back to req.URL when no prior response exists.
+func CheckRedirectSSRF(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 || req.Response == nil {
+		return nil
+	}
+	origHost := via[0].URL.Hostname()
+	destHost := req.URL.Hostname()
+	if destHost == origHost {
+		return nil // same-host redirect is always allowed
+	}
+	if IsPrivateOrLinkLocal(destHost) {
+		return fmt.Errorf("SSRF protection: redirect from %q to private/link-local host %q denied", origHost, destHost)
+	}
+	return nil
+}
 
 // IsPrivateOrLinkLocal reports whether host denotes a loopback, private,
 // link-local, or unspecified address. It accepts any IP-literal form the Go

--- a/internal/ipaddr/ipaddr_test.go
+++ b/internal/ipaddr/ipaddr_test.go
@@ -15,7 +15,9 @@
 package ipaddr
 
 import (
+	"net/http"
 	"net/netip"
+	"net/url"
 	"testing"
 )
 
@@ -83,5 +85,56 @@ func TestIsPrivateOrLinkLocal(t *testing.T) {
 		if got := IsPrivateOrLinkLocal(tc.host); got != tc.want {
 			t.Errorf("IsPrivateOrLinkLocal(%q) = %v, want %v", tc.host, got, tc.want)
 		}
+	}
+}
+
+func TestCheckRedirectSSRF(t *testing.T) {
+	makeReq := func(dest, origHost string) (*http.Request, []*http.Request) {
+		u, _ := url.Parse(dest)
+		req := &http.Request{
+			URL:      u,
+			Response: &http.Response{Request: &http.Request{URL: &url.URL{Host: origHost}}},
+		}
+		via := []*http.Request{{URL: &url.URL{Host: origHost}}}
+		return req, via
+	}
+
+	// Blocked destinations
+	blocked := []struct{ orig, dest string }{
+		{"registry.example.com", "http://169.254.169.254/latest/meta-data/"},
+		{"registry.example.com", "http://192.168.1.1/admin"},
+		{"registry.example.com", "http://10.0.0.1/internal"},
+		{"registry.example.com", "http://127.0.0.1:9999/creds"},
+		{"registry.example.com", "http://[::1]/internal"},
+	}
+	for _, tc := range blocked {
+		req, via := makeReq(tc.dest, tc.orig)
+		if err := CheckRedirectSSRF(req, via); err == nil {
+			t.Errorf("CheckRedirectSSRF(orig=%q, dest=%q): expected error, got nil", tc.orig, tc.dest)
+		}
+	}
+
+	// Allowed destinations
+	allowed := []struct{ orig, dest string }{
+		{"registry.example.com", "https://registry.example.com/v2/foo/bar"},
+		{"127.0.0.1:5000", "http://127.0.0.1:5000/v2/foo/bar"},
+		{"registry.example.com", "http://8.8.8.8/blob"},
+		{"registry.example.com", "https://storage.googleapis.com/bucket/blob"},
+	}
+	for _, tc := range allowed {
+		req, via := makeReq(tc.dest, tc.orig)
+		if err := CheckRedirectSSRF(req, via); err != nil {
+			t.Errorf("CheckRedirectSSRF(orig=%q, dest=%q): unexpected error: %v", tc.orig, tc.dest, err)
+		}
+	}
+
+	// Edge cases
+	req := &http.Request{URL: &url.URL{Host: "169.254.169.254"}}
+	if err := CheckRedirectSSRF(req, nil); err != nil {
+		t.Errorf("CheckRedirectSSRF with empty via: expected nil, got %v", err)
+	}
+	via := []*http.Request{{URL: &url.URL{Host: "registry.example.com"}}}
+	if err := CheckRedirectSSRF(req, via); err != nil {
+		t.Errorf("CheckRedirectSSRF with nil Response: expected nil, got %v", err)
 	}
 }

--- a/pkg/v1/remote/fetcher.go
+++ b/pkg/v1/remote/fetcher.go
@@ -81,29 +81,8 @@ func makeFetcher(ctx context.Context, target resource, o *options) (*fetcher, er
 	}, nil
 }
 
-// checkRedirectSSRF rejects HTTP redirects that cross from a public host to a
-// private or link-local IP literal. This prevents a malicious registry from
-// issuing a 302 to a cloud instance metadata service (e.g. 169.254.169.254)
-// or another internal network address during blob or manifest downloads.
-//
-// Same-host redirects and redirects to non-IP hostnames (including DNS names
-// that may resolve to private addresses) are allowed. The first redirect in
-// the chain uses the original request URL as the "origin host" via
-// req.Response.Request, falling back to req.URL when no prior response exists.
-func checkRedirectSSRF(req *http.Request, via []*http.Request) error {
-	if len(via) == 0 || req.Response == nil {
-		return nil
-	}
-	origHost := via[0].URL.Hostname()
-	destHost := req.URL.Hostname()
-	if destHost == origHost {
-		return nil // same-host redirect is always allowed
-	}
-	if ipaddr.IsPrivateOrLinkLocal(destHost) {
-		return fmt.Errorf("SSRF protection: redirect from %q to private/link-local host %q denied", origHost, destHost)
-	}
-	return nil
-}
+// checkRedirectSSRF delegates to ipaddr.CheckRedirectSSRF.
+var checkRedirectSSRF = ipaddr.CheckRedirectSSRF
 
 func (f *fetcher) Do(req *http.Request) (*http.Response, error) {
 	return f.client.Do(req)

--- a/pkg/v1/remote/transport/ping.go
+++ b/pkg/v1/remote/transport/ping.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-containerregistry/internal/ipaddr"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote/internal/authchallenge"
@@ -59,7 +60,10 @@ func Ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*Challen
 }
 
 func pingSingle(ctx context.Context, reg name.Registry, t http.RoundTripper, scheme string) (*Challenge, error) {
-	client := http.Client{Transport: t}
+	client := http.Client{
+		Transport:     t,
+		CheckRedirect: ipaddr.CheckRedirectSSRF,
+	}
 	url := fmt.Sprintf("%s://%s/v2/", scheme, reg.RegistryStr())
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/v1/remote/transport/ping_test.go
+++ b/pkg/v1/remote/transport/ping_test.go
@@ -16,6 +16,7 @@ package transport
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -245,4 +246,49 @@ func mustInsecureRegistry(r string) name.Registry {
 		panic(err)
 	}
 	return reg
+}
+
+// TestPingRedirectSSRF verifies that pingSingle refuses to follow a
+// registry-initiated redirect to a private or loopback address.
+//
+// The victim server listens on IPv6 loopback ([::1]) while the fake registry
+// listens on 127.0.0.1, so the redirect is cross-host and its destination is
+// a loopback IP literal, which CheckRedirectSSRF must reject before any
+// request reaches the victim.
+func TestPingRedirectSSRF(t *testing.T) {
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback unavailable: %v", err)
+	}
+	var victimHits int32
+	victim := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		atomic.AddInt32(&victimHits, 1)
+	}))
+	victim.Listener.Close()
+	victim.Listener = l
+	victim.Start()
+	defer victim.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, victim.URL+"/steal", http.StatusFound)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg, err := name.NewRegistry(u.Host, name.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := Ping(context.Background(), reg, server.Client().Transport)
+	if err == nil || !strings.Contains(err.Error(), "SSRF protection") {
+		t.Errorf("Ping: expected SSRF protection error, got pr=%v, err=%v", pr, err)
+	}
+
+	if n := atomic.LoadInt32(&victimHits); n != 0 {
+		t.Errorf("victim server received %d request(s); the redirect should have been blocked before any request was sent", n)
+	}
 }


### PR DESCRIPTION
### Summary
In PR #2432, `CheckRedirectSSRF` was introduced to prevent writer-side and reader-side HTTP clients from following cross-host redirects to private/link-local/loopback IP literals (such as AWS/GCP IMDS `169.254.169.254`). In that PR description, a note was left:
> *"The client inside transport/ping.go is in a different package and is left as a follow-up."*

Issue #2440 also highlighted this gap (item 4: `pkg/v1/remote/transport/ping.go:62 (pingSingle)` where `http.Client{Transport: t}` followed redirects without `CheckRedirect`).

### Changes
1. **Move `CheckRedirectSSRF` to `internal/ipaddr`**:
   - `internal/ipaddr` is accessible to both `pkg/v1/remote` and `pkg/v1/remote/transport` without code duplication or circular dependencies.
   - `pkg/v1/remote/fetcher.go` delegates to `ipaddr.CheckRedirectSSRF` (`var checkRedirectSSRF = ipaddr.CheckRedirectSSRF`), preserving exact compatibility.
2. **Apply redirect guard in `pingSingle`**:
   - Configured `http.Client{Transport: t, CheckRedirect: ipaddr.CheckRedirectSSRF}` in `pkg/v1/remote/transport/ping.go`.
3. **Tests**:
   - Added unit tests for `CheckRedirectSSRF` in `internal/ipaddr/ipaddr_test.go` covering blocked private/loopback/link-local IPs, allowed same-host/public IPs/hostnames, and edge cases.
   - Added `TestPingRedirectSSRF` in `pkg/v1/remote/transport/ping_test.go` verifying that a redirect from a registry to a loopback address is rejected before sending requests to the target.
