### PR TITLE
mutate: don't drop layers in Time when the config history is short

### DIFF
--- a/pkg/v1/mutate/mutate.go
+++ b/pkg/v1/mutate/mutate.go
@@ -483,32 +483,28 @@ func Time(img v1.Image, t time.Time, opts ...tarball.LayerOption) (v1.Image, err
 		return nil, fmt.Errorf("getting original config file: %w", err)
 	}
 
-	addendums := make([]Addendum, max(len(ocf.History), len(layers)))
-	var historyIdx, addendumIdx int
-	for layerIdx := 0; layerIdx < len(layers); addendumIdx, layerIdx = addendumIdx+1, layerIdx+1 {
-		newLayer := layerTime(layers[layerIdx], t, opts...)
+	// Give every history entry its own addendum, and skip the layer for
+	// EmptyLayer ones. Every layer gets an addendum of its own, even when the
+	// config's history has run out, so that no layer is ever dropped.
+	addendums := make([]Addendum, 0, len(ocf.History)+len(layers))
+	var historyIdx int
+	for _, layer := range layers {
+		// History entries before this layer's entry don't have layers of their own.
+		for ; historyIdx < len(ocf.History) && ocf.History[historyIdx].EmptyLayer; historyIdx++ {
+			addendums = append(addendums, Addendum{History: ocf.History[historyIdx]})
+		}
 
-		// try to search for the history entry that corresponds to this layer
-		for ; historyIdx < len(ocf.History); historyIdx++ {
-			addendums[addendumIdx].History = ocf.History[historyIdx]
-			// if it's an EmptyLayer, do not set the Layer and have the Addendum with just the History
-			// and move on to the next History entry
-			if ocf.History[historyIdx].EmptyLayer {
-				addendumIdx++
-				continue
-			}
-			// otherwise, we can exit from the cycle
+		addendum := Addendum{Layer: layerTime(layer, t, opts...)}
+		if historyIdx < len(ocf.History) {
+			addendum.History = ocf.History[historyIdx]
 			historyIdx++
-			break
 		}
-		if addendumIdx < len(addendums) {
-			addendums[addendumIdx].Layer = newLayer
-		}
+		addendums = append(addendums, addendum)
 	}
 
 	// add all leftover History entries
-	for ; historyIdx < len(ocf.History); historyIdx, addendumIdx = historyIdx+1, addendumIdx+1 {
-		addendums[addendumIdx].History = ocf.History[historyIdx]
+	for ; historyIdx < len(ocf.History); historyIdx++ {
+		addendums = append(addendums, Addendum{History: ocf.History[historyIdx]})
 	}
 
 	newImage, err = Append(newImage, addendums...)
@@ -534,9 +530,13 @@ func Time(img v1.Image, t time.Time, opts ...tarball.LayerOption) (v1.Image, err
 
 	for i, h := range cfg.History {
 		h.Created = v1.Time{Time: t}
-		h.CreatedBy = ocf.History[i].CreatedBy
-		h.Comment = ocf.History[i].Comment
-		h.EmptyLayer = ocf.History[i].EmptyLayer
+		// Layers that had no history entry of their own keep a zero-valued one,
+		// so only copy the original fields while the original history lasts.
+		if i < len(ocf.History) {
+			h.CreatedBy = ocf.History[i].CreatedBy
+			h.Comment = ocf.History[i].Comment
+			h.EmptyLayer = ocf.History[i].EmptyLayer
+		}
 		// Explicitly ignore Author field; which hinders reproducibility
 		h.Author = ""
 		cfg.History[i] = h

--- a/pkg/v1/mutate/mutate_test.go
+++ b/pkg/v1/mutate/mutate_test.go
@@ -598,6 +598,88 @@ func TestMutateTime(t *testing.T) {
 	}
 }
 
+// TestMutateTimeHistoryLayerMismatch covers images whose config history doesn't
+// line up with their layers. Time used to consume one addendum slot per history
+// entry, so once the history ran out the remaining layers had nowhere to go and
+// were dropped, and rewriting the config indexed the original history past its
+// end. Such configs are unusual but valid: the history field is optional, and
+// e.g. buildah's --omit-history produces images with layers but no entries.
+func TestMutateTimeHistoryLayerMismatch(t *testing.T) {
+	const wantLayers = 3
+
+	for _, tc := range []struct {
+		name    string
+		history func(*v1.ConfigFile)
+	}{
+		{
+			name:    "no history at all",
+			history: func(cf *v1.ConfigFile) { cf.History = nil },
+		},
+		{
+			name:    "history shorter than layers",
+			history: func(cf *v1.ConfigFile) { cf.History = cf.History[:1] },
+		},
+		{
+			name: "all history entries marked empty",
+			history: func(cf *v1.ConfigFile) {
+				for i := range cf.History {
+					cf.History[i].EmptyLayer = true
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			img, err := random.Image(256, wantLayers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cf, err := img.ConfigFile()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cf = cf.DeepCopy()
+			tc.history(cf)
+			img, err = mutate.ConfigFile(img, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := mutate.Time(img, time.Time{})
+			if err != nil {
+				t.Fatalf("Time: %v", err)
+			}
+
+			layers, err := got.Layers()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(layers) != wantLayers {
+				t.Fatalf("got %d layers, want %d", len(layers), wantLayers)
+			}
+
+			gotConfig := getConfigFile(t, got)
+			if len(gotConfig.RootFS.DiffIDs) != wantLayers {
+				t.Errorf("got %d diff IDs, want %d", len(gotConfig.RootFS.DiffIDs), wantLayers)
+			}
+			// Layer N's diff ID has to match the Nth config entry, otherwise the
+			// image the caller gets back is broken.
+			for i, l := range layers {
+				diffID, err := l.DiffID()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if gotConfig.RootFS.DiffIDs[i] != diffID {
+					t.Errorf("layer %d diff ID = %v, config says %v", i, diffID, gotConfig.RootFS.DiffIDs[i])
+				}
+			}
+
+			if err := validate.Image(got); err != nil {
+				t.Errorf("mutated image is invalid: %v", err)
+			}
+		})
+	}
+}
+
 func TestMutateMediaType(t *testing.T) {
 	want := types.OCIManifestSchema1
 	wantCfg := types.OCIConfigJSON


### PR DESCRIPTION
`mutate.Time` lines the original config history up with the layers so it knows which ones to rewrite, but it walks both with the same index. When the config has fewer history entries than layers the two drift apart: the leftover layers have no addendum slot so they get skipped without a word, and the pass that rewrites the config then indexes the original history past its end and panics.

An image with layers and an empty `history` field hits both. That shape isn't hypothetical -- `validate.Image` accepts it, and it's what `buildah bud --omit-history` produces. On current `main`, `random.Image(256, 3)` with `History` cleared panics at `pkg/v1/mutate/mutate.go:537`; with three `EmptyLayer: true` entries instead, `Time` quietly returns an image with zero layers.

The fix gives every layer an addendum of its own and only borrows a history entry while one is left, so a layer can never fall off the end, and the rewrite stops copying history fields once the original runs out. Layers that never had a history entry keep a zero-valued one, which is what they already got when the counts happened to match. `Canonical` goes through `Time`, so it's covered too.

I added `TestMutateTimeHistoryLayerMismatch` for the three shapes (no history, history shorter than the layers, all entries marked empty); each checks the layer count, that every layer's diff ID still matches its config entry, and that the result validates. The two existing `TestMutateTime` cases still pass.

I couldn't find an issue for this, otherwise I'd have linked it.