### PR TITLE
mutate: compute the index before answering a by-hash lookup

### DIFF
--- a/pkg/v1/mutate/index.go
+++ b/pkg/v1/mutate/index.go
@@ -162,6 +162,9 @@ func (i *index) compute() error {
 }
 
 func (i *index) Image(h v1.Hash) (v1.Image, error) {
+	if err := i.computeForLookup(); err != nil {
+		return nil, err
+	}
 	if img, ok := i.imageMap[h]; ok {
 		return img, nil
 	}
@@ -169,10 +172,24 @@ func (i *index) Image(h v1.Hash) (v1.Image, error) {
 }
 
 func (i *index) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	if err := i.computeForLookup(); err != nil {
+		return nil, err
+	}
 	if idx, ok := i.indexMap[h]; ok {
 		return idx, nil
 	}
 	return i.base.ImageIndex(h)
+}
+
+// computeForLookup populates the lookup maps before one of the by-hash
+// accessors reads them. A streamable layer that has not been consumed yet is
+// tolerated, the same way Manifests does it, because the maps are filled before
+// computeDescriptor reports ErrNotComputed.
+func (i *index) computeForLookup() error {
+	if err := i.compute(); err != nil && !errors.Is(err, stream.ErrNotComputed) {
+		return err
+	}
+	return nil
 }
 
 type withLayer interface {
@@ -181,6 +198,9 @@ type withLayer interface {
 
 // Workaround for #819.
 func (i *index) Layer(h v1.Hash) (v1.Layer, error) {
+	if err := i.computeForLookup(); err != nil {
+		return nil, err
+	}
 	if layer, ok := i.layerMap[h]; ok {
 		return layer, nil
 	}

--- a/pkg/v1/mutate/index_test.go
+++ b/pkg/v1/mutate/index_test.go
@@ -254,3 +254,67 @@ func TestAppend_ArtifactType_Override(t *testing.T) {
 		t.Errorf("manifest artifactType: got %q, want %q", got, wantArtifactType)
 	}
 }
+
+// The by-hash accessors read lookup maps that only compute() populates, while
+// Digest, IndexManifest, RawManifest and Manifests all call compute() first. If
+// an accessor is the first call made on a freshly mutated index, the maps are
+// nil, the lookup misses and the call falls through to the base index, which
+// does not hold the addendum. The same index then answers differently depending
+// on the order it was asked.
+func TestAppendManifestsLookupBeforeCompute(t *testing.T) {
+	newIndex := func(t *testing.T) (v1.ImageIndex, v1.Hash, v1.Hash) {
+		t.Helper()
+
+		base, err := random.Index(1024, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		img, err := random.Image(1024, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		child, err := random.Index(1024, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		imgHash, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		childHash, err := child.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		added := mutate.AppendManifests(base,
+			mutate.IndexAddendum{Add: img},
+			mutate.IndexAddendum{Add: child},
+		)
+		return added, imgHash, childHash
+	}
+
+	t.Run("Image before anything else", func(t *testing.T) {
+		added, imgHash, _ := newIndex(t)
+		if _, err := added.Image(imgHash); err != nil {
+			t.Errorf("Image(%s) as the first call: %v", imgHash, err)
+		}
+	})
+
+	t.Run("ImageIndex before anything else", func(t *testing.T) {
+		added, _, childHash := newIndex(t)
+		if _, err := added.ImageIndex(childHash); err != nil {
+			t.Errorf("ImageIndex(%s) as the first call: %v", childHash, err)
+		}
+	})
+
+	t.Run("Image after IndexManifest still works", func(t *testing.T) {
+		added, imgHash, _ := newIndex(t)
+		if _, err := added.IndexManifest(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := added.Image(imgHash); err != nil {
+			t.Errorf("Image(%s) after IndexManifest: %v", imgHash, err)
+		}
+	})
+}


### PR DESCRIPTION
`Digest`, `IndexManifest`, `RawManifest` and `Manifests` all call `i.compute()` before doing anything. The three by-hash accessors do not:

```go
func (i *index) Image(h v1.Hash) (v1.Image, error) {
	if img, ok := i.imageMap[h]; ok {   // imageMap is still nil here
		return img, nil
	}
	return i.base.Image(h)
}
```

`imageMap`, `indexMap` and `layerMap` are only populated inside `compute()`. So if `Image`, `ImageIndex` or `Layer` is the first call made on a freshly mutated index, the map is nil, the lookup misses, and the call falls through to the base index, which does not have the manifest that was just appended. The same index gives different answers depending on the order it is asked in. It is also an unsynchronized read of maps that `compute()` writes under `i.Mutex`.

On main, driving the exported `mutate.AppendManifests`:

```
Image(sha256:9be6d50f...) as the first call: image not found: sha256:9be6d50f...
ImageIndex(sha256:250d86b9...) as the first call: image not found: sha256:250d86b9...
```

while asking for `IndexManifest()` first and then `Image()` succeeds.

The fix routes the three accessors through a small helper that calls `compute()` and tolerates `stream.ErrNotComputed`, matching what `Manifests` already does. That matters for `Layer`, which is the workaround for #819: the maps are filled before `computeDescriptor` reports `ErrNotComputed`, so a streamable layer that has not been consumed yet still resolves.

Verification: `TestAppendManifestsLookupBeforeCompute` in `pkg/v1/mutate/index_test.go` covers `Image` first, `ImageIndex` first, and `Image` after `IndexManifest` as a control. The first two fail on main and pass here.

Worth flagging: `go test ./pkg/v1/...` has nine pre-existing failures in my environment, all stream and gzip digest comparisons (`TestAppendStreamableLayer`, `TestStreamLayer`, `TestLargeStream` and similar). The failure set is byte-identical before and after this change, so none of them are mine, but I did not chase down why they fail here.
